### PR TITLE
[Bug] 답변 목록 페이지(my/responses, users/:username/responses)의 컨텐츠가 헤더/하단 탭에 가려집니다 

### DIFF
--- a/src/routes/responses/AllResponses.tsx
+++ b/src/routes/responses/AllResponses.tsx
@@ -54,12 +54,7 @@ function AllResponses() {
   return (
     <MainContainer>
       <SubHeader title={t('title', { username: username || myProfile?.username })} />
-      <Layout.FlexCol
-        w="100%"
-        mt={(username ? TITLE_HEADER_HEIGHT : 0) + TOP_MARGIN}
-        ph={16}
-        gap={12}
-      >
+      <Layout.FlexCol w="100%" mt={TITLE_HEADER_HEIGHT + TOP_MARGIN} ph={16} gap={12}>
         {responses.map((response) => (
           <ResponseItem
             key={response.id}


### PR DESCRIPTION
## Issue Number: #694 

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?
- [x] 데스크탑, 모바일에서의 정상 작동을 확인했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## Testable backend branch name

## What does this PR do?
- 답변목록이 헤더탭에 가려지던 문제 해결
- 기존에 username의 유무에 따라 margin top의 간격이 다르게 설정되어있었던걸로 확인되는데, 현재 디자인에서는 유저 본인이 본인의 답변목록 페이지를 들어가든 / 다른 유저의 답변목록 페이지를 들어가든 동일하게 위 상단탭에 유저네임이 적혀있는 것으로 확인됩니다.
- 이에 따라, username 유무에 따른 로직을 삭제하였는데, 제가 혹시 놓친 부분이 있다면 말씀해주세요!

## Preview Image


https://github.com/user-attachments/assets/dadc9110-450c-47e1-a52e-ea2ef06822a9



## Further comments
