### PR TITLE
(#565) 음악검색 바텀시트의 input 창으로 focus가도록 수정

### DIFF
--- a/src/components/_common/search-input/SearchInput.tsx
+++ b/src/components/_common/search-input/SearchInput.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, Dispatch, SetStateAction, useRef, useState } from 'react';
+import { ChangeEvent, Dispatch, SetStateAction, useEffect, useRef, useState } from 'react';
 import DeleteButton from '@components/_common/delete-button/DeleteButton';
 import { Layout, SvgIcon } from '@design-system';
 import * as S from './SearchInput.styled';
@@ -6,12 +6,20 @@ import * as S from './SearchInput.styled';
 interface Props {
   query: string;
   setQuery: Dispatch<SetStateAction<string>>;
+  autoFocus?: boolean;
   fontSize?: number;
   placeholder?: string;
   cancelText?: string;
 }
 
-export default function SearchInput({ query, setQuery, fontSize, placeholder, cancelText }: Props) {
+export default function SearchInput({
+  query,
+  setQuery,
+  autoFocus,
+  fontSize,
+  placeholder,
+  cancelText,
+}: Props) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [searchMode, setSearchMode] = useState(false);
 
@@ -30,6 +38,11 @@ export default function SearchInput({ query, setQuery, fontSize, placeholder, ca
     setSearchMode(false);
     setQuery('');
   };
+
+  useEffect(() => {
+    if (!autoFocus) return;
+    inputRef.current?.focus();
+  }, [autoFocus]);
 
   return (
     <Layout.FlexRow w="100%" alignItems="center" justifyContent="space-between">

--- a/src/components/check-in/check-in-edit/check-in-spotify-search-input/CheckInSpotifySearchInput.tsx
+++ b/src/components/check-in/check-in-edit/check-in-spotify-search-input/CheckInSpotifySearchInput.tsx
@@ -20,7 +20,11 @@ function CheckInSpotifySearchInput(props: CheckInSpotifySearchInputProps) {
       <Layout.Absolute l={8}>
         <SvgIcon name="search" size={24} fill="MEDIUM_GRAY" />
       </Layout.Absolute>
-      <S.StyledCheckInSpotifySearchInput {...props} placeholder={t('search_placeholder') || ''} />
+      <S.StyledCheckInSpotifySearchInput
+        {...props}
+        readOnly
+        placeholder={t('search_placeholder') || ''}
+      />
       <Layout.Absolute r={8}>
         <SvgIcon name="spotify" size={24} />
       </Layout.Absolute>

--- a/src/components/check-in/check-in-edit/music-search-bottom-sheet/MusicSearchBottomSheet.tsx
+++ b/src/components/check-in/check-in-edit/music-search-bottom-sheet/MusicSearchBottomSheet.tsx
@@ -66,6 +66,7 @@ function MusicSearchBottomSheet({
             <SearchInput
               query={query}
               setQuery={setQuery}
+              autoFocus
               fontSize={16}
               placeholder={t('search_placeholder') || undefined}
               cancelText={t('cancel') || undefined}


### PR DESCRIPTION
## Issue Number: #565

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?
- [x] 데스크탑, 모바일에서의 정상 작동을 확인했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## Testable backend branch name: main

## What does this PR do?
- 체크인에서 음악 검색 바텀시트가 열릴때 input창으로 focus가 갈 수 있도록 `autoFocus` 기능 추가

## Preview Image

https://github.com/user-attachments/assets/8aee6594-373a-4100-a090-fb9afe55cb88



## Further comments
