### PR TITLE
[Bug] 웹 모바일에서 높이가 좀 작은 경우 modal이 화면을 넘어가버리는 경우가 있음

### DIFF
--- a/src/components/_common/bottom-modal/BottomModal.tsx
+++ b/src/components/_common/bottom-modal/BottomModal.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { MouseEvent, useEffect, useRef, useState } from 'react';
-import { DEFAULT_MARGIN } from '@constants/layout';
+import { DEFAULT_MARGIN, SCREEN_HEIGHT } from '@constants/layout';
 import { ColorKeys } from '@design-system';
 import { usePreventScroll } from '@hooks/usePreventScroll';
 import * as S from './BottomModal.styled';
@@ -22,8 +22,8 @@ function BottomModal({
   children,
   bgColor = 'rgba(0, 0, 0, 0.7)',
   containerBgColor = 'WHITE',
-  h,
-  maxHeight = 650,
+  h = SCREEN_HEIGHT - 50,
+  maxHeight = 750,
   TopComponent,
 }: BottomModalProps) {
   const bodyRef = useRef<HTMLDivElement>(null);

--- a/src/components/_common/prompt/SendPromptModal.tsx
+++ b/src/components/_common/prompt/SendPromptModal.tsx
@@ -122,7 +122,7 @@ function SendPromptModal({ visible, onClose, questionId }: SendPromptModalProps)
   }, [visible]);
 
   return createPortal(
-    <BottomModal visible={visible} onClose={onClose} h={650}>
+    <BottomModal visible={visible} onClose={onClose}>
       <SendPromptModalContainer>
         <Layout.LayoutBase w={75} h={5} bgColor="MEDIUM_GRAY" />
         <SendPromptModalTitle type="title-large">

--- a/src/components/check-in/check-in-edit/availability-select-bottom-sheet/AvailabilitySelectBottomSheet.tsx
+++ b/src/components/check-in/check-in-edit/availability-select-bottom-sheet/AvailabilitySelectBottomSheet.tsx
@@ -34,7 +34,7 @@ function AvailabilitySelectBottomSheet({
   };
 
   return (
-    <BottomModal visible={visible} onClose={closeBottomSheet} maxHeight={700}>
+    <BottomModal visible={visible} onClose={closeBottomSheet} h={300}>
       <Layout.FlexCol alignItems="center" w="100%" bgColor="WHITE">
         <Icon name="home_indicator" />
         <Typo type="title-large">{t('title')}</Typo>

--- a/src/components/check-in/check-in-edit/music-search-bottom-sheet/MusicSearchBottomSheet.tsx
+++ b/src/components/check-in/check-in-edit/music-search-bottom-sheet/MusicSearchBottomSheet.tsx
@@ -5,7 +5,6 @@ import BottomModal from '@components/_common/bottom-modal/BottomModal';
 import BottomModalActionButton from '@components/_common/bottom-modal/BottomModalActionButton';
 import Icon from '@components/_common/icon/Icon';
 import SearchInput from '@components/_common/search-input/SearchInput';
-import { SCREEN_HEIGHT } from '@constants/layout';
 import { Layout, Typo } from '@design-system';
 import useAsyncEffect from '@hooks/useAsyncEffect';
 import SpotifyManager from '@libs/SpotifyManager';
@@ -57,7 +56,7 @@ function MusicSearchBottomSheet({
 
   if (!trackList) return null;
   return (
-    <BottomModal visible={visible} onClose={closeBottomSheet} h={SCREEN_HEIGHT - 30}>
+    <BottomModal visible={visible} onClose={closeBottomSheet}>
       <Layout.FlexCol alignItems="center" w="100%" bgColor="WHITE">
         <Icon name="home_indicator" />
         <Typo type="title-large">{t('title')}</Typo>

--- a/src/components/comments/comment-bottom-sheet/CommentBottomSheet.tsx
+++ b/src/components/comments/comment-bottom-sheet/CommentBottomSheet.tsx
@@ -45,7 +45,7 @@ function CommentBottomSheet({ postType, post, visible, closeBottomSheet }: Props
   };
 
   return createPortal(
-    <BottomModal visible={visible} onClose={closeBottomSheet} h={650} maxHeight={650}>
+    <BottomModal visible={visible} onClose={closeBottomSheet}>
       <CommentBottomHeaderWrapper>
         <Layout.FlexRow w="100%" justifyContent="center">
           <Icon name="home_indicator" />

--- a/src/components/header/bottom-sheet/NewPostBottomSheet.tsx
+++ b/src/components/header/bottom-sheet/NewPostBottomSheet.tsx
@@ -39,7 +39,7 @@ function NewPostBottomSheet({ visible, closeBottomSheet, setSelectPrompt }: Prop
   };
 
   return (
-    <BottomModal visible={visible} onClose={closeBottomSheet} maxHeight={650}>
+    <BottomModal visible={visible} onClose={closeBottomSheet}>
       <Layout.FlexCol alignItems="center" pb={34} w="100%" bgColor="WHITE">
         <Icon name="home_indicator" />
         <Typo type="title-large">Create</Typo>

--- a/src/components/music/music-detail-bottom-sheet/MusicDetailBottomSheet.tsx
+++ b/src/components/music/music-detail-bottom-sheet/MusicDetailBottomSheet.tsx
@@ -34,7 +34,7 @@ function MusicDetailBottomSheet({ track, sharer, visible, closeBottomSheet }: Pr
   };
 
   return (
-    <BottomModal visible={visible} onClose={closeBottomSheet} maxHeight={650}>
+    <BottomModal visible={visible} onClose={closeBottomSheet}>
       <Layout.FlexCol alignItems="center" pb={100} w="100%" bgColor="WHITE">
         <Icon name="home_indicator" />
         {/* sharer info */}

--- a/src/components/prompt/select-prompt-sheet/SelectPromptSheet.tsx
+++ b/src/components/prompt/select-prompt-sheet/SelectPromptSheet.tsx
@@ -15,7 +15,7 @@ function SelectPromptSheet({ visible, closeBottomSheet }: Props) {
   const [t] = useTranslation('translation', { keyPrefix: 'prompts' });
 
   return createPortal(
-    <BottomModal visible={visible} onClose={closeBottomSheet} h={650} maxHeight={650}>
+    <BottomModal visible={visible} onClose={closeBottomSheet}>
       <Layout.FlexCol alignItems="center" pb={34} w="100%" bgColor="WHITE">
         <Icon name="home_indicator" />
         <Typo type="title-large">{t('select_a_prompt')}</Typo>


### PR DESCRIPTION
## Issue Number: #453 

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?
- [x] 데스크탑, 모바일에서의 정상 작동을 확인했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## Testable backend branch name

## What does this PR do?
bottom modal의 height가 화면의 높이를 넘지 않도록 default height 재설정(화면높이-50) 후 기존 코드에 설정되어있던 height값들 정리

## Preview Image
<img width="370" alt="image" src="https://github.com/GooJinSun/WhoAmI-Today-frontend/assets/64309836/34108d32-bb11-47a3-af2c-5aeca078a297">

## Further comments
