### PR TITLE
(#451) 채팅목록 편집 페이지에서 하단 버튼이 화면 너비에 관계없이 센터 정렬되도록 수정

### DIFF
--- a/src/routes/chat-room/ChatRoom.styled.ts
+++ b/src/routes/chat-room/ChatRoom.styled.ts
@@ -1,12 +1,7 @@
 import styled from 'styled-components';
 import { SubHeaderWrapper } from '@components/sub-header/SubHeader.styled';
-import { MAX_WINDOW_WIDTH, TOP_NAVIGATION_HEIGHT } from '@constants/layout';
-import { Layout } from '@design-system';
+import { TOP_NAVIGATION_HEIGHT } from '@constants/layout';
 import { MainWrapper } from '@styles/wrappers';
-
-export const ChatRoomContainer = styled(Layout.Fixed)`
-  max-width: ${MAX_WINDOW_WIDTH}px;
-`;
 
 export const ChatRoomHeaderWrapper = styled(SubHeaderWrapper)`
   border-bottom: 1.2px solid ${({ theme }) => theme.MEDIUM_GRAY};

--- a/src/routes/chat-room/ChatRoom.tsx
+++ b/src/routes/chat-room/ChatRoom.tsx
@@ -6,19 +6,15 @@ import ProfileImage from '@components/_common/profile-image/ProfileImage';
 import { MessageInputBox } from '@components/chat-room/message-input-box/MessageInputBox';
 import { MessageList } from '@components/chat-room/message-list/MessageList';
 import { MessageNotiSettingDialog } from '@components/chat-room/message-noti-setting-dialog/MessageNotiSettingDialog';
-import { Z_INDEX } from '@constants/layout';
 import { Layout, Typo } from '@design-system';
 import useAsyncEffect from '@hooks/useAsyncEffect';
 import useInfiniteScroll from '@hooks/useInfiniteScroll';
 import { ChatRoom as ChatRoomType, ResponseMessageAction } from '@models/api/chat';
+import { ModalContainer } from '@styles/wrappers';
 import { getChatMessages, getChatRoomInfo } from '@utils/apis/chat';
 import { useChatRoomAutoScroll } from 'src/routes/chat-room/_hooks/useChatRoomAutoScroll';
 import { useChatRoomSocketProvider } from 'src/routes/chat-room/_hooks/useChatRoomSocketProvider';
-import {
-  ChatRoomContainer,
-  ChatRoomHeaderWrapper,
-  MessageListScrollContainer,
-} from './ChatRoom.styled';
+import { ChatRoomHeaderWrapper, MessageListScrollContainer } from './ChatRoom.styled';
 
 export function ChatRoom() {
   const { roomId } = useParams();
@@ -101,14 +97,7 @@ export function ChatRoom() {
   };
 
   return (
-    <ChatRoomContainer
-      t={0}
-      w="100%"
-      h="100%"
-      z={Z_INDEX.MODAL_CONTAINER}
-      bgColor="WHITE"
-      alignItems="center"
-    >
+    <ModalContainer>
       <ChatRoomHeaderWrapper>
         <Layout.FlexRow justifyContent="space-between" w="100%" alignItems="center">
           <Icon name="arrow_left" size={36} color="BLACK" onClick={handleClickGoBack} />
@@ -149,6 +138,6 @@ export function ChatRoom() {
         onClickMute={setMuteOn}
         onClose={closeNotiSettingDialog}
       />
-    </ChatRoomContainer>
+    </ModalContainer>
   );
 }

--- a/src/routes/edit-chats/EditChats.styled.ts
+++ b/src/routes/edit-chats/EditChats.styled.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { BOTTOM_TABBAR_HEIGHT } from '@constants/layout';
+import { BOTTOM_TABBAR_HEIGHT, MAX_WINDOW_WIDTH } from '@constants/layout';
 import { Layout } from '@design-system';
 import { MainWrapper } from '@styles/wrappers';
 
@@ -12,17 +12,15 @@ export const EditChatsScrollContainer = styled(MainWrapper)`
 export const StyledBottomArea = styled(Layout.Fixed)`
   box-shadow: 0px -4px 12px 0px rgba(0, 0, 0, 0.16);
   height: ${BOTTOM_TABBAR_HEIGHT}px;
+  max-width: ${MAX_WINDOW_WIDTH}px;
 `;
 
 const StyledBottomButton = styled.button`
-  display: flex;
-  width: 175px;
+  flex: 1;
   height: 55px;
   padding: 18px 16px;
   justify-content: center;
   align-items: center;
-  gap: 10px;
-  flex-shrink: 0;
 
   border-radius: 13px;
   backdrop-filter: blur(40px);
@@ -30,7 +28,6 @@ const StyledBottomButton = styled.button`
 
 export const StyledMuteButton = styled(StyledBottomButton)`
   background: ${({ theme }) => theme.MEDIUM_GRAY};
-
   span {
     color: ${({ theme }) => theme.WHITE};
   }

--- a/src/routes/edit-chats/EditChats.tsx
+++ b/src/routes/edit-chats/EditChats.tsx
@@ -3,8 +3,8 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { ChatRoomList } from '@components/chats/chat-room-list/ChatRoomList';
 import SubHeader from '@components/sub-header/SubHeader';
-import { Z_INDEX } from '@constants/layout';
 import { Layout, Typo } from '@design-system';
+import { ModalContainer } from '@styles/wrappers';
 import {
   EditChatsScrollContainer,
   StyledBottomArea,
@@ -49,14 +49,7 @@ export function EditChats() {
   };
 
   return (
-    <Layout.Fixed
-      t={0}
-      w="100%"
-      h="100%"
-      z={Z_INDEX.MODAL_CONTAINER}
-      bgColor="WHITE"
-      alignItems="center"
-    >
+    <ModalContainer>
       <SubHeader
         title={t('header.title')}
         RightComponent={
@@ -71,7 +64,7 @@ export function EditChats() {
         <ChatRoomList isEditMode onClickCheckBox={handleClickCheckBox} checkList={checkList} />
       </EditChatsScrollContainer>
       <StyledBottomArea w="100%" b={0} pv={15} ph={8} bgColor="WHITE">
-        <Layout.FlexRow w="100%" gap={5}>
+        <Layout.FlexRow w="100%" gap={5} justifyContent="center">
           <StyledMuteButton type="button" onClick={handleClickMute} disabled={!hasCheckList}>
             <Typo type="button-large">
               {[t('button.mute'), hasCheckList && `(${checkListLength})`].filter(Boolean).join(' ')}
@@ -86,6 +79,6 @@ export function EditChats() {
           </StyledDeleteButton>
         </Layout.FlexRow>
       </StyledBottomArea>
-    </Layout.Fixed>
+    </ModalContainer>
   );
 }

--- a/src/styles/wrappers.ts
+++ b/src/styles/wrappers.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { MAX_WINDOW_WIDTH } from '@constants/layout';
+import { MAX_WINDOW_WIDTH, Z_INDEX } from '@constants/layout';
 import { Layout } from '@design-system';
 
 export const RootContainer = styled(Layout.FlexCol)`
@@ -16,4 +16,14 @@ export const MainWrapper = styled(Layout.FlexCol)`
   height: 100%;
   width: 100%;
   overflow-y: auto;
+`;
+
+export const ModalContainer = styled(Layout.Fixed)`
+  width: 100%;
+  max-width: ${MAX_WINDOW_WIDTH}px;
+  height: 100%;
+  top: 0;
+  z-index: ${Z_INDEX.MODAL_CONTAINER};
+  background-color: ${({ theme }) => theme.WHITE};
+  align-items: center;
 `;


### PR DESCRIPTION
## Issue Number: #451

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?
- [x] 데스크탑, 모바일에서의 정상 작동을 확인했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## Testable backend branch name: main

## What does this PR do?
- 채팅목록 편집페이지 하단 버튼이 화면 너비에 관계없이 센터 정렬되고, 버튼 너비가 화면에 꽉차도록 수정.
- 채팅목록편집과 채팅방에서 공통으로 사용되는 스타일 코드를 분리하여 공통화(ModalContainer)

## Preview Image

https://github.com/GooJinSun/WhoAmI-Today-frontend/assets/48233023/c4d6ca85-2686-4268-9743-27e49c52095d



## Further comments
