### PR TITLE
(#764) 버전별 기능 플래그 상태 설정

### DIFF
--- a/src/constants/featureFlag.ts
+++ b/src/constants/featureFlag.ts
@@ -1,7 +1,9 @@
 import { VersionType } from '@models/api/user';
 
 export enum FeatureFlagKey {
+  /** 친구탭 페이지에서 친구 피드(친구들의 게시물을 최신순으로 노출)를 노출하는 플래그 */
   FRIEND_FEED = 'friendFeed',
+  /** 친구탭 페이지에서 전체 친구 목록을 노출하는 플래그 */
   FRIEND_LIST = 'friendList',
 }
 

--- a/src/constants/featureFlag.ts
+++ b/src/constants/featureFlag.ts
@@ -1,0 +1,25 @@
+import { VersionType } from '@models/api/user';
+
+export enum FeatureFlagKey {
+  FRIEND_FEED = 'friendFeed',
+  FRIEND_LIST = 'friendList',
+}
+
+export type FeatureFlagMap = { [feature in FeatureFlagKey]: boolean };
+export type FeatureFlagMapCollection = {
+  [version in VersionType]: FeatureFlagMap;
+};
+
+const DEFAULT_FLAGS = {
+  [FeatureFlagKey.FRIEND_FEED]: true,
+  [FeatureFlagKey.FRIEND_LIST]: false,
+};
+
+export const FEATURE_FLAG_MAP_COLLECTION: FeatureFlagMapCollection = {
+  [VersionType.DEFAULT]: { ...DEFAULT_FLAGS },
+  [VersionType.EXPERIMENT]: {
+    ...DEFAULT_FLAGS,
+    [FeatureFlagKey.FRIEND_FEED]: false,
+    [FeatureFlagKey.FRIEND_LIST]: true,
+  },
+};

--- a/src/models/api/user.ts
+++ b/src/models/api/user.ts
@@ -100,6 +100,11 @@ export type UsernameValidateErrorType =
 
 export type DayOfWeek = '0' | '1' | '2' | '3' | '4' | '5' | '6'; // 0 = Sunday, 1 = Monday, etc.
 
+export enum VersionType {
+  DEFAULT = 'default',
+  EXPERIMENT = 'experiment',
+}
+
 export interface MyProfile extends User {
   email: string;
   date_of_birth: string | null;
@@ -116,6 +121,7 @@ export interface MyProfile extends User {
   unread_noti: boolean;
   timezone?: string;
   check_in?: MyCheckIn;
+  current_ver: VersionType;
 }
 
 export interface FriendRequest {

--- a/src/routes/Root.tsx
+++ b/src/routes/Root.tsx
@@ -12,6 +12,8 @@ import { Layout } from '@design-system';
 import { usePostAppMessage } from '@hooks/useAppMessage';
 import useAsyncEffect from '@hooks/useAsyncEffect';
 import useFcm from '@hooks/useFcm';
+import { useBoundStore } from '@stores/useBoundStore';
+import { UserSelector } from '@stores/user';
 import { MainWrapper, RootContainer } from '@styles/wrappers';
 import { getMobileDeviceInfo } from '@utils/getUserAgent';
 
@@ -32,6 +34,12 @@ function Root() {
       value: document.cookie,
     });
   }, [postMessage]);
+
+  const { featureFlags } = useBoundStore(UserSelector);
+
+  useEffect(() => {
+    console.debug(`featureFlags`, featureFlags);
+  }, [featureFlags]);
 
   return (
     <SWRConfig value={{ provider: () => new Map() }}>

--- a/src/utils/apis/user.ts
+++ b/src/utils/apis/user.ts
@@ -58,6 +58,7 @@ export const checkIfSignIn = async () => {
     const user = await getMe();
     const currentTimezone = await syncTimeZone(user?.timezone);
     useBoundStore.getState().setMyProfile({ ...user, timezone: currentTimezone });
+    useBoundStore.getState().setFeatureFlags();
     return user;
   } catch {
     resetBoundStores();


### PR DESCRIPTION
## Issue Number: #764

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?
- [x] 데스크탑, 모바일에서의 정상 작동을 확인했나요?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## Testable backend branch name: main

## What does this PR do?
- 유저 프로필(/user/me/)에서 내려주는 현재 버전 정보를 이용해서 기능 플래그 상태를 설정.
  - 예시로 기능 플래그를 몇 개 추가해두었습니다. 본격적으로 분기하면서 추가해나가도록 하겠습니다~

## Preview Image

- 'default'
  <img width="1015" alt="스크린샷 2025-02-08 12 59 43" src="https://github.com/user-attachments/assets/ad67a55f-2a34-42f7-8260-47f9bab6846a" />

- 'experiment'

  <img width="990" alt="스크린샷 2025-02-08 13 15 23" src="https://github.com/user-attachments/assets/50879e8e-8172-4f87-8065-2039f15e2070" />


## Further comments
