### PR TITLE
(#735) 대댓글 작성 취소시 댓글 작성 대상 초기화

### DIFF
--- a/src/components/comment-list/comment-input-box/CommentInputBox.tsx
+++ b/src/components/comment-list/comment-input-box/CommentInputBox.tsx
@@ -136,6 +136,12 @@ function CommentInputBox({
     handleSubmitComment();
   };
 
+  const handleClickCloseReply = () => {
+    resetReplyTo?.();
+    resetCommentTo();
+    resetCommentType();
+  };
+
   const isVirtualKeyboardOpen = useIsVirtualKeyboardOpenInIOS();
 
   useEffect(() => {
@@ -185,7 +191,7 @@ function CommentInputBox({
                   username: commentTargetAuthor,
                 })}
               </Typo>
-              <SvgIcon name="close_comment" size={24} onClick={resetReplyTo} />
+              <SvgIcon name="close_comment" size={24} onClick={handleClickCloseReply} />
             </Layout.FlexRow>
           )}
           <S.CommentInput


### PR DESCRIPTION
## Issue Number: #735

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?
- [x] 데스크탑, 모바일에서의 정상 작동을 확인했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## Testable backend branch name
main

## What does this PR do?
- 대댓글 작성 취소시에 대댓글 여부만 취소되고 댓글 작성 대상은 여전히 대댓글의 댓글로 설정되어있음.
- 대댓글 작성 취소시에 댓글 작성 대상을 post로 복구하도록 수정.


## Preview Image

https://github.com/user-attachments/assets/4c1c2be6-8a25-42d7-9282-a04e66e00fb5


## Further comments
