### PR TITLE
(#523) 비밀댓글의 대댓글의 경우 private으로만 댓글을 남길 수 있어야함

### DIFF
--- a/src/components/comment-list/comment-input-box/CommentInputBox.tsx
+++ b/src/components/comment-list/comment-input-box/CommentInputBox.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, KeyboardEvent, useEffect, useState } from 'react';
+import { ChangeEvent, KeyboardEvent, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import ProfileImage from '@components/_common/profile-image/ProfileImage';
 import { Button, CheckBox, Layout, SvgIcon, Typo } from '@design-system';
@@ -37,13 +37,18 @@ function CommentInputBox({
   const [t] = useTranslation('translation', { keyPrefix: 'comment' });
   const myProfile = useBoundStore((state) => state.myProfile);
   const [content, setContent] = useState('');
-  const [initialIsPrivate, setInitialIsPrivate] = useState<boolean | undefined>(undefined);
+  const initialIsPrivateRef = useRef(isPrivate);
+  const [initialIsPrivate, setInitialIsPrivate] = useState(initialIsPrivateRef.current);
+
+  useEffect(() => {
+    initialIsPrivateRef.current = isPrivate;
+  }, [isPrivate]);
 
   useEffect(() => {
     if (isReply) {
-      setInitialIsPrivate(isPrivate);
+      setInitialIsPrivate(initialIsPrivateRef.current);
     }
-  }, [isReply, replyTo, isPrivate]);
+  }, [isReply, replyTo]);
 
   const handleCheckboxChange = () => {
     if (!initialIsPrivate) {


### PR DESCRIPTION
## Issue Number: #523

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?
- [x] 데스크탑, 모바일에서의 정상 작동을 확인했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## Testable backend branch name

## What does this PR do?
비밀댓글에 reply를 남길시에 체크박스 해제 안되도록
일반댓글에 reply를 남길시에 체크박스 토글이 가능하도록 수정 

## Preview Image

https://github.com/user-attachments/assets/fc6578e4-da5d-428a-9040-81022f7ce3c3


## Further comments
