### PR TITLE
(#164) 읽은 노티와 읽지 않은 노티가 구분이 안됩니다

### DIFF
--- a/src/components/notification/NotificationItem.tsx
+++ b/src/components/notification/NotificationItem.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTheme } from 'styled-components';
 import ProfileImage from '@components/_common/profile-image/ProfileImage';
+import { DEFAULT_MARGIN } from '@constants/layout';
 import { Font, Layout } from '@design-system';
 import { Notification } from '@models/notification';
 import { readNotification } from '@utils/apis/notification';
@@ -31,10 +32,8 @@ function NotificationItem({ item }: NotificationItemProps) {
       w="100%"
       onClick={handleClickNotification}
       pv={14}
-      mb={2}
-      ph={4}
-      outline="GRAY_10"
-      rounded={4}
+      bgColor={is_read ? 'BASIC_WHITE' : 'GRAY_10'}
+      ph={DEFAULT_MARGIN}
     >
       <Layout.FlexRow w={50} h={50} mr={7} alignItems="center" justifyContent="center">
         <ProfileImage imageUrl={profile_image} size={40} />

--- a/src/routes/Notifications.tsx
+++ b/src/routes/Notifications.tsx
@@ -4,7 +4,7 @@ import Loader from '@components/_common/loader/Loader';
 import MainContainer from '@components/_common/main-container/MainContainer';
 import NotificationItem from '@components/notification/NotificationItem';
 import TitleHeader from '@components/title-header/TitleHeader';
-import { DEFAULT_MARGIN, TITLE_HEADER_HEIGHT } from '@constants/layout';
+import { TITLE_HEADER_HEIGHT } from '@constants/layout';
 import { Layout } from '@design-system';
 import useInfiniteScroll from '@hooks/useInfiniteScroll';
 import { Notification } from '@models/notification';
@@ -31,7 +31,7 @@ function Notifications() {
   return (
     <MainContainer>
       <TitleHeader title={t('title')} />
-      <Layout.FlexCol mt={TITLE_HEADER_HEIGHT + 8} w="100%" ph={DEFAULT_MARGIN}>
+      <Layout.FlexCol mt={TITLE_HEADER_HEIGHT + 8} w="100%">
         {notifications.map((noti) => (
           <NotificationItem item={noti} key={noti.id} />
         ))}


### PR DESCRIPTION
## Issue Number: #164 

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?
- [x] 데스크탑, 모바일에서의 정상 작동을 확인했나요?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?

일단 임시로 읽은 노티와 읽지 않은 노티를 구분할 수 있도록 추가했습니다
(나중에 ver2 이후 디자인이 나오면 적용 해두겠습니다~)

## Preview Image
https://github.com/GooJinSun/WhoAmI-Today-frontend/assets/42240753/2803b239-cfbf-4a33-a968-33bc4f6b358f

## Further comments

노티가 많은 경우 스크롤을 유지하면서 페이지를 이동하는 기능이 필요할 것 같습니다 (노티 이외의 페이지에서도 필요할수도..)
다른 refactor 개선 이슈로 올려두겠습니당
