### PR TITLE
[New Feature] pull-to-refresh시 댓글 개수가 업데이트 되지 않는다고 합니다

### DIFF
--- a/src/routes/My.tsx
+++ b/src/routes/My.tsx
@@ -1,4 +1,5 @@
 import { useCallback } from 'react';
+import { mutate } from 'swr';
 import Divider from '@components/_common/divider/Divider';
 import PullToRefresh from '@components/_common/pull-to-refresh/PullToRefresh';
 import { FLOATING_BUTTON_SIZE } from '@components/header/floating-button/FloatingButton.styled';
@@ -9,7 +10,7 @@ import { Layout } from '@design-system';
 import { useRestoreScrollPosition } from '@hooks/useRestoreScrollPosition';
 import { useBoundStore } from '@stores/useBoundStore';
 import { UserSelector } from '@stores/user';
-import { getMe, getMyNotes, getMyResponses } from '@utils/apis/my';
+import { getMe } from '@utils/apis/my';
 import { MainScrollContainer } from './Root';
 
 function My() {
@@ -21,7 +22,12 @@ function My() {
   const { featureFlags } = useBoundStore(UserSelector);
 
   const handleRefresh = useCallback(async () => {
-    await Promise.all([getMyResponses(null), getMyNotes(null), fetchCheckIn(), getMe()]);
+    await Promise.all([
+      mutate('/user/me/responses/'),
+      mutate('/user/me/notes/'),
+      fetchCheckIn(),
+      getMe(),
+    ]);
   }, [fetchCheckIn]);
 
   const { scrollRef } = useRestoreScrollPosition('myPage');

--- a/src/routes/UserPage.tsx
+++ b/src/routes/UserPage.tsx
@@ -77,22 +77,22 @@ function UserPage() {
         userId={userId}
         unreadCount={unreadCount}
       />
-      <PullToRefresh onRefresh={handleRefresh}>
-        <div
-          id={MAIN_SCROLL_CONTAINER_ID}
-          ref={scrollRef}
-          style={{
-            height: `calc(100vh - ${TITLE_HEADER_HEIGHT}px - ${BOTTOM_TABBAR_HEIGHT}px)`,
-            overflowY: 'auto',
-            WebkitOverflowScrolling: 'touch',
-            msOverflowStyle: 'none',
-            scrollbarWidth: 'none',
-            width: '100%',
-            marginTop: `${TITLE_HEADER_HEIGHT}px`,
-            paddingBottom: '24px', // 하단 여유 공간 추가
-            position: 'relative',
-          }}
-        >
+      <div
+        id={MAIN_SCROLL_CONTAINER_ID}
+        ref={scrollRef}
+        style={{
+          height: `calc(100vh - ${TITLE_HEADER_HEIGHT}px - ${BOTTOM_TABBAR_HEIGHT}px)`,
+          overflowY: 'auto',
+          WebkitOverflowScrolling: 'touch',
+          msOverflowStyle: 'none',
+          scrollbarWidth: 'none',
+          width: '100%',
+          marginTop: `${TITLE_HEADER_HEIGHT}px`,
+          paddingBottom: '24px', // 하단 여유 공간 추가
+          position: 'relative',
+        }}
+      >
+        <PullToRefresh onRefresh={handleRefresh}>
           <Layout.FlexCol w="100%" bgColor="LIGHT">
             {user.state === 'hasError' && <CommonError />}
             {user.state === 'hasValue' && user.data && (
@@ -133,8 +133,8 @@ function UserPage() {
               </>
             )}
           </Layout.FlexCol>
-        </div>
-      </PullToRefresh>
+        </PullToRefresh>
+      </div>
     </MainContainer>
   );
 }

--- a/src/routes/UserPage.tsx
+++ b/src/routes/UserPage.tsx
@@ -42,7 +42,7 @@ function UserPage() {
   const outlet = useOutlet();
 
   useEffect(() => {
-    if (!isMyPage) {
+    if (isMyPage) {
       navigate('/my');
     }
   }, [isMyPage, navigate]);

--- a/src/routes/UserPage.tsx
+++ b/src/routes/UserPage.tsx
@@ -1,8 +1,10 @@
-import { useContext, useEffect, useRef, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import { useNavigate, useOutlet, useParams } from 'react-router-dom';
+import { mutate } from 'swr';
 import CommonError from '@components/_common/common-error/CommonError';
 import { Divider } from '@components/_common/divider/Divider.styled';
 import MainContainer from '@components/_common/main-container/MainContainer';
+import PullToRefresh from '@components/_common/pull-to-refresh/PullToRefresh';
 import UserHeader from '@components/header/user-header/UserHeader';
 import NoteSection from '@components/note/note-section/NoteSection';
 import Profile from '@components/profile/Profile';
@@ -13,6 +15,7 @@ import { BOTTOM_TABBAR_HEIGHT, TITLE_HEADER_HEIGHT } from '@constants/layout';
 import { MAIN_SCROLL_CONTAINER_ID } from '@constants/scroll';
 import { Layout } from '@design-system';
 import useAsyncEffect from '@hooks/useAsyncEffect';
+import { useRestoreScrollPosition } from '@hooks/useRestoreScrollPosition';
 import { useBoundStore } from '@stores/useBoundStore';
 import { UserSelector } from '@stores/user';
 import { readFriendCheckIn } from '@utils/apis/checkIn';
@@ -24,7 +27,6 @@ function UserPage() {
   const [showMore, setShowMore] = useState(false);
   const navigate = useNavigate();
   const { featureFlags } = useBoundStore(UserSelector);
-  const containerRef = useRef<HTMLDivElement>(null);
 
   const { user, updateUser } = useContext(UserPageContext);
   const userId = user.data?.id;
@@ -37,16 +39,30 @@ function UserPage() {
 
   useAsyncEffect(readCheckIn, [user.data]);
 
+  const outlet = useOutlet();
+
   useEffect(() => {
-    if (!isMyPage) return;
-    return navigate('/my');
+    if (!isMyPage) {
+      navigate('/my');
+    }
   }, [isMyPage, navigate]);
 
   const handleClickMore = () => {
     setShowMore(true);
   };
 
-  const outlet = useOutlet();
+  const { scrollRef } = useRestoreScrollPosition('friendsPage');
+
+  const handleRefresh = async () => {
+    if (!username) return;
+
+    const encodedUsername = encodeURIComponent(username);
+
+    await Promise.all([
+      mutate(`/user/${encodedUsername}/responses/`),
+      mutate(`/user/${encodedUsername}/notes/`),
+    ]);
+  };
 
   // outlet이 있으면 outlet만 렌더링
   if (outlet) {
@@ -61,62 +77,64 @@ function UserPage() {
         userId={userId}
         unreadCount={unreadCount}
       />
-      <div
-        id={MAIN_SCROLL_CONTAINER_ID}
-        style={{
-          height: `calc(100vh - ${TITLE_HEADER_HEIGHT}px - ${BOTTOM_TABBAR_HEIGHT}px)`,
-          overflowY: 'auto',
-          WebkitOverflowScrolling: 'touch',
-          msOverflowStyle: 'none',
-          scrollbarWidth: 'none',
-          width: '100%',
-          marginTop: `${TITLE_HEADER_HEIGHT}px`,
-          paddingBottom: '24px', // 하단 여유 공간 추가
-          position: 'relative',
-        }}
-        ref={containerRef}
-      >
-        <Layout.FlexCol w="100%" bgColor="LIGHT">
-          {user.state === 'hasError' && <CommonError />}
-          {user.state === 'hasValue' && user.data && (
-            <UserMoreModal
-              isVisible={showMore}
-              setIsVisible={setShowMore}
-              user={user.data}
-              callback={updateUser}
-            />
-          )}
-          {(user.state === 'loading' || user.state === 'hasValue') && (
-            <>
-              {/** profile section */}
-              <Layout.FlexRow
-                w="100%"
-                alignItems="center"
-                justifyContent="space-between"
-                p={12}
-                bgColor="WHITE"
-                rounded={8}
-              >
-                <Profile user={user.data} />
-              </Layout.FlexRow>
-              {featureFlags?.friendList && (
-                <>
-                  {/** responses and notes section */}
-                  <Divider width={8} bgColor="LIGHT" />
-                  <Layout.FlexCol pv={12} pl={12} w="100%" bgColor="WHITE" rounded={8}>
-                    <ResponseSection username={username} />
-                  </Layout.FlexCol>
-                </>
-              )}
+      <PullToRefresh onRefresh={handleRefresh}>
+        <div
+          id={MAIN_SCROLL_CONTAINER_ID}
+          ref={scrollRef}
+          style={{
+            height: `calc(100vh - ${TITLE_HEADER_HEIGHT}px - ${BOTTOM_TABBAR_HEIGHT}px)`,
+            overflowY: 'auto',
+            WebkitOverflowScrolling: 'touch',
+            msOverflowStyle: 'none',
+            scrollbarWidth: 'none',
+            width: '100%',
+            marginTop: `${TITLE_HEADER_HEIGHT}px`,
+            paddingBottom: '24px', // 하단 여유 공간 추가
+            position: 'relative',
+          }}
+        >
+          <Layout.FlexCol w="100%" bgColor="LIGHT">
+            {user.state === 'hasError' && <CommonError />}
+            {user.state === 'hasValue' && user.data && (
+              <UserMoreModal
+                isVisible={showMore}
+                setIsVisible={setShowMore}
+                user={user.data}
+                callback={updateUser}
+              />
+            )}
+            {(user.state === 'loading' || user.state === 'hasValue') && (
+              <>
+                {/** profile section */}
+                <Layout.FlexRow
+                  w="100%"
+                  alignItems="center"
+                  justifyContent="space-between"
+                  p={12}
+                  bgColor="WHITE"
+                  rounded={8}
+                >
+                  <Profile user={user.data} />
+                </Layout.FlexRow>
+                {featureFlags?.friendList && (
+                  <>
+                    {/** responses and notes section */}
+                    <Divider width={8} bgColor="LIGHT" />
+                    <Layout.FlexCol pv={12} pl={12} w="100%" bgColor="WHITE" rounded={8}>
+                      <ResponseSection username={username} />
+                    </Layout.FlexCol>
+                  </>
+                )}
 
-              <Divider width={8} bgColor="LIGHT" />
-              <Layout.FlexCol pt={8} pl={12} pb="default" w="100%" bgColor="WHITE" rounded={8}>
-                <NoteSection username={username} />
-              </Layout.FlexCol>
-            </>
-          )}
-        </Layout.FlexCol>
-      </div>
+                <Divider width={8} bgColor="LIGHT" />
+                <Layout.FlexCol pt={8} pl={12} pb="default" w="100%" bgColor="WHITE" rounded={8}>
+                  <NoteSection username={username} />
+                </Layout.FlexCol>
+              </>
+            )}
+          </Layout.FlexCol>
+        </div>
+      </PullToRefresh>
     </MainContainer>
   );
 }

--- a/src/routes/friends/FriendsFeed.tsx
+++ b/src/routes/friends/FriendsFeed.tsx
@@ -10,7 +10,6 @@ import { useRestoreScrollPosition } from '@hooks/useRestoreScrollPosition';
 import { useSWRInfiniteScroll } from '@hooks/useSWRInfiniteScroll';
 import { Note } from '@models/post';
 import { useBoundStore } from '@stores/useBoundStore';
-import { getAllFeed } from '@utils/apis/feed';
 import { getMe } from '@utils/apis/my';
 import { MainScrollContainer } from 'src/routes/Root';
 
@@ -24,10 +23,6 @@ function FriendsFeed() {
     fetchCheckIn: state.fetchCheckIn,
   }));
 
-  const handleRefresh = useCallback(async () => {
-    await Promise.all([getAllFeed(null), fetchCheckIn(), getMe()]);
-  }, [fetchCheckIn]);
-
   const {
     targetRef,
     data: notes,
@@ -37,6 +32,10 @@ function FriendsFeed() {
   } = useSWRInfiniteScroll<Note>({
     key: `/user/feed/`,
   });
+
+  const handleRefresh = useCallback(async () => {
+    await Promise.all([refetchFeed(), fetchCheckIn(), getMe()]);
+  }, [refetchFeed, fetchCheckIn]);
 
   return (
     <MainScrollContainer scrollRef={scrollRef} showNotificationPermission>


### PR DESCRIPTION
## Issue Number: #962 

## Self Check List

- [ ] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [ ] base branch로부터 rebase를 했나요?
- [ ] 데스크탑, 모바일에서의 정상 작동을 확인했나요?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## Testable backend branch name

## What does this PR do?
- 기존의 Pull-to-refresh시 작동하는 Refresh function 수정 (Ver R/Q의 MyPage, verR의 FriendFeed)
 : 기존에 getNotes(null), getResponses(null)을 통해 데이터를 가져오는 것이 컴포넌트 연결된 상태 (SWR캐시)에 반영되지 않아서 UI가 업데이트 되지 않는 문제를 해결

- VerR/Q의 친구페이지에서도 pull to refresh가 작동하도록 구현 추가

## Preview Image

https://github.com/user-attachments/assets/c6463dd0-7c57-45c0-8ec5-f0fe5fef7c53



## Further comments
- 계정 여러개로 테스팅 필요 (실시간으로 UserA의 커멘트 개수 / 좋아요 개수 등이 업데이트 되었을 시 UserB의 계정에서 pull-to-refresh시에 해당 업데이트가 반영되는지 확인 필요)
