### PR TITLE
(#906) 유저페이지에서 친구인 경우에만 Ping 페이지 이동 버튼 노출하도록 수정

### DIFF
--- a/src/components/header/user-header/UserHeader.tsx
+++ b/src/components/header/user-header/UserHeader.tsx
@@ -1,6 +1,8 @@
+import { useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Icon from '@components/_common/icon/Icon';
 import SubHeader from '@components/sub-header/SubHeader';
+import { UserPageContext } from '@components/user-page/UserPage.context';
 import { Layout } from '@design-system';
 
 interface UserHeaderProps {
@@ -11,6 +13,8 @@ interface UserHeaderProps {
 
 function UserHeader({ username, userId, onClickMore }: UserHeaderProps) {
   const navigate = useNavigate();
+  const { user } = useContext(UserPageContext);
+  const areFriends = user?.data?.are_friends === true;
 
   const handleClickPing = async () => {
     if (!userId) return;
@@ -28,7 +32,7 @@ function UserHeader({ username, userId, onClickMore }: UserHeaderProps) {
       RightComponent={
         <Layout.FlexRow gap={8} alignItems="center">
           <Icon name="dots_menu" size={44} onClick={handleClickMore} />
-          <Icon name="ping_send" size={24} onClick={handleClickPing} padding={2} />
+          {areFriends && <Icon name="ping_send" size={24} onClick={handleClickPing} padding={2} />}
         </Layout.FlexRow>
       }
     />


### PR DESCRIPTION
## Issue Number: #906 

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?
- [x] 데스크탑, 모바일에서의 정상 작동을 확인했나요?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## Testable backend branch name

## What does this PR do?
- 유저페이지에서 친구인 경우에만 유저페이지 헤더에서 Ping 페이지 이동 버튼 노출하도록 수정

## Preview Image
| 친구인 경우 헤더에 Ping 메시지 버튼 노출 | 친구가 아닌 경우 헤더에 Ping 메시지 버튼 미노출 |
| -- | -- |
| <img width="381" alt="스크린샷 2025-03-22 17 56 21" src="https://github.com/user-attachments/assets/eb63f3f8-1074-43ff-a58c-11061328e844" /> | <img width="378" alt="스크린샷 2025-03-22 17 56 14" src="https://github.com/user-attachments/assets/100fd253-c3cb-455b-be67-9a85d81b181c" /> | 

## Further comments
