### PR TITLE
(#713) 음악 선택 모달이 다 열린 이후에 input 창이 포커스되도록 수정

### DIFF
--- a/src/components/_common/bottom-modal/BottomModal.tsx
+++ b/src/components/_common/bottom-modal/BottomModal.tsx
@@ -7,6 +7,7 @@ import * as S from './BottomModal.styled';
 interface BottomModalProps {
   visible: boolean;
   onClose?: () => void;
+  onTransitionEnd?: () => void;
   children: React.ReactNode;
   bgColor?: string;
   containerBgColor?: ColorKeys;
@@ -17,6 +18,7 @@ interface BottomModalProps {
 function BottomModal({
   visible,
   onClose,
+  onTransitionEnd,
   children,
   bgColor = 'rgba(0, 0, 0, 0.7)',
   containerBgColor = 'WHITE',
@@ -51,6 +53,10 @@ function BottomModal({
   // NOTE: 모달 아래 클릭 영역이 있을 때 이벤트 전파 방지
   const onClickModal = (e: MouseEvent) => e.stopPropagation();
 
+  const handleTransitionEnd = () => {
+    onTransitionEnd?.();
+  };
+
   return (
     <>
       {visible && (
@@ -68,7 +74,12 @@ function BottomModal({
           )}
         </S.Background>
       )}
-      <S.Container visible={visible} height={height} bgColor={containerBgColor}>
+      <S.Container
+        visible={visible}
+        height={height}
+        bgColor={containerBgColor}
+        onTransitionEnd={handleTransitionEnd}
+      >
         <S.Body ref={bodyRef} onClick={onClickModal}>
           {children}
         </S.Body>

--- a/src/components/check-in/check-in-edit/music-search-bottom-sheet/MusicSearchBottomSheet.tsx
+++ b/src/components/check-in/check-in-edit/music-search-bottom-sheet/MusicSearchBottomSheet.tsx
@@ -54,9 +54,19 @@ function MusicSearchBottomSheet({
     setSelected(track.id);
   };
 
+  const [autoFocus, setAutoFocus] = useState(false);
+  const autoFocusInput = () => {
+    setAutoFocus(true);
+  };
+
   if (!trackList) return null;
   return (
-    <BottomModal visible={visible} onClose={closeBottomSheet} heightMode="full">
+    <BottomModal
+      visible={visible}
+      onClose={closeBottomSheet}
+      heightMode="full"
+      onTransitionEnd={autoFocusInput}
+    >
       <Layout.FlexCol alignItems="center" w="100%" bgColor="WHITE">
         <Icon name="home_indicator" />
         <Typo type="title-large">{t('title')}</Typo>
@@ -66,7 +76,7 @@ function MusicSearchBottomSheet({
             <SearchInput
               query={query}
               setQuery={setQuery}
-              autoFocus
+              autoFocus={autoFocus}
               fontSize={16}
               placeholder={t('search_placeholder') || undefined}
               cancelText={t('cancel') || undefined}


### PR DESCRIPTION
## Issue Number: #713

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?
- [x] 데스크탑, 모바일에서의 정상 작동을 확인했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## Testable backend branch name
main

## What does this PR do?
- 바텀 모달이 열릴때 transition으로 인해서 입력창 포커스시 가상 키보드가 열릴때 입력창이 가려지고 있음.
- transition이 끝난 후에 자동 포커스를 실행하도록 수정

## Preview Image

https://github.com/user-attachments/assets/0934014d-e951-4b23-91a9-92c35ec8960f



## Further comments
