### PR TITLE
(#777) 데스크탑에서 Ping 페이지에서 알림설정 배너가 인풋창을 가리는 버그 수정

### DIFF
--- a/src/routes/Root.tsx
+++ b/src/routes/Root.tsx
@@ -60,11 +60,17 @@ interface MainScrollContainerProps {
   children?: ReactNode;
   scrollRef?: RefObject<HTMLDivElement>;
   onScroll?: (e: UIEvent) => void;
+  showNotificationPermission?: boolean;
 }
 
-export function MainScrollContainer({ children, scrollRef, onScroll }: MainScrollContainerProps) {
+export function MainScrollContainer({
+  children,
+  scrollRef,
+  onScroll,
+  showNotificationPermission = false,
+}: MainScrollContainerProps) {
   const { isMobile } = getMobileDeviceInfo();
-  const showNotificationPermission = !isMobile;
+  const showBanner = showNotificationPermission && !isMobile;
 
   return (
     <MainWrapper
@@ -72,13 +78,13 @@ export function MainScrollContainer({ children, scrollRef, onScroll }: MainScrol
       ref={scrollRef}
       alignItems="center"
       pt={TOP_NAVIGATION_HEIGHT}
-      pb={BOTTOM_TABBAR_HEIGHT + (showNotificationPermission ? NOTI_PERMISSION_BANNER_HEIGHT : 0)}
+      pb={BOTTOM_TABBAR_HEIGHT + (showBanner ? NOTI_PERMISSION_BANNER_HEIGHT : 0)}
       onScroll={onScroll}
     >
       {children}
       <Outlet />
       {/* 데스크톱 웹만 노출 */}
-      {showNotificationPermission && <NotiPermissionBanner />}
+      {showBanner && <NotiPermissionBanner />}
     </MainWrapper>
   );
 }

--- a/src/routes/friends/FriendsFeed.tsx
+++ b/src/routes/friends/FriendsFeed.tsx
@@ -39,7 +39,7 @@ function FriendsFeed() {
   });
 
   return (
-    <MainScrollContainer scrollRef={scrollRef}>
+    <MainScrollContainer scrollRef={scrollRef} showNotificationPermission>
       <PullToRefresh onRefresh={handleRefresh}>
         <Layout.FlexCol w="100%">
           {isLoading ? (

--- a/src/routes/friends/FriendsList.tsx
+++ b/src/routes/friends/FriendsList.tsx
@@ -51,7 +51,7 @@ function FriendsList() {
   const { scrollRef } = useRestoreScrollPosition('friendsPage');
 
   return (
-    <MainScrollContainer scrollRef={scrollRef}>
+    <MainScrollContainer scrollRef={scrollRef} showNotificationPermission>
       <PullToRefresh onRefresh={handleRefresh}>
         <Layout.FlexCol w="100%" pb={FLOATING_BUTTON_SIZE + 20}>
           {/* Favorites */}


### PR DESCRIPTION
## Issue Number: #777

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?
- [x] 데스크탑, 모바일에서의 정상 작동을 확인했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## Testable backend branch name

## What does this PR do?
- 데스크탑에서 Ping 페이지에서 알림설정 배너가 인풋창을 가리는 버그 수정
  - 친구피드, 친구목록에서만 해당 배너를 노출하도록 수정.

## Preview Image
- 수정전
  
  <img width="549" alt="스크린샷 2025-03-15 14 56 43" src="https://github.com/user-attachments/assets/4030885a-eb02-4f62-9bab-7bf62b4a647a" />

- 수정후

  <img width="548" alt="스크린샷 2025-03-15 14 56 15" src="https://github.com/user-attachments/assets/1f52936d-d17e-4446-859d-a69f668d5c61" />

## Further comments
