### PR TITLE
(#422) 답변, 노트 > 댓글 추가 아이콘, comments text 누르면 CommentBottomSheet 노출 

### DIFF
--- a/src/components/_common/post-footer/PostFooter.tsx
+++ b/src/components/_common/post-footer/PostFooter.tsx
@@ -1,3 +1,4 @@
+import { MouseEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Layout, Typo } from '@design-system';
 import { Note, POST_TYPE, Response } from '@models/post';
@@ -20,9 +21,9 @@ function PostFooter({ likedUserList, isMyPage, post, showComments }: PostFooterP
     keyPrefix: post.type === POST_TYPE.RESPONSE ? 'responses' : 'notes',
   });
 
-  const handleClickComment = () => {
-    // TODO
-    console.log('comment');
+  const handleClickComment = (e: MouseEvent) => {
+    e.stopPropagation();
+    showComments();
   };
 
   return (
@@ -36,28 +37,9 @@ function PostFooter({ likedUserList, isMyPage, post, showComments }: PostFooterP
         <Icon name="add_comment" size={23} onClick={handleClickComment} />
       </Layout.FlexRow>
 
-      {/* temporal: comment_count not showing in Responses */}
-      {post.type === POST_TYPE.RESPONSE && (
-        <Icon
-          name="star"
-          size={23}
-          onClick={(e) => {
-            e.stopPropagation();
-            showComments();
-          }}
-        />
-      )}
-      {/*  */}
-
       {!!comment_count && (
         <Layout.FlexRow>
-          <button
-            type="button"
-            onClick={(e) => {
-              e.stopPropagation();
-              showComments();
-            }}
-          >
+          <button type="button" onClick={handleClickComment}>
             <Typo type="label-large" color="BLACK" underline>
               {comment_count || 0} {t('comments')}
             </Typo>


### PR DESCRIPTION
## Issue Number: #422 

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?
- [x] 데스크탑, 모바일에서의 정상 작동을 확인했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## Testable backend branch name

## What does this PR do?
답변/노트에 있는 댓글추가아이콘, comments tex 누를시에 detail 페이지가 아닌 bottom sheet가 뜨도록 수정
그 외의 박스 내 영역 클릭시에는 detail page로

## Preview Image

## Further comments
