### PR TITLE
bugfix: #561 노트이미지 크롭 > 사파리에서 여전히 스크롤되는 버그 수정

### DIFF
--- a/src/components/note/new-note-image-edit/NewNoteImageEdit.tsx
+++ b/src/components/note/new-note-image-edit/NewNoteImageEdit.tsx
@@ -68,7 +68,7 @@ function NewNoteImageEdit({ setIsVisible, imageUrl, onCompleteImageCrop }: NewNo
   };
 
   return (
-    <Layout.AbsoluteFullScreen bgColor="DARK">
+    <Layout.FixedFullScreen bgColor="DARK">
       {croppedImg ? (
         <>
           {/* 크롭 완료된 이미지 미리보기 */}
@@ -114,7 +114,7 @@ function NewNoteImageEdit({ setIsVisible, imageUrl, onCompleteImageCrop }: NewNo
           </>
         )
       )}
-    </Layout.AbsoluteFullScreen>
+    </Layout.FixedFullScreen>
   );
 }
 

--- a/src/design-system/layouts/Absolute.ts
+++ b/src/design-system/layouts/Absolute.ts
@@ -13,19 +13,15 @@ export const AbsoluteFill = styled.div<BgColor>`
   background-color: ${({ theme, bgColor }) => theme[bgColor || 'TRANSPARENT']};
 `;
 
-export const AbsoluteFullScreen = styled.div<BgColor & Flex>`
+export const FixedFullScreen = styled.div<BgColor & Flex>`
   width: ${SCREEN_WIDTH}px;
   height: 100%;
-  position: absolute;
-  left: 0;
-  right: 0;
-  top: 0;
-  bottom: 0;
+  position: fixed;
+  transform: translate(-50%);
+  left: 50%;
   background-color: ${({ theme, bgColor }) => theme[bgColor || 'TRANSPARENT']};
   align-items: ${({ alignItems }) => alignItems || 'flex-start'};
   justify-content: ${({ justifyContent }) => justifyContent || 'flex-start'};
-  -webkit-overflow-scrolling: touch;
-  overflow: hidden;
 `;
 
 type AbsoluteStyle = {


### PR DESCRIPTION
## Issue Number:#561

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?
- [x] 데스크탑, 모바일에서의 정상 작동을 확인했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## Testable backend branch name
`main`
## What does this PR do?
노트이미지 크롭 > 사파리에서 여전히 스크롤되는 버그 수정
> 스크롤이 되지 않게 `fixed`로 변경했습니다

## Preview Image

|as-is|to-be|
|-|-|
|![as-is](https://github.com/user-attachments/assets/69bde2be-1e4d-4daa-9c20-851dcdbd6fe0)|![to-be](https://github.com/user-attachments/assets/df6a77a7-f88e-45e3-aa32-98476fa75a56)|


## Further comments
