### PR TITLE
(#469) checkin 수정시 노래 검색 바텀 모달 높이 너무 낮음

### DIFF
--- a/src/components/check-in/check-in-edit/music-search-bottom-sheet/MusicSearchBottomSheet.tsx
+++ b/src/components/check-in/check-in-edit/music-search-bottom-sheet/MusicSearchBottomSheet.tsx
@@ -56,7 +56,7 @@ function MusicSearchBottomSheet({
 
   if (!trackList) return null;
   return (
-    <BottomModal visible={visible} onClose={closeBottomSheet}>
+    <BottomModal visible={visible} onClose={closeBottomSheet} heightMode="full">
       <Layout.FlexCol alignItems="center" w="100%" bgColor="WHITE">
         <Icon name="home_indicator" />
         <Typo type="title-large">{t('title')}</Typo>


### PR DESCRIPTION
## Issue Number: #469

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?
- [x] 데스크탑, 모바일에서의 정상 작동을 확인했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## Testable backend branch name

- any branch

## What does this PR do?

MusicSearch bottom sheet 높이 수정

## Preview Image

before
<img width="402" alt="Screenshot 2024-06-15 at 3 29 24 PM" src="https://github.com/GooJinSun/WhoAmI-Today-frontend/assets/42240753/30e5da50-9b1f-4460-ab44-12ae21a92ff8">

after
<img width="407" alt="Screenshot 2024-06-15 at 3 28 59 PM" src="https://github.com/GooJinSun/WhoAmI-Today-frontend/assets/42240753/42131bfa-e87b-41cb-884d-4132a32167db">

## Further comments
