### PR TITLE
(#404) 앱알림설정문구에 Note Item이 가려지는 문제

### DIFF
--- a/src/components/_common/noti-permission-banner/NotiPermissionBanner.tsx
+++ b/src/components/_common/noti-permission-banner/NotiPermissionBanner.tsx
@@ -18,7 +18,7 @@ function NotiPermissionBanner() {
     <S.Container
       justifyContent="center"
       bgColor="GRAY_10"
-      h={HEIGHT}
+      h={NOTI_PERMISSION_BANNER_HEIGHT}
       w="100%"
       onClick={handleRequest}
     >
@@ -31,6 +31,6 @@ function NotiPermissionBanner() {
   );
 }
 
-export const HEIGHT = 50;
+export const NOTI_PERMISSION_BANNER_HEIGHT = 50;
 
 export default NotiPermissionBanner;

--- a/src/routes/Root.tsx
+++ b/src/routes/Root.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { Outlet } from 'react-router-dom';
 import NotiPermissionBanner, {
-  HEIGHT,
+  NOTI_PERMISSION_BANNER_HEIGHT,
 } from '@components/_common/noti-permission-banner/NotiPermissionBanner';
 import Header from '@components/header/Header';
 import Tab from '@components/tab/Tab';
@@ -40,7 +40,9 @@ function Root() {
         <MainWrapper
           alignItems="center"
           pt={TOP_NAVIGATION_HEIGHT}
-          pb={BOTTOM_TABBAR_HEIGHT + (showNotificationPermission ? HEIGHT : 0)}
+          pb={
+            BOTTOM_TABBAR_HEIGHT + (showNotificationPermission ? NOTI_PERMISSION_BANNER_HEIGHT : 0)
+          }
         >
           <Outlet />
           {/* 데스크톱 웹만 노출 */}


### PR DESCRIPTION
## Issue Number: #404

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?
- [x] 데스크탑, 모바일에서의 정상 작동을 확인했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## Testable backend branch name

main

## What does this PR do?

앱 알림 설정 문구가 있을 경우 pb 값을 추가

## Preview Image

before
<img width="460" alt="Screenshot 2024-06-01 at 1 52 57 PM" src="https://github.com/GooJinSun/WhoAmI-Today-frontend/assets/42240753/0ed3f352-177d-43ba-9c50-277137204231">

after
<img width="428" alt="Screenshot 2024-06-01 at 1 52 37 PM" src="https://github.com/GooJinSun/WhoAmI-Today-frontend/assets/42240753/1f2d5d4e-fed1-4208-a8a8-ecb4bba0131a">


## Further comments
