### PR TITLE
(#535) 유저페이지에서 노트 무한 스크롤시 같은 페이지가 로드되는 버그 수정

### DIFF
--- a/src/components/note/note-section/NoteSection.tsx
+++ b/src/components/note/note-section/NoteSection.tsx
@@ -26,7 +26,9 @@ function NoteSection({ username }: NoteSectionProps) {
   });
 
   const fetchNotes = async (page: string | null, isRefresh?: boolean) => {
-    const { results, next } = username ? await getUserNotes(username) : await getMyNotes(page);
+    const { results, next } = username
+      ? await getUserNotes(username, page)
+      : await getMyNotes(page);
     if (!results) return;
     setNextPage(next);
     if (isRefresh) {


### PR DESCRIPTION
## Issue Number: #535

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?
- [x] 데스크탑, 모바일에서의 정상 작동을 확인했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## Testable backend branch name: main

## What does this PR do?
- 유저페이지에서 노트 무한 스크롤시 첫 페이지만 불러오는 버그 수정
  - api 요청시에 다음 페이지에 대한 정보를 넘겨주지 않고 있었음.

## Preview Image

https://github.com/user-attachments/assets/c3cf497a-4451-4e2e-8313-dcaef69f1460




## Further comments
