### PR TITLE
(#406) 비밀댓글 체크 아이콘이 깨져보이는 버그

### DIFF
--- a/src/design-system/Inputs/CheckBox.styled.ts
+++ b/src/design-system/Inputs/CheckBox.styled.ts
@@ -13,6 +13,8 @@ export const StyledRectCheckBox = styled.div`
     appearance: none;
     width: 20px;
     height: 20px;
+    flex-shrink: 0;
+    border-radius: 0px;
 
     background-image: url('/icons/checkbox_rectangle_default.svg');
 


### PR DESCRIPTION
## Issue Number: #406 

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?
- [x] 데스크탑, 모바일에서의 정상 작동을 확인했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## Testable backend branch name

- main 

## What does this PR do?

비밀댓글에 쓰이는 CheckBox 컴포넌트 style 수정

## Preview Image

before
![IMG_5561](https://github.com/GooJinSun/WhoAmI-Today-frontend/assets/42240753/42fb8117-e07f-4b19-89c2-1526ac42a91d)

after
![IMG_5560](https://github.com/GooJinSun/WhoAmI-Today-frontend/assets/42240753/fc27106e-788a-4fde-a34d-3d1c9adae161)


before
![IMG_5563](https://github.com/GooJinSun/WhoAmI-Today-frontend/assets/42240753/2c9643f9-3d63-4ab3-99b4-8382646aa8d3)

after
![IMG_5564](https://github.com/GooJinSun/WhoAmI-Today-frontend/assets/42240753/ca2ffa48-4aaa-4f70-bd76-626fb9f5d7fe)


## Further comments

- 해당 컴포넌트가 사용되던 Research Intro 페이지에서도 이슈가 있는거같아서 함께 수정했습니다
- @dbwk18 앱에서 실시간 디버깅하기 쉽지 않으실 것 같아서 제가 잠시 보다가 수정했습니다 🙏 확인 한번만 해주세요!