### PR TITLE
(#402) 노트 섹션 width값이 화면에 가변적이도록 수정

### DIFF
--- a/src/components/note/note-item/NoteItem.tsx
+++ b/src/components/note/note-item/NoteItem.tsx
@@ -5,7 +5,6 @@ import Icon from '@components/_common/icon/Icon';
 import PostFooter from '@components/_common/post-footer/PostFooter';
 import ProfileImage from '@components/_common/profile-image/ProfileImage';
 import CommentBottomSheet from '@components/comments/comment-bottom-sheet/CommentBottomSheet';
-import { SCREEN_WIDTH } from '@constants/layout';
 import { Layout, Typo } from '@design-system';
 import { Note } from '@models/post';
 import { convertTimeDiffByString } from '@utils/timeHelpers';
@@ -46,7 +45,7 @@ function NoteItem({ note, isMyPage, enableCollapse = true, type = 'LIST' }: Note
   return (
     <>
       <Layout.FlexCol
-        w={SCREEN_WIDTH - 12 * 2}
+        w="100%"
         p={12}
         gap={8}
         outline="LIGHT"

--- a/src/components/note/note-section/NoteSection.tsx
+++ b/src/components/note/note-section/NoteSection.tsx
@@ -41,9 +41,9 @@ function NoteSection({ username }: NoteSectionProps) {
         </Typo>
       </Layout.FlexRow>
       <Layout.FlexCol w="100%" pr={12}>
-        <Layout.FlexCol gap={16} mt={10} h="100%">
+        <Layout.FlexCol gap={8} mt={10} w="100%" h="100%">
           {noteList.length === 0 ? (
-            <Layout.FlexRow alignItems="center" h="100%">
+            <Layout.FlexRow alignItems="center" w="100%" h="100%">
               <NoContents title={t('no_contents.notes')} />
             </Layout.FlexRow>
           ) : (


### PR DESCRIPTION
## Issue Number: #402

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?
- [x] 데스크탑, 모바일에서의 정상 작동을 확인했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## Testable backend branch name: main

## What does this PR do?
- 노트 아이템이 화면을 채울 수 있도록 수정
  - width값을 100%로

## Preview Image

https://github.com/GooJinSun/WhoAmI-Today-frontend/assets/48233023/28b28620-35b0-41cf-aa41-811320798926


## Further comments
