### PR TITLE
(#742) 개발자도구에서 styled-component displayName을 확인할 수 있도록 수정

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -17,4 +17,15 @@ module.exports = {
       '@libs': path.resolve(__dirname, 'src/libs'),
     },
   },
+  babel: {
+    plugins: [
+      [
+        'babel-plugin-styled-components',
+        {
+          fileName: false,
+          displayName: true,
+        },
+      ],
+    ],
+  },
 };

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@types/styled-components": "^5.1.26",
     "@typescript-eslint/eslint-plugin": "^5.59.2",
     "@typescript-eslint/parser": "^5.59.2",
+    "babel-plugin-styled-components": "^2.1.4",
     "eslint": "^8.44.0",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-prettier": "^8.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3661,7 +3661,7 @@ babel-plugin-polyfill-regenerator@^0.6.1:
   dependencies:
     "@babel/helper-define-polyfill-provider" "^0.6.2"
 
-"babel-plugin-styled-components@>= 1.12.0":
+"babel-plugin-styled-components@>= 1.12.0", babel-plugin-styled-components@^2.1.4:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-2.1.4.tgz#9a1f37c7f32ef927b4b008b529feb4a2c82b1092"
   integrity sha512-Xgp9g+A/cG47sUyRwwYxGM4bR/jDRg5N6it/8+HxCnbT5XNKSKDT9xm4oag/osgqjC2It/vH0yXsomOG6k558g==


### PR DESCRIPTION
## Issue Number: #742

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?
- [x] 데스크탑, 모바일에서의 정상 작동을 확인했나요?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## Testable backend branch name
main

## What does this PR do?
- 개발자도구에서 styled-component displayName을 확인할 수 있도록 plugin 추가

## Preview Image
<img width="1204" alt="스크린샷 2024-11-23 17 44 24" src="https://github.com/user-attachments/assets/785c7ceb-16ef-4b75-96ed-68958355874f">



## Further comments
