### PR TITLE
(#633) 게시글(답변/노트)의 길이가 길어질 경우, 디테일 페이지 > 좋아요 목록의 유저 프로필 아이콘이 댓글 인풋창 위로 올라옵니다

### DIFF
--- a/src/components/comment-list/CommentList.styled.ts
+++ b/src/components/comment-list/CommentList.styled.ts
@@ -1,7 +1,8 @@
 import styled from 'styled-components';
-import { MAX_WINDOW_WIDTH } from '@constants/layout';
+import { MAX_WINDOW_WIDTH, Z_INDEX } from '@constants/layout';
 import { Layout } from '@design-system';
 
 export const StyledCommentListFooter = styled(Layout.Fixed)`
   max-width: ${MAX_WINDOW_WIDTH}px;
+  z-index: ${Z_INDEX.BOTTOM_TAB};
 `;


### PR DESCRIPTION
## Issue Number: #633

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?
- [x] 데스크탑, 모바일에서의 정상 작동을 확인했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## Testable backend branch name

any branch

## What does this PR do?

- StyledCommentListFooter의 z-index를 Bottom tab과 같은 위치로 올립니다!

## Preview Image

before

https://github.com/user-attachments/assets/f4101e6c-24c3-4f42-90e1-b888771c6380

after 

https://github.com/user-attachments/assets/bb069861-46dc-46a9-9a71-3897d1386040


## Further comments
