### PR TITLE
(#524) 댓글 author profile 누르면 그 유저 페이지로 이동해야함

### DIFF
--- a/src/components/_common/profile-image/ProfileImage.tsx
+++ b/src/components/_common/profile-image/ProfileImage.tsx
@@ -11,11 +11,19 @@ interface ProfileImageProps {
    * 강제로 이미지 업데이트가 필요한 경우 사용(e.g 설정>프로필 이미지 변경 이후 설정 페이지로 돌아온 경우)
    */
   ts?: number;
+  onClick?: () => void;
 }
 
-function ProfileImage({ imageUrl, username, className, ts, size = 36 }: ProfileImageProps) {
+function ProfileImage({
+  imageUrl,
+  username,
+  className,
+  ts,
+  size = 36,
+  onClick,
+}: ProfileImageProps) {
   return (
-    <NonShrinkWrapper>
+    <NonShrinkWrapper onClick={onClick}>
       <Layout.LayoutBase w={size} h={size} rounded={size / 2} className={className}>
         {imageUrl ? (
           <img

--- a/src/components/comment-list/comment-item/CommentItem.tsx
+++ b/src/components/comment-list/comment-item/CommentItem.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
 import Icon from '@components/_common/icon/Icon';
 import LikeButton from '@components/_common/like-button/LikeButton';
 import ProfileImage from '@components/_common/profile-image/ProfileImage';
@@ -25,7 +26,7 @@ function CommentItem({
   const [t] = useTranslation('translation', { keyPrefix: 'comment' });
   const { author_detail, created_at, is_private, replies } = comment;
   const { username, profile_image } = author_detail ?? {};
-
+  const navigate = useNavigate();
   const [createdAt] = useState(() => (created_at ? new Date(created_at) : null));
   const [currentDate] = useState(() => new Date());
 
@@ -44,12 +45,16 @@ function CommentItem({
     // TBU
   };
 
+  const navigateToProfile = () => {
+    navigate(`/users/${username}`);
+  };
+
   return (
     <Layout.FlexCol w="100%">
       <Layout.FlexRow w="100%" justifyContent="space-between" alignItems="flex-start" gap={8}>
         {/* Author Profile */}
         <Layout.FlexCol w={30}>
-          <ProfileImage imageUrl={profile_image} size={30} />
+          <ProfileImage imageUrl={profile_image} size={30} onClick={navigateToProfile} />
         </Layout.FlexCol>
         {/* Author name, time, content */}
         <Layout.FlexCol flex={1} alignItems="center">


### PR DESCRIPTION
## Issue Number: #524

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?
- [x] 데스크탑, 모바일에서의 정상 작동을 확인했나요?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## Testable backend branch name

main

## What does this PR do?

댓글 작성자 프로필 이미지를 누르면 그 유저의 페이지로 이동하도록 합니다

## Preview Image

https://github.com/user-attachments/assets/e64dca76-6caa-46b9-97ca-9c25b1985a2e

## Further comments
프로필 사진을 눌렀을 때 꼭 그 유저의 페이지로 이동하는 것뿐 아니라 다른 동작도 같이 전달하는 게 나을 것 같기도 했고 또, 프로필 사진을 눌렀을 때 유저의 페이지로 이동하지 않는 것을 기대하는 케이스도 있을 것 같아서 쉽게 onClick prop 만 넘겨서 처리하도록 했습니다~!
