### PR TITLE
(#528) 내프로필 > 수정 > pronouns, bio 수정이 안됩니다

### DIFF
--- a/src/routes/settings/EditProfile.tsx
+++ b/src/routes/settings/EditProfile.tsx
@@ -24,13 +24,11 @@ function EditProfile() {
     openToast: state.openToast,
   }));
 
-  const [draft, setDraft] = useState<Pick<MyProfile, 'bio' | 'username' | 'pronouns'>>(
-    myProfile || {
-      bio: '',
-      username: '',
-      pronouns: '',
-    },
-  );
+  const [draft, setDraft] = useState<Pick<MyProfile, 'bio' | 'username' | 'pronouns'>>({
+    bio: myProfile?.bio ?? '',
+    username: myProfile?.username ?? '',
+    pronouns: myProfile?.pronouns ?? '',
+  });
 
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -74,11 +72,14 @@ function EditProfile() {
 
   const handleClickSave = async () => {
     if (!myProfile) return;
+
+    const profileData = {
+      ...draft,
+      ...(croppedImg ? { profile_image: croppedImg.file } : {}),
+    };
+
     editProfile({
-      profile: {
-        ...draft,
-        ...(croppedImg ? { profile_image: croppedImg.file } : {}),
-      },
+      profile: profileData,
       onSuccess: (data: MyProfile) => {
         updateMyProfile({ ...data });
         openToast({ message: t('response.updated') });


### PR DESCRIPTION
## Issue Number: #528

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?
- [x] 데스크탑, 모바일에서의 정상 작동을 확인했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## Testable backend branch name

main

## What does this PR do?

profile 이미지가 있는 경우 pronouns, bio가 수정이 안되는 이슈를 수정했습니다.
EditProfile 컴포넌트의 draft 초기 상태에 profile_image (string url 형식)가 있는 경우에 문제가 된것이라고 파악했고
draft 초기 상태에 불필요한 값들이 있어서 꼭 필요한 값들만 남겼습니다.

## Preview Image

before

https://github.com/user-attachments/assets/4991c7fc-2c75-4857-9a98-3c8e312ffe33


after

https://github.com/user-attachments/assets/16910b08-6993-4c68-9e6c-695ef43d91c6


## Further comments
