### PR TITLE
bugfix: #639 하단 탭을 기준으로 플로팅 버튼 정렬하도록 수정 && NewFloatingButton -> FloatingButton

### DIFF
--- a/src/components/header/common-header/CommonHeader.tsx
+++ b/src/components/header/common-header/CommonHeader.tsx
@@ -5,7 +5,6 @@ import { Layout } from '@design-system';
 import { useBoundStore } from '@stores/useBoundStore';
 import { Noti } from '../Header.styled';
 import MainHeader from '../MainHeader';
-import NewFloatingButton from '../new-floating-button/NewFloatingButton';
 import SideMenu from '../side-menu/SideMenu';
 
 interface CommonHeaderProps {
@@ -39,7 +38,6 @@ function CommonHeader({ title }: CommonHeaderProps) {
         }
       />
       {showSideMenu && <SideMenu closeSideMenu={() => setShowSideMenu(false)} />}
-      <NewFloatingButton />
     </>
   );
 }

--- a/src/components/header/floating-button/FloatingButton.styled.ts
+++ b/src/components/header/floating-button/FloatingButton.styled.ts
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
-export const StyledNewFloatingButton = styled.button`
-  position: fixed;
+export const StyledFloatingButton = styled.button`
+  position: absolute;
   z-index: 500;
   bottom: 100px;
   right: 20px;

--- a/src/components/header/floating-button/FloatingButton.tsx
+++ b/src/components/header/floating-button/FloatingButton.tsx
@@ -2,9 +2,9 @@ import { useState } from 'react';
 import SelectPromptSheet from '@components/prompt/select-prompt-sheet/SelectPromptSheet';
 import { SvgIcon } from '@design-system';
 import NewPostBottomSheet from '../bottom-sheet/NewPostBottomSheet';
-import { StyledNewFloatingButton } from './NewFloatingButton.styled';
+import { StyledFloatingButton } from './FloatingButton.styled';
 
-function NewFloatingButton() {
+function FloatingButton() {
   const [bottomSheet, setBottomSheet] = useState(false);
   const [selectPrompt, setSelectPrompt] = useState(false);
 
@@ -14,9 +14,9 @@ function NewFloatingButton() {
 
   return (
     <>
-      <StyledNewFloatingButton onClick={handleNewPost}>
+      <StyledFloatingButton onClick={handleNewPost}>
         <SvgIcon name="add_post" size={44} />
-      </StyledNewFloatingButton>
+      </StyledFloatingButton>
       {bottomSheet && (
         <NewPostBottomSheet
           visible={bottomSheet}
@@ -31,4 +31,4 @@ function NewFloatingButton() {
   );
 }
 
-export default NewFloatingButton;
+export default FloatingButton;

--- a/src/components/tab/Tab.tsx
+++ b/src/components/tab/Tab.tsx
@@ -1,4 +1,7 @@
 import { useTranslation } from 'react-i18next';
+import { useLocation } from 'react-router-dom';
+
+import FloatingButton from '@components/header/floating-button/FloatingButton';
 import { Layout, SvgIcon, Typo } from '@design-system';
 import { useBoundStore } from '@stores/useBoundStore';
 import { NavTabItem, StyledTabItem, TabWrapper } from './Tab.styled';
@@ -48,6 +51,12 @@ function TabItem({ to, type, size = 48 }: TabItemProps) {
 }
 
 export default function Tab() {
+  const location = useLocation();
+  const showFloatingButton =
+    location.pathname === '/friends' ||
+    location.pathname === '/my' ||
+    location.pathname === '/questions';
+
   return (
     <TabWrapper>
       <Layout.FlexRow w="100%" justifyContent="center" alignItems="center" gap={80} pt={4}>
@@ -56,6 +65,7 @@ export default function Tab() {
         {/* <TabItem to="/chats" type="chats" size={28} /> */}
         <TabItem to="/questions" type="questions" size={28} />
       </Layout.FlexRow>
+      {showFloatingButton && <FloatingButton />}
     </TabWrapper>
   );
 }


### PR DESCRIPTION
## Issue Number: #639

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?
- [x] 데스크탑, 모바일에서의 정상 작동을 확인했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## Testable backend branch name
`main`
## What does this PR do?
- 하단 탭을 기준으로 플로팅 버튼 정렬하도록 수정
> 유리님  아이디어 감사합니다! 아주 깔끔하게 해결되네요! <nav> 태그 안에 button이 들어가는게 조금 마음이 걸리지만... 더 나은 해결책이 없는 것 같아 그대로 적용합니다!

[데스크탑]
<img width="1511" alt="스크린샷 2024-08-31 오전 11 55 54" src="https://github.com/user-attachments/assets/cc82461f-70dc-4da1-a398-b03608ffb86a">
[모바일]
<img width="1510" alt="스크린샷 2024-08-31 오전 11 53 49" src="https://github.com/user-attachments/assets/364d1593-ddc5-4c85-b11d-3f23bdb2746e">


- 컴포넌트명 수정 NewFloatingButton -> FloatingButton
## Preview Image

## Further comments
