### PR TITLE
(#354) 프로필 사진 이미지 업데이트 로직 수정, 불필요한 버튼 삭제하고 editProfile에 프로필 사진변경까지 통합

### DIFF
--- a/src/routes/settings/EditProfile.tsx
+++ b/src/routes/settings/EditProfile.tsx
@@ -10,10 +10,10 @@ import ValidatedTextArea from '@components/_common/validated-textarea/ValidatedT
 import { StyledEditProfileButton } from '@components/settings/SettingsButtons.styled';
 import SubHeader from '@components/sub-header/SubHeader';
 import { TITLE_HEADER_HEIGHT } from '@constants/layout';
-import { Button, Layout, Typo } from '@design-system';
+import { Layout, Typo } from '@design-system';
 import { MyProfile } from '@models/api/user';
 import { useBoundStore } from '@stores/useBoundStore';
-import { changeProfileImage, editProfile } from '@utils/apis/my';
+import { editProfile } from '@utils/apis/my';
 import { CroppedImg, readFile } from '@utils/getCroppedImg';
 
 function EditProfile() {
@@ -68,11 +68,6 @@ function EditProfile() {
 
   const navigate = useNavigate();
 
-  const handleChangeProfileImage = () => {
-    if (!croppedImg) return;
-    changeProfileImage({ profileImage: croppedImg.file, onSuccess: () => navigate('/settings') });
-  };
-
   const handleClickCancel = () => {
     navigate(-1);
   };
@@ -82,11 +77,12 @@ function EditProfile() {
     editProfile({
       profile: {
         ...draft,
+        ...(croppedImg ? { profile_image: croppedImg.file } : {}),
       },
-      onSuccess: () => {
-        updateMyProfile({ ...draft });
-        navigate(-1);
+      onSuccess: (data: MyProfile) => {
+        updateMyProfile({ ...data });
         openToast({ message: t('response.updated') });
+        navigate('/settings');
       },
     });
   };
@@ -170,17 +166,6 @@ function EditProfile() {
           limit={120}
         />
       </Layout.FlexCol>
-      {croppedImg && (
-        <Layout.Absolute w="100%" b="50px" pl={24} pr={24} flexDirection="column">
-          <Button.Large
-            type="filled"
-            status="normal"
-            sizing="stretch"
-            text={t('update')}
-            onClick={handleChangeProfileImage}
-          />
-        </Layout.Absolute>
-      )}
       {isEditModalVisible && (
         <ProfileImageEdit
           setIsVisible={setIsEditModalVisible}

--- a/src/utils/apis/my.ts
+++ b/src/utils/apis/my.ts
@@ -21,43 +21,25 @@ export const editProfile = ({
   onSuccess,
   onError,
 }: {
-  profile: Pick<MyProfile, 'bio' | 'username' | 'pronouns'>;
-  onSuccess?: () => void;
+  profile: Pick<MyProfile, 'bio' | 'username' | 'pronouns'> & { profile_image?: File };
+  onSuccess: (data: MyProfile) => void;
   onError?: (error: string) => void;
 }) => {
   const formData = new FormData();
 
   Object.entries(profile).forEach(([key, value]) => {
+    if (profile.profile_image && key === 'profile_image') {
+      formData.append('profile_image', profile.profile_image, 'profile_image.png');
+      return;
+    }
     if (value) {
       formData.append(key, value as string);
     }
   });
 
   axiosFormDataInstance
-    .patch('/user/me/', formData)
-    .then(() => onSuccess?.())
-    .catch((e) => {
-      onError?.(e);
-    });
-};
-
-// update my profile image
-export const changeProfileImage = ({
-  profileImage,
-  onSuccess,
-  onError,
-}: {
-  profileImage: File;
-  onSuccess?: () => void;
-  onError?: (error: string) => void;
-}) => {
-  const formData = new FormData();
-
-  formData.append('profile_image', profileImage, 'profile_image.png');
-
-  axiosFormDataInstance
-    .patch('/user/me/', formData)
-    .then(() => onSuccess?.())
+    .patch<MyProfile>('/user/me/', formData)
+    .then((res) => onSuccess(res.data))
     .catch((e) => {
       onError?.(e);
     });


### PR DESCRIPTION
## Issue Number: #354

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?
- [x] 데스크탑, 모바일에서의 정상 작동을 확인했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## Testable backend branch name
main

## What does this PR do?
- 프로필 사진 변경 요청 플로우 수정
프로필 사진을 크롭하고 나면 우측 헤더에 save(A), 화면 중앙 하단에 update(B) 버튼이 두개가 생겼는데,
A 버튼에서 프로필 사진을 변경하는 Patch 요청의 `form data에 profile_image를 binary 가 아닌 url로 보내주고 있었음(400 Error)`
실제로 프로필 사진을 저장했던 B버튼을 제거하고, A로 정보 수정과 프로필 사진 변경을 한번에 할 수 있도록 수정

|as-is|to-be|
|-|-|
|<img width="376" alt="스크린샷 2024-04-27 오후 2 20 23" src="https://github.com/GooJinSun/WhoAmI-Today-frontend/assets/37523788/30933685-1c53-4025-a4d6-e639882ad771">|<img width="376" alt="image" src="https://github.com/GooJinSun/WhoAmI-Today-frontend/assets/37523788/f8c9c8c7-82b8-4c2d-bece-fe8277a83207">|


## Preview Image

https://github.com/GooJinSun/WhoAmI-Today-frontend/assets/37523788/4d986e09-4f0f-4710-b521-3b599c8c0f70


## Further comments
