### PR TITLE
(#691) 유저페이지 > 댓글 > 다른 유저페이지 접근시 이전 유저의 정보가 노출되는 버그 수정

### DIFF
--- a/src/components/header/user-header/UserHeader.tsx
+++ b/src/components/header/user-header/UserHeader.tsx
@@ -1,14 +1,13 @@
 import Icon from '@components/_common/icon/Icon';
 import SubHeader from '@components/sub-header/SubHeader';
 import { Layout } from '@design-system';
-import { User } from '@models/user';
 
 interface UserHeaderProps {
-  user?: User;
+  username?: string;
   onClickMore: () => void;
 }
 
-function UserHeader({ user, onClickMore }: UserHeaderProps) {
+function UserHeader({ username, onClickMore }: UserHeaderProps) {
   // const handleClickChat = async () => {
   //   if (!user) return;
   //   const roomId = await getChatRoomIdByUserId(user.id);
@@ -20,10 +19,10 @@ function UserHeader({ user, onClickMore }: UserHeaderProps) {
     onClickMore();
   };
 
-  if (!user) return null;
+  if (!username) return null;
   return (
     <SubHeader
-      title={user.username}
+      title={username}
       RightComponent={
         <Layout.FlexRow gap={8} alignItems="center">
           {/* <Icon name="chat_outline" size={44} onClick={handleClickChat} /> */}

--- a/src/routes/UserPage.tsx
+++ b/src/routes/UserPage.tsx
@@ -56,7 +56,7 @@ function UserPage() {
 
   return (
     <MainContainer>
-      <UserHeader user={user.data} onClickMore={handleClickMore} />
+      <UserHeader username={username} onClickMore={handleClickMore} />
       {(user.state === 'hasError' || !username) && <CommonError />}
       {user.state === 'hasValue' && user.data && (
         <Layout.FlexCol w="100%" bgColor="LIGHT" mt={TITLE_HEADER_HEIGHT}>


### PR DESCRIPTION
## Issue Number: #691

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?
- [x] 데스크탑, 모바일에서의 정상 작동을 확인했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## Testable backend branch name: main

## What does this PR do?
- 유저페이지 > 댓글 > 다른 유저페이지 접근시 이전 유저의 정보가 노출되는 버그 
  - username이 변경되는 경우 다시 프로필정보를 불러올 수 있도록 의존성 배열에 추가 64873f04b0c1dece85843e60df6c312152d5a5ff
    > ~초기진입시 헤더에서 잠시 이전 유저의 정보가 노출되지만, 이 부분은 #686 에서 이어서 개선하도록 하겠습니다.~ 생각해보니 쉽게 수정가능해서 커밋 추가해뒀습니다. [ec94917](https://github.com/GooJinSun/WhoAmI-Today-frontend/pull/693/commits/ec9491744d2cd56a2e7baf10fdc7d45aa3747e58)
  - `NoteSection`과 `ResponseSection`이 갱신되지 않는 버그는 #692 에서 수정되어서 base 브랜치를 `refact/issue-656/my` 로 설정했습니다.

## Preview Image

https://github.com/user-attachments/assets/b84e06c6-a46c-4fb1-b34d-15e9081ee4d3




## Further comments
