### PR TITLE
(#667) 질문 선택 모달에서도 /questions에서 사용하는 전체 질문 목록 API(/qna/questions) 를 사용하도록 수정

### DIFF
--- a/src/components/prompt/prompts-of-the-day/PromptOfTheDay.tsx
+++ b/src/components/prompt/prompts-of-the-day/PromptOfTheDay.tsx
@@ -1,10 +1,13 @@
 import { MutableRefObject, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDraggable } from 'react-use-draggable-scroll';
+import { Loader } from '@components/_common/loader/Loader.styled';
+import NoContents from '@components/_common/no-contents/NoContents';
 import PromptCard from '@components/_common/prompt/PromptCard';
 import RecentPromptCard from '@components/_common/prompt/RecentPromptCard';
 import { Layout, Typo } from '@design-system';
 import useAsyncEffect from '@hooks/useAsyncEffect';
+import useInfiniteFetchQuestions from '@hooks/useInfiniteFetchQuestions';
 import { TodayQuestionsSelector } from '@stores/todaysQuestions';
 import { useBoundStore } from '@stores/useBoundStore';
 import {
@@ -16,6 +19,8 @@ import {
 function PromptsOfTheDay() {
   const [t] = useTranslation('translation', { keyPrefix: 'prompts' });
   const { todaysQuestions, fetchTodaysQuestions } = useBoundStore(TodayQuestionsSelector);
+  const { questions, isLoading, targetRef } = useInfiniteFetchQuestions();
+
   const ref = useRef<HTMLDivElement>() as MutableRefObject<HTMLInputElement>;
   const { events } = useDraggable(ref);
 
@@ -41,9 +46,18 @@ function PromptsOfTheDay() {
         <Typo type="title-medium">{t('recent_prompts')}</Typo>
       </Layout.FlexRow>
       <StyledRecentPromptsOfTheDay gap={16} w="100%" alignItems="center">
-        {todaysQuestions.map((question) => (
-          <RecentPromptCard key={question.id} question={question} />
+        {questions.map((question) => (
+          <RecentPromptCard question={question} key={question.id} />
         ))}
+        <div ref={targetRef} />
+        {isLoading && (
+          <Layout.FlexRow w="100%" h={40}>
+            <Loader />
+          </Layout.FlexRow>
+        )}
+        {!isLoading && questions.length < 1 && (
+          <NoContents text={t('no_contents.all_questions')} mv={10} />
+        )}
       </StyledRecentPromptsOfTheDay>
     </Layout.FlexCol>
   );

--- a/src/hooks/useInfiniteFetchQuestions.ts
+++ b/src/hooks/useInfiniteFetchQuestions.ts
@@ -1,0 +1,31 @@
+import { useState } from 'react';
+import { Question } from '@models/post';
+import { getAllQuestions } from '@utils/apis/question';
+import useInfiniteScroll from './useInfiniteScroll';
+
+const useInfiniteFetchQuestions = () => {
+  const [questions, setQuestions] = useState<Question[]>([]);
+  const [nextPage, setNextPage] = useState<string | null | undefined>(undefined);
+
+  const { isLoading, targetRef, setIsLoading } = useInfiniteScroll<HTMLDivElement>(async () => {
+    if (nextPage === null) return setIsLoading(false);
+    await fetchQuestions(nextPage === undefined ? null : nextPage);
+  });
+
+  const fetchQuestions = async (page: string | null) => {
+    const { results, next } = await getAllQuestions(page);
+    if (!results) return;
+    setNextPage(next);
+    setQuestions([...questions, ...results]);
+    setIsLoading(false);
+  };
+
+  return {
+    isLoading,
+    targetRef,
+    fetchQuestions,
+    questions,
+  };
+};
+
+export default useInfiniteFetchQuestions;

--- a/src/routes/AllQuestions.tsx
+++ b/src/routes/AllQuestions.tsx
@@ -1,32 +1,15 @@
-import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import Loader from '@components/_common/loader/Loader';
 import NoContents from '@components/_common/no-contents/NoContents';
 import PromptCard from '@components/_common/prompt/PromptCard';
 import { DEFAULT_MARGIN } from '@constants/layout';
 import { Layout } from '@design-system';
-import useInfiniteScroll from '@hooks/useInfiniteScroll';
-import { Question } from '@models/post';
-import { getAllQuestions } from '@utils/apis/question';
+import useInfiniteFetchQuestions from '@hooks/useInfiniteFetchQuestions';
 import { MainScrollContainer } from './Root';
 
 function AllQuestions() {
   const [t] = useTranslation('translation');
-  const [questions, setQuestions] = useState<Question[]>([]);
-  const [nextPage, setNextPage] = useState<string | null | undefined>(undefined);
-
-  const { isLoading, targetRef, setIsLoading } = useInfiniteScroll<HTMLDivElement>(async () => {
-    if (nextPage === null) return setIsLoading(false);
-    await fetchQuestions(nextPage === undefined ? null : nextPage);
-  });
-
-  const fetchQuestions = async (page: string | null) => {
-    const { results, next } = await getAllQuestions(page);
-    if (!results) return;
-    setNextPage(next);
-    setQuestions([...questions, ...results]);
-    setIsLoading(false);
-  };
+  const { questions, targetRef, isLoading } = useInfiniteFetchQuestions();
 
   return (
     <MainScrollContainer>


### PR DESCRIPTION
## Issue Number: #667 

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?
- [x] 데스크탑, 모바일에서의 정상 작동을 확인했나요?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## Testable backend branch name
`main`
## What does this PR do?
- https://github.com/GooJinSun/WhoAmI-Today-backend/pull/338 에서 오늘의 질문 API`/api/qna/questions/daily` 변경됨에 따라 프론트도 수정
  - as-is: `/api/qna/questions/daily` 에서 최근 6일의 오늘의 질문을 내려줌
  - to-be: `/api/qna/questions/daily` 에서는 오늘의 질문 5개만 내려주도록 수정. 최근 질문은 전체 질문 리스트 API( `/api/qna/questions`)를 사용하도록 수정함

cc. @njs03332 
 
## Preview Image
<img width="501" alt="image" src="https://github.com/user-attachments/assets/1b2471f6-ba80-4fff-864e-8edd3c3a2ef4">
## Further comments
