### PR TITLE
(#32) 위클리 캘린더 주차계산 로직 수정

### DIFF
--- a/src/components/calendar/weekly-calendar/WeeklyCalendar.helper.ts
+++ b/src/components/calendar/weekly-calendar/WeeklyCalendar.helper.ts
@@ -3,6 +3,7 @@ import {
   differenceInCalendarWeeks,
   endOfWeek,
   format,
+  nextWednesday,
   startOfMonth,
   startOfWeek,
 } from 'date-fns';
@@ -23,7 +24,8 @@ export const getCalendarWeek = (currentDate: Date) => {
 
 export const getCalendarTitle = (currentDate: Date) => {
   const startDayOfMonth = startOfMonth(currentDate).getDay();
-  const baseDateOfWeek = startOfWeek(currentDate, { weekStartsOn: 3 });
+  const baseDateOfWeek = nextWednesday(startOfWeek(currentDate));
+
   const baseDay = baseDateOfWeek.getDate();
 
   const correctionValue = startDayOfMonth <= 3 ? 1 : 0;


### PR DESCRIPTION
## Issue Number: #32

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?
- [x] 데스크탑, 모바일에서의 정상 작동을 확인했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?
- 원인: `startOfWeek` 함수에서 시작 요일을 수요일(`{ weekStartsOn: 3 }`)로 하여 기준 날짜를 구하면 현재 날짜가 수요일 이전인 경우 이전 주의 수요일로 계산되어 주차가 잘못 계산됨.
- 해결: 현재 날짜에서 주의 시작일을 구하고(시작요일 default: 일요일) 그 날짜를 기준으로 다음 수요일(`nextWednesday`)을 구하여 항상 그 주의 수요일이 기준 날짜가 되도록 수정.


## Preview Image
- 현재 날짜가 `2023/5/8(월)`인 경우

| as-is (이전 주의 주차로 계산됨) | to-be (올바르게 주차가 계산됨) |
| -- | -- |
| <img width="489" alt="스크린샷 2023-05-27 오전 10 28 07" src="https://github.com/GooJinSun/WhoAmI-Today-frontend/assets/48233023/72664926-5b36-4a1c-b959-c5d33f92b9a3"> | <img width="490" alt="스크린샷 2023-05-27 오전 10 28 26" src="https://github.com/GooJinSun/WhoAmI-Today-frontend/assets/48233023/481be860-37c4-4be1-8a7e-69169669d558"> | 


## Further comments
- 추후 다국어를 적용하여 영어인 경우 1st, 2nd, 3rd.. 로 서수 접미어?를 붙여주겠습니다!