### PR TITLE
bugfix: #561 노트이미지 크롭 > '완료' 버튼이 보이지 않는 버그 수정

### DIFF
--- a/src/components/note/new-note-image-edit/NewNoteImageEdit.styled.ts
+++ b/src/components/note/new-note-image-edit/NewNoteImageEdit.styled.ts
@@ -1,5 +1,10 @@
 import styled from 'styled-components';
 import { BOTTOM_TABBAR_HEIGHT, TOP_NAVIGATION_HEIGHT } from '@constants/layout';
+import { Layout } from '@design-system';
+
+export const StyledNoteImageEditContainer = styled(Layout.FixedFullScreen)`
+  z-index: 200;
+`;
 
 export const StyledNewNoteImageWrapper = styled.div`
   width: 100%;

--- a/src/components/note/new-note-image-edit/NewNoteImageEdit.tsx
+++ b/src/components/note/new-note-image-edit/NewNoteImageEdit.tsx
@@ -3,11 +3,15 @@ import { useTranslation } from 'react-i18next';
 import ReactCrop, { centerCrop, PixelCrop } from 'react-image-crop';
 import SubHeader from '@components/sub-header/SubHeader';
 import { NOTE_IMAGE_CROP_MIN_SIZE } from '@constants/size';
-import { Layout, Typo } from '@design-system';
+import { Typo } from '@design-system';
 import { CroppedImg, getReactImageCrop } from '@utils/getCroppedImg';
 // NOTE: 이렇게 css 를 직접 로드하지 않으면 로드가 안됨... 확인 필요
 import 'react-image-crop/dist/ReactCrop.css';
-import { StyledNewNoteImage, StyledNewNoteImageWrapper } from './NewNoteImageEdit.styled';
+import {
+  StyledNewNoteImage,
+  StyledNewNoteImageWrapper,
+  StyledNoteImageEditContainer,
+} from './NewNoteImageEdit.styled';
 
 interface NewNoteImageEditProps {
   setIsVisible: (visible: boolean) => void;
@@ -68,7 +72,7 @@ function NewNoteImageEdit({ setIsVisible, imageUrl, onCompleteImageCrop }: NewNo
   };
 
   return (
-    <Layout.FixedFullScreen bgColor="DARK">
+    <StyledNoteImageEditContainer bgColor="DARK">
       {croppedImg ? (
         <>
           {/* 크롭 완료된 이미지 미리보기 */}
@@ -114,7 +118,7 @@ function NewNoteImageEdit({ setIsVisible, imageUrl, onCompleteImageCrop }: NewNo
           </>
         )
       )}
-    </Layout.FixedFullScreen>
+    </StyledNoteImageEditContainer>
   );
 }
 


### PR DESCRIPTION
## Issue Number: #561

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?
- [x] 데스크탑, 모바일에서의 정상 작동을 확인했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## Testable backend branch name
`main`
## What does this PR do?
https://github.com/GooJinSun/WhoAmI-Today-frontend/pull/745 의 사이드 이펙트로 노트이미지 크롭 > '완료' 버튼이 보이지 않는 버그 수정
> 호호.. 정신이 아득해져서 이런 실수를...

## Preview

https://github.com/user-attachments/assets/9346fcef-e9f7-4830-a706-ab2e289e088f

 Image

## Further comments
