### PR TITLE
(#857) (#869) 메인탭 변경시 안읽은 노티 개수 갱신

### DIFF
--- a/src/components/header/common-header/CommonHeader.tsx
+++ b/src/components/header/common-header/CommonHeader.tsx
@@ -1,8 +1,9 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Icon from '@components/_common/icon/Icon';
 import IconNudge from '@components/_common/icon-nudge/IconNudge';
 import { Layout } from '@design-system';
 import { useBoundStore } from '@stores/useBoundStore';
+import { getMe } from '@utils/apis/my';
 import { Noti } from '../Header.styled';
 import MainHeader from '../MainHeader';
 import SideMenu from '../side-menu/SideMenu';
@@ -20,6 +21,11 @@ function CommonHeader({ title }: CommonHeaderProps) {
   const handleClickHamburger = () => {
     setShowSideMenu(true);
   };
+
+  // unread_noti_cnt 갱신을 위해 탭 변경시 getMe 실행
+  useEffect(() => {
+    getMe();
+  }, [title]);
 
   return (
     <>


### PR DESCRIPTION
## Issue Number: #857 #869

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?
- [x] 데스크탑, 모바일에서의 정상 작동을 확인했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## Testable backend branch name

## What does this PR do?
- 메인탭 변경시 안읽은 노티 개수 갱신

## Preview Image

- #857

  https://github.com/user-attachments/assets/4242f42b-a1c4-4a63-91c1-0f6b6ef28b47

- #869 

  https://github.com/user-attachments/assets/710104ad-42c8-4dff-8e91-7040fd4d5bbf


## Further comments


