### PR TITLE
feat: #608 친구목록 로딩중에 노출하는 레이아웃 수정

### DIFF
--- a/src/routes/friends/Friends.tsx
+++ b/src/routes/friends/Friends.tsx
@@ -27,11 +27,10 @@ function Friends() {
     refetchAllFriends,
   } = useInfiniteFetchFriends();
 
-  const {
-    data: favoriteFriends,
-    isLoading: isFavoriteFriendsLoading,
-    mutate: refetchFavoriteFriends,
-  } = useSWR('/user/friends/?type=favorites', getFavoriteFriends);
+  const { data: favoriteFriends, mutate: refetchFavoriteFriends } = useSWR(
+    '/user/friends/?type=favorites',
+    getFavoriteFriends,
+  );
 
   const navigate = useNavigate();
   const handleClickEditFriends = () => {
@@ -44,8 +43,6 @@ function Friends() {
   };
 
   const handleClickExploreFriends = () => navigate('/friends/explore');
-
-  if (isAllFriendsLoading && isFavoriteFriendsLoading) return <Loader />;
 
   return (
     <MainScrollContainer>
@@ -78,11 +75,11 @@ function Friends() {
               }
             />
           )}
-          {/* Friend Requests */}
-          <Divider width={1} marginLeading={9} />
+          {favoriteFriends && allFriends && <Divider width={1} marginLeading={9} />}
           {/* All Friends */}
           <SwipeLayoutList>
             <Layout.FlexCol w="100%">
+              {/* Friend Requests */}
               <Layout.FlexRow
                 w="100%"
                 ph={16}
@@ -101,29 +98,27 @@ function Friends() {
                 />
               </Layout.FlexRow>
               <Layout.FlexCol w="100%" pv={8} gap={4}>
-                {allFriends ? (
-                  <>
-                    {/* Explore Friends */}
-                    <Layout.FlexRow w="100%" ph={16} gap={16}>
-                      <StyledUpdatedFriendItem
-                        w="100%"
-                        alignItems="center"
-                        justifyContent="space-between"
-                      >
-                        <Layout.FlexRow
-                          alignItems="center"
-                          gap={7}
-                          onClick={handleClickExploreFriends}
-                        >
-                          <Icon name="add_user" background="LIGHT_GRAY" size={44} />
-                          <Layout.FlexCol>
-                            <Layout.FlexRow gap={4} alignItems="center">
-                              <Typo type="label-large">{t('explore_friends.title')}</Typo>
-                            </Layout.FlexRow>
-                          </Layout.FlexCol>
+                {/* Explore Friends */}
+                <Layout.FlexRow w="100%" ph={16} gap={16}>
+                  <StyledUpdatedFriendItem
+                    w="100%"
+                    alignItems="center"
+                    justifyContent="space-between"
+                  >
+                    <Layout.FlexRow alignItems="center" gap={7} onClick={handleClickExploreFriends}>
+                      <Icon name="add_user" background="LIGHT_GRAY" size={44} />
+                      <Layout.FlexCol>
+                        <Layout.FlexRow gap={4} alignItems="center">
+                          <Typo type="label-large">{t('explore_friends.title')}</Typo>
                         </Layout.FlexRow>
-                      </StyledUpdatedFriendItem>
+                      </Layout.FlexCol>
                     </Layout.FlexRow>
+                  </StyledUpdatedFriendItem>
+                </Layout.FlexRow>
+                {isAllFriendsLoading ? (
+                  <Loader />
+                ) : allFriends ? (
+                  <>
                     {/* 친구 목록 */}
                     {allFriends.map(({ results }) =>
                       results?.map((user) => {


### PR DESCRIPTION
## Issue Number: #608

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?
- [x] 데스크탑, 모바일에서의 정상 작동을 확인했나요?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## Testable backend branch name

## What does this PR do?
- 친구 목록 로딩 레이아웃 수정 
> 즐겨찾기한 친구쪽은 데이터가 없는 경우 아예 영역을 노출하지 않아서 그런지 생각보다 레이아웃이랄게 없어 별 차이가 없네요..ㅎㅎ 

## Preview Image
- before

https://github.com/user-attachments/assets/00a5b645-0eef-4f4e-93e0-8ad953ee5401


- after

https://github.com/user-attachments/assets/7eb875db-5cfd-4e82-843f-efb5d77b0986



## Further comments
