### PR TITLE
[Bug] (데스크탑 버전) 친구 피드 > 노티 설정 메시지, 모달 zindex 정리 필요

### DIFF
--- a/src/components/comments/comment-bottom-sheet/CommentBottomSheet.styled.ts
+++ b/src/components/comments/comment-bottom-sheet/CommentBottomSheet.styled.ts
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import {
+  BOTTOMSHEET_FOOTER_HEIGHT,
   BOTTOMSHEET_HEADER_HEIGHT,
   DEFAULT_MARGIN,
   MAX_WINDOW_WIDTH,
@@ -22,7 +23,7 @@ export const CommentBottomHeaderWrapper = styled(Layout.Fixed)`
 
 export const CommentBottomContentWrapper = styled(Layout.FlexCol)`
   width: 100%;
-  height: ${SCREEN_HEIGHT - BOTTOMSHEET_HEADER_HEIGHT - 128}px;
+  height: ${SCREEN_HEIGHT - BOTTOMSHEET_HEADER_HEIGHT - BOTTOMSHEET_FOOTER_HEIGHT}px;
   padding: 15px 0;
   margin-top: ${BOTTOMSHEET_HEADER_HEIGHT}px;
   overflow: auto;
@@ -31,5 +32,7 @@ export const CommentBottomContentWrapper = styled(Layout.FlexCol)`
 export const CommentBottomFooterWrapper = styled(Layout.FlexCol)`
   position: fixed;
   width: 100%;
+  height: ${BOTTOMSHEET_FOOTER_HEIGHT - 24}px;
   bottom: 0;
+  z-index: ${Z_INDEX.BOTTOM_TAB};
 `;

--- a/src/constants/layout.ts
+++ b/src/constants/layout.ts
@@ -2,6 +2,7 @@ const MAX_WINDOW_WIDTH = 500;
 const BOTTOM_TABBAR_HEIGHT = 80;
 const TOP_NAVIGATION_HEIGHT = 44;
 const BOTTOMSHEET_HEADER_HEIGHT = 85;
+const BOTTOMSHEET_FOOTER_HEIGHT = 121;
 const DEFAULT_MARGIN = 16;
 const SCREEN_WIDTH = typeof window !== 'undefined' ? Math.min(window.innerWidth, 500) : 0;
 const SCREEN_HEIGHT = typeof window !== 'undefined' ? window.innerHeight : 0;
@@ -16,6 +17,7 @@ const Z_INDEX = {
 };
 
 export {
+  BOTTOMSHEET_FOOTER_HEIGHT,
   BOTTOMSHEET_HEADER_HEIGHT,
   BOTTOM_TABBAR_HEIGHT,
   DEFAULT_MARGIN,


### PR DESCRIPTION
## Issue Number: #688 

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?
- [x] 데스크탑, 모바일에서의 정상 작동을 확인했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## Testable backend branch name

## What does this PR do?
- 노티설정이 Bottom modal 보다 위에 보여지는 문제 해결
- Comment bottom sheet에서 Comment Item과 Comment bottom footer가 겹쳐보여지는 문제 해결

## Preview Image

Before

https://github.com/user-attachments/assets/279a4478-737c-4909-b44d-6f9504514413

<img width="423" alt="image" src="https://github.com/user-attachments/assets/e0214611-b4f4-460b-aaa8-3a90571c5ed4">

After

https://github.com/user-attachments/assets/698b942c-6a50-4224-877b-3198924a980a

<img width="499" alt="image" src="https://github.com/user-attachments/assets/df564c2b-79a1-4386-9d09-954db2b28167">



## Further comments
