### PR TITLE
(#654) settings - notification 에 푸시 알림 설정이 켜지지 않음

### DIFF
--- a/src/hooks/useAppMessage.tsx
+++ b/src/hooks/useAppMessage.tsx
@@ -4,10 +4,6 @@ import { isApp } from '@utils/getUserAgent';
 
 type MessageDataType = Extract<PostMessageDataType, { key: PostMessageKeyType }>;
 
-const isPostMessageData = (data: unknown): data is PostMessageDataType => {
-  return typeof data === 'object' && data !== null && 'key' in data;
-};
-
 // 앱 -> 웹 메시지 수신 (GET)
 export const useGetAppMessage = <K extends PostMessageKeyType>({
   cb,
@@ -20,11 +16,9 @@ export const useGetAppMessage = <K extends PostMessageKeyType>({
     if (!isApp) return;
     const handleMessage = (event: MessageEvent) => {
       const { data } = event;
-      if (data.type) return;
       try {
         const parsedData = JSON.parse(data);
         if (!parsedData.key || parsedData.key !== key) return;
-        if (!isPostMessageData(parsedData.data)) return;
 
         const messageData = parsedData.data as PostMessageKeyToData[K];
         cb(messageData);


### PR DESCRIPTION
## Issue Number: #654

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?
- [x] 데스크탑, 모바일에서의 정상 작동을 확인했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## Testable backend branch name

any branch

## What does this PR do?

- useAppMessage hook에서 굳이 data type 검증 필요없을 것 같아 삭제
- 앱에서 보내는 data 타입에 따라서 메시지 잘 받을 수 있게 수정 (`key`, `data`이라는 키값을 받아서 처리해야하는데 `type`을 바라보고 있어서 문제였음)

## Preview Image

https://github.com/user-attachments/assets/a622cb9c-0750-456a-afd3-93c850000ca4


## Further comments

언제부터 동작안했는지 모르겠네요.. 중간에 app message를 받는 형식을 예전에 수정했던 것 같은데 그 작업하면서 버그가 생겼던 것 같습니다 ㅠㅠ 다음부턴 좀 더 꼼꼼하게 볼게요..!
