### PR TITLE
(#817) 친구 프로필 섹션 깨지는 경우 대응

### DIFF
--- a/src/components/profile/Profile.tsx
+++ b/src/components/profile/Profile.tsx
@@ -55,19 +55,18 @@ function Profile({ user }: ProfileProps) {
   return (
     <Layout.FlexCol w="100%" gap={16}>
       <Layout.FlexRow w="100%" gap={8}>
-        <ProfileImage imageUrl={user?.profile_image} username={username} size={80} />
-        <Layout.FlexCol w="100%" gap={8}>
+        <Layout.FlexRow>
+          <ProfileImage imageUrl={user?.profile_image} username={username} size={80} />
+        </Layout.FlexRow>
+        <Layout.FlexCol gap={8} w="100%">
           <Layout.FlexRow w="100%" justifyContent="space-between" alignItems="center">
-            {/* username / pronouns */}
-            <Layout.FlexRow gap={8} alignItems="center">
-              <Typo type="title-large" ellipsis={{ enabled: true, maxWidth: 160 }}>
-                {isMyPage ? myProfile?.username || '' : username || ''}
-              </Typo>
-
-              <Typo type="label-medium">
-                {(isMyPage ? myProfile?.pronouns : friendData?.pronouns) &&
-                  `(${isMyPage ? myProfile?.pronouns : friendData?.pronouns})`}
-              </Typo>
+            <Layout.FlexRow w="100%" gap={8} alignItems="center">
+              <Layout.FlexRow alignItems="center" gap={4}>
+                {/* username */}
+                <Typo type="title-large" numberOfLines={1}>
+                  {isMyPage ? myProfile?.username || '' : username || ''}
+                </Typo>
+              </Layout.FlexRow>
               {/** connections */}
               {user && !isMyProfile(user) && areFriends(user) && (
                 <>
@@ -111,11 +110,23 @@ function Profile({ user }: ProfileProps) {
               />
             )}
           </Layout.FlexRow>
+          {/* pronouns */}
+          {(isMyPage ? myProfile?.pronouns : friendData?.pronouns) && (
+            <Layout.FlexRow alignItems="center">
+              <Typo type="label-medium">(</Typo>
+              <Typo type="label-medium" numberOfLines={1}>
+                {isMyPage ? myProfile?.pronouns : friendData?.pronouns}
+              </Typo>
+              <Typo type="label-medium">)</Typo>
+            </Layout.FlexRow>
+          )}
           {/* bio */}
           {user?.bio && (
-            <Typo type="body-medium" numberOfLines={3}>
-              {user.bio}
-            </Typo>
+            <Layout.FlexCol w="100%">
+              <Typo type="body-medium" numberOfLines={2}>
+                {user.bio}
+              </Typo>
+            </Layout.FlexCol>
           )}
         </Layout.FlexCol>
       </Layout.FlexRow>

--- a/src/design-system/Font/Font.styled.ts
+++ b/src/design-system/Font/Font.styled.ts
@@ -73,6 +73,7 @@ export const StyledFont = styled.span<FontAttrs & TypoPropBase>`
       overflow: hidden;
       display: -webkit-box;
       -webkit-box-orient: vertical;
+      word-break: break-word;
       max-height: ${fontSize * lineHeight * numberOfLines}px;
     `}
 


### PR DESCRIPTION
## Issue Number: #817

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?
- [x] 데스크탑, 모바일에서의 정상 작동을 확인했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## Testable backend branch name

main

## What does this PR do?

- 친구/내 페이지의 Profile 섹션 레이아웃 변경
- friend 라벨 버튼이 추가되면서 bio를 username 아래쪽으로 옮김
- 기타 pronouns, bio 가 길어졌을때 대응

## Preview Image

친구 페이지

![CleanShot 2025-03-02 at 01 55 59@2x](https://github.com/user-attachments/assets/8408f70c-f42e-43d7-9959-7663695d45e2)

내 페이지

![CleanShot 2025-03-02 at 01 57 14@2x](https://github.com/user-attachments/assets/de835143-c230-4ff3-b524-eff489f6bdb1)


## Further comments
