### PR TITLE
[Bug] 댓글의 message 버튼은 게시글의 작성자만 볼 수 있도록 수정 필요

### DIFF
--- a/src/components/comment-list/CommentList.tsx
+++ b/src/components/comment-list/CommentList.tsx
@@ -4,6 +4,7 @@ import Loader from '@components/_common/loader/Loader';
 import { Layout } from '@design-system';
 import useInfiniteScroll from '@hooks/useInfiniteScroll';
 import { Comment, Note, Response } from '@models/post';
+import { useBoundStore } from '@stores/useBoundStore';
 import { deleteComment } from '@utils/apis/comments';
 import CommentInputBox from './comment-input-box/CommentInputBox';
 import CommentItem from './comment-item/CommentItem';
@@ -25,6 +26,8 @@ function CommentList({ postType, post, setReload }: CommentListProps) {
 
   const [commentTo, setCommentTo] = useState<Response | Note | Comment>(post);
   const [commentToType, setCommentToType] = useState<'Response' | 'Note' | 'Comment'>(postType);
+
+  const { myProfile } = useBoundStore((state) => ({ myProfile: state.myProfile }));
 
   const { isLoading, targetRef, setIsLoading } = useInfiniteScroll<HTMLDivElement>(async () => {
     if (nextPage === null) return setIsLoading(false);
@@ -62,6 +65,7 @@ function CommentList({ postType, post, setReload }: CommentListProps) {
         {comments.map((comment) => (
           <CommentItem
             key={comment.id}
+            isPostAuthor={myProfile?.id === post.author_detail.id}
             comment={comment}
             onClickReplyBtn={() => {
               setReplyTo(comment);

--- a/src/components/comment-list/comment-item/CommentItem.tsx
+++ b/src/components/comment-list/comment-item/CommentItem.tsx
@@ -10,12 +10,18 @@ import { useBoundStore } from '@stores/useBoundStore';
 import { convertTimeDiffByString } from '@utils/timeHelpers';
 
 interface CommentItemProps {
+  isPostAuthor?: boolean;
   comment: Comment | PrivateComment;
   replyAvailable?: boolean;
   onClickReplyBtn?: () => void;
 }
 
-function CommentItem({ comment, onClickReplyBtn, replyAvailable = true }: CommentItemProps) {
+function CommentItem({
+  isPostAuthor,
+  comment,
+  onClickReplyBtn,
+  replyAvailable = true,
+}: CommentItemProps) {
   const [t] = useTranslation('translation', { keyPrefix: 'comment' });
   const { author_detail, created_at, is_private, replies } = comment;
   const { username, profile_image } = author_detail ?? {};
@@ -82,14 +88,16 @@ function CommentItem({ comment, onClickReplyBtn, replyAvailable = true }: Commen
                   </Layout.FlexRow>
                 </button>
               )}
-              <button type="button" onClick={handleSendMessage}>
-                <Layout.FlexRow gap={4} alignItems="center">
-                  <SvgIcon name="comment_message" size={24} />
-                  <Typo type="label-medium" color="DARK_GRAY">
-                    {t('message')}
-                  </Typo>
-                </Layout.FlexRow>
-              </button>
+              {!isCommentAuthor && isPostAuthor && (
+                <button type="button" onClick={handleSendMessage}>
+                  <Layout.FlexRow gap={4} alignItems="center">
+                    <SvgIcon name="comment_message" size={24} />
+                    <Typo type="label-medium" color="DARK_GRAY">
+                      {t('message')}
+                    </Typo>
+                  </Layout.FlexRow>
+                </button>
+              )}
             </Layout.FlexRow>
           </Layout.FlexCol>
         </Layout.FlexCol>
@@ -107,7 +115,12 @@ function CommentItem({ comment, onClickReplyBtn, replyAvailable = true }: Commen
       {/* replies */}
       <Layout.FlexCol w="100%" gap={8} pl={20} mt={14}>
         {replies?.map((reply) => (
-          <CommentItem key={reply.id} comment={reply} replyAvailable={false} />
+          <CommentItem
+            key={reply.id}
+            isPostAuthor={isPostAuthor}
+            comment={reply}
+            replyAvailable={false}
+          />
         ))}
       </Layout.FlexCol>
     </Layout.FlexCol>

--- a/src/components/comments/comment-bottom-sheet/CommentBottomSheet.tsx
+++ b/src/components/comments/comment-bottom-sheet/CommentBottomSheet.tsx
@@ -10,6 +10,7 @@ import { getCommentList } from '@components/comment-list/CommentList.helper';
 import { Layout, Typo } from '@design-system';
 import useAsyncEffect from '@hooks/useAsyncEffect';
 import { Comment, Note, Response } from '@models/post';
+import { useBoundStore } from '@stores/useBoundStore';
 import {
   CommentBottomContentWrapper,
   CommentBottomFooterWrapper,
@@ -33,6 +34,8 @@ function CommentBottomSheet({ postType, post, visible, closeBottomSheet }: Props
 
   const [commentTo, setCommentTo] = useState<Response | Note | Comment>(post);
   const [commentToType, setCommentToType] = useState<'Response' | 'Note' | 'Comment'>(postType);
+
+  const { myProfile } = useBoundStore((state) => ({ myProfile: state.myProfile }));
 
   const fetchComments = async (page: string | null, update: boolean) => {
     const { results, next } = await getCommentList(postType, post.id, page);
@@ -75,6 +78,7 @@ function CommentBottomSheet({ postType, post, visible, closeBottomSheet }: Props
         {comments.map((comment) => (
           <CommentItem
             key={comment.id}
+            isPostAuthor={myProfile?.id === post.author_detail.id}
             comment={comment}
             onClickReplyBtn={() => {
               setReplyTo(comment);


### PR DESCRIPTION
## Issue Number: #507 

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?
- [x] 데스크탑, 모바일에서의 정상 작동을 확인했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## Testable backend branch name

## What does this PR do?
게시글의 작성자가 아닌 경우 댓글의 message 버튼 disable
내가 작성한 댓글의 경우도 message 버튼 disable

## Preview Image
- Adoor1이 보는 Adoor1의 게시글 댓글들
<img width="499" alt="image" src="https://github.com/GooJinSun/WhoAmI-Today-frontend/assets/64309836/c435c861-3c3a-4413-95c2-bece4764b738">

- Adoor4가 보는 Adoor1의 게시글 댓글들
<img width="491" alt="image" src="https://github.com/GooJinSun/WhoAmI-Today-frontend/assets/64309836/83bc8ce1-d291-4c66-9c0b-528d5f4b575d">


## Further comments
