### PR TITLE
(#345) root 접근(<Intro/>)시에도 로그인 여부 확인하고, 로그인 정보가 있다면 /friends로 redirect하도록 수정

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,13 +3,13 @@ import ReactDOM from 'react-dom/client';
 import { createBrowserRouter, Navigate, RouterProvider } from 'react-router-dom';
 import { ThemeProvider } from 'styled-components';
 import ToastBar from '@components/_common/toast-bar/ToastBar';
+import ErrorPage from '@components/error-page/ErrorPage';
 import { Colors, Typo } from '@design-system';
 import { useGetAppMessage } from '@hooks/useAppMessage';
 import { useBoundStore } from '@stores/useBoundStore';
 import GlobalStyle from '@styles/global-styles';
 import { checkIfSignIn } from '@utils/apis/user';
 import { ChatRoom } from 'src/routes/chat-room/ChatRoom';
-import ErrorPage from './components/error-page/ErrorPage';
 import './i18n';
 import SpotifyManager from './libs/SpotifyManager';
 import reportWebVitals from './reportWebVitals';
@@ -47,7 +47,7 @@ import SignIn from './routes/SignIn';
 import SignUp from './routes/SignUp';
 
 const router = createBrowserRouter([
-  { path: '', element: <Intro /> },
+  { path: '', element: <Intro />, loader: checkIfSignIn },
   {
     path: '/',
     element: <Root />,

--- a/src/routes/Intro.tsx
+++ b/src/routes/Intro.tsx
@@ -1,9 +1,13 @@
 import { useTranslation } from 'react-i18next';
+import { Navigate, useLoaderData } from 'react-router-dom';
 import MainContainer from '@components/_common/main-container/MainContainer';
 import { Button, Layout } from '@design-system';
 
 function Intro() {
   const [t] = useTranslation('translation', { keyPrefix: 'intro' });
+  const data = useLoaderData();
+
+  if (data) return <Navigate to="/friends" replace />;
   return (
     <MainContainer>
       <Layout.FlexCol w="100%" h="100%" justifyContent="center" alignItems="center" mb={100}>


### PR DESCRIPTION
## Issue Number: #345

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?
- [x] 데스크탑, 모바일에서의 정상 작동을 확인했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## Testable backend branch name
main

## What does this PR do?
root 접근(<Intro/>)시에도 로그인 여부 확인하고, 로그인 정보가 있다면 /friends로 redirect하도록 수정

## Preview Image
### as-is: 로그인 관련 토큰이 브라우저에 있어도 root(https://diivers.world, http:localhost:3000)로 접근하면 다시 로그인 해야하는것처럼 보임

https://github.com/GooJinSun/WhoAmI-Today-frontend/assets/37523788/0242925c-f927-430c-959a-04132aac8d56

### to-be: 로그인 관련 토큰이 브라우저에 있다면, root로 접근했을 때 /friends로 redirect하도록 수정

https://github.com/GooJinSun/WhoAmI-Today-frontend/assets/37523788/53d63366-bf53-4e16-8117-40420f175861

## Further comments
