### PR TITLE
(#784) 친구 목록에서 new 플로팅 버튼이 맨 마지막 친구 가림

### DIFF
--- a/src/components/header/bottom-sheet/NewPostBottomSheet.tsx
+++ b/src/components/header/bottom-sheet/NewPostBottomSheet.tsx
@@ -43,7 +43,7 @@ function NewPostBottomSheet({ visible, closeBottomSheet, setSelectPrompt }: Prop
     <BottomModal visible={visible} onClose={closeBottomSheet}>
       <Layout.FlexCol alignItems="center" pb={34} w="100%" bgColor="WHITE">
         <Icon name="home_indicator" />
-        <Typo type="title-large">Create</Typo>
+        <Typo type="title-large">{t('title')}</Typo>
         <Layout.FlexCol gap={12} pt={24} pb={24} w="100%">
           {BOTTOM_SHEET_LIST.map((menu) => (
             <React.Fragment key={menu.key}>

--- a/src/components/header/floating-button/FloatingButton.styled.ts
+++ b/src/components/header/floating-button/FloatingButton.styled.ts
@@ -1,12 +1,14 @@
 import styled from 'styled-components';
 
+export const FLOATING_BUTTON_SIZE = 60;
+
 export const StyledFloatingButton = styled.button`
   position: absolute;
   z-index: 500;
   bottom: 100px;
   right: 20px;
-  width: 60px;
-  height: 60px;
+  width: ${FLOATING_BUTTON_SIZE}px;
+  height: ${FLOATING_BUTTON_SIZE}px;
   background-color: ${({ theme }) => theme.SECONDARY};
   border-radius: 50%;
   box-shadow: 0px 5px 10px 0px rgba(0, 0, 0, 0.2);

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -90,6 +90,7 @@
         "settings": "Settings"
       },
       "bottom_sheet": {
+        "title": "Create",
         "check-in": "Check-in",
         "note": "Note",
         "prompts": "Response to prompts"

--- a/src/i18n/locales/ko/translation.json
+++ b/src/i18n/locales/ko/translation.json
@@ -90,6 +90,7 @@
         "settings": "설정"
       },
       "bottom_sheet": {
+        "title": "만들기",
         "check-in": "체크인 수정",
         "note": "새 노트 작성",
         "prompts": "새 답변 작성"

--- a/src/routes/AllQuestions.tsx
+++ b/src/routes/AllQuestions.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import NoContents from '@components/_common/no-contents/NoContents';
 import PromptCard from '@components/_common/prompt/PromptCard';
+import { FLOATING_BUTTON_SIZE } from '@components/header/floating-button/FloatingButton.styled';
 import { DEFAULT_MARGIN } from '@constants/layout';
 import { Layout } from '@design-system';
 import { useRestoreScrollPosition } from '@hooks/useRestoreScrollPosition';
@@ -23,7 +24,7 @@ function AllQuestions() {
 
   return (
     <MainScrollContainer scrollRef={scrollRef}>
-      <Layout.FlexCol pv={14} w="100%" ph={DEFAULT_MARGIN} gap={20}>
+      <Layout.FlexCol pv={14} w="100%" ph={DEFAULT_MARGIN} gap={20} pb={FLOATING_BUTTON_SIZE + 20}>
         {isLoading ? (
           <AllQuestionsLoader />
         ) : questions?.[0] && questions[0].count > 0 ? (

--- a/src/routes/My.tsx
+++ b/src/routes/My.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import Divider from '@components/_common/divider/Divider';
 import Icon from '@components/_common/icon/Icon';
 import PullToRefresh from '@components/_common/pull-to-refresh/PullToRefresh';
+import { FLOATING_BUTTON_SIZE } from '@components/header/floating-button/FloatingButton.styled';
 import NoteSection from '@components/note/note-section/NoteSection';
 import Profile from '@components/profile/Profile';
 import ResponseSection from '@components/response/response-section/ResponseSection';
@@ -38,7 +39,7 @@ function My() {
   return (
     <MainScrollContainer scrollRef={scrollRef}>
       <PullToRefresh onRefresh={handleRefresh}>
-        <Layout.FlexCol w="100%">
+        <Layout.FlexCol w="100%" pb={FLOATING_BUTTON_SIZE + 20}>
           <Divider width={8} bgColor="LIGHT" />
           <Layout.FlexRow
             w="100%"

--- a/src/routes/friends/Friends.tsx
+++ b/src/routes/friends/Friends.tsx
@@ -8,6 +8,7 @@ import { SwipeLayoutList } from '@components/_common/swipe-layout/SwipeLayoutLis
 import FavoriteFriendItem from '@components/friends/favorite-friend-item/FavoriteFriendItem';
 import UpdatedFriendItem from '@components/friends/updated-friend-item/UpdatedFriendItem';
 import { StyledUpdatedFriendItem } from '@components/friends/updated-friend-item/UpdatedFriendItem.styled';
+import { FLOATING_BUTTON_SIZE } from '@components/header/floating-button/FloatingButton.styled';
 import { Button, Layout, SvgIcon, Typo } from '@design-system';
 import { useFetchFavoriteFriends } from '@hooks/useFetchFavoriteFriends';
 import { useRestoreScrollPosition } from '@hooks/useRestoreScrollPosition';
@@ -53,7 +54,7 @@ function Friends() {
   return (
     <MainScrollContainer scrollRef={scrollRef}>
       <PullToRefresh onRefresh={handleRefresh}>
-        <Layout.FlexCol w="100%">
+        <Layout.FlexCol w="100%" pb={FLOATING_BUTTON_SIZE + 20}>
           {/* Favorites */}
           <Collapse
             title={[t('favorites'), !!favoriteFriends && `(${favoriteFriends.length})`]


### PR DESCRIPTION
## Issue Number: #784

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?
- [x] 데스크탑, 모바일에서의 정상 작동을 확인했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## Testable backend branch name

## What does this PR do?

- Floating 버튼 사이즈만큼 padding bottom 추가 (친구, 마이, 질문 탭)
- NewPostBottomSheet translation 적용 안되어있던 부분 추가

## Preview Image

before

![CleanShot 2025-03-02 at 02 12 20@2x](https://github.com/user-attachments/assets/e0335a54-9450-4f26-bd23-5e356d60860a)

after

![CleanShot 2025-03-02 at 02 12 00@2x](https://github.com/user-attachments/assets/d6782a08-cbfa-4122-ace9-ff083159ff61)


## Further comments
