### PR TITLE
(#1063) (ver. Q) 답변 목록에서 이모지 피커가 잘려서 노출되는 버그 수정

### DIFF
--- a/src/components/_common/post-footer/PostFooter.tsx
+++ b/src/components/_common/post-footer/PostFooter.tsx
@@ -4,8 +4,8 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import EmojiPicker from '@components/emoji-picker/EmojiPicker';
 import {
-  getEmojiPickerDirection,
   getEmojiPickerHeight,
+  getEmojiPickerPosition,
 } from '@components/emoji-picker/EmojiPicker.helper';
 import { Layout, Typo } from '@design-system';
 import { Note, POST_DP_TYPE, POST_TYPE, ReactionUserSample, Response } from '@models/post';
@@ -122,10 +122,13 @@ function PostFooter({
   const handleClickEmojiButton = () => {
     const isCurrentlyActive =
       emojiPickerTarget?.type === post.type && emojiPickerTarget?.id === post.id;
-    const pickerDirection = getEmojiPickerDirection(toggleButtonRef.current, emojiPickerHeight);
+
+    if (!toggleButtonRef.current) return;
+
+    const pickerPosition = getEmojiPickerPosition(toggleButtonRef.current, emojiPickerHeight);
 
     setEmojiPickerTarget(
-      isCurrentlyActive ? null : { type: post.type, id: post.id, direction: pickerDirection },
+      isCurrentlyActive ? null : { type: post.type, id: post.id, ...pickerPosition },
     );
   };
 
@@ -180,12 +183,16 @@ function PostFooter({
         </Layout.FlexRow>
       )}
       <EmojiPicker
+        createPortalId={
+          displayType === 'LIST' && post.type === 'Response'
+            ? 'response_section_emoji_picker'
+            : undefined
+        }
         selectedEmojis={myEmojiList}
         onSelectEmoji={handleSelectEmoji}
         onUnselectEmoji={handleUnselectEmoji}
         height={emojiPickerHeight}
         left={displayType === 'DETAIL' ? -10 : undefined}
-        top={(toggleButtonRef?.current?.getBoundingClientRect()?.height ?? 0) + 6}
         post={post}
       />
     </Layout.FlexCol>

--- a/src/components/_common/post-footer/PostFooter.tsx
+++ b/src/components/_common/post-footer/PostFooter.tsx
@@ -7,6 +7,7 @@ import {
   getEmojiPickerHeight,
   getEmojiPickerPosition,
 } from '@components/emoji-picker/EmojiPicker.helper';
+import { BOTTOM_TABBAR_HEIGHT } from '@constants/layout';
 import { Layout, Typo } from '@design-system';
 import { Note, POST_DP_TYPE, POST_TYPE, ReactionUserSample, Response } from '@models/post';
 import { useBoundStore } from '@stores/useBoundStore';
@@ -125,7 +126,12 @@ function PostFooter({
 
     if (!toggleButtonRef.current) return;
 
-    const pickerPosition = getEmojiPickerPosition(toggleButtonRef.current, emojiPickerHeight);
+    const pickerPosition = getEmojiPickerPosition({
+      targetEl: toggleButtonRef.current,
+      pickerHeight: emojiPickerHeight,
+      bottomAreaHeight:
+        displayType === 'DETAIL' ? BOTTOM_TABBAR_HEIGHT + 100 : BOTTOM_TABBAR_HEIGHT,
+    });
 
     setEmojiPickerTarget(
       isCurrentlyActive ? null : { type: post.type, id: post.id, ...pickerPosition },

--- a/src/components/check-in/check-in-edit/check-in-emoji/CheckInEmoji.tsx
+++ b/src/components/check-in/check-in-edit/check-in-emoji/CheckInEmoji.tsx
@@ -27,7 +27,7 @@ function CheckInEmoji({ mood, onDelete, onSelectEmoji }: CheckInEmojiProps) {
     }
 
     if (!toggleButtonRef.current) return;
-    const pickerPosition = getEmojiPickerPosition(toggleButtonRef.current);
+    const pickerPosition = getEmojiPickerPosition({ targetEl: toggleButtonRef.current });
     setEmojiPickerTarget({ type: 'CheckIn', id: null, ...pickerPosition });
   };
 

--- a/src/components/check-in/check-in-edit/check-in-emoji/CheckInEmoji.tsx
+++ b/src/components/check-in/check-in-edit/check-in-emoji/CheckInEmoji.tsx
@@ -4,7 +4,7 @@ import DeleteButton from '@components/_common/delete-button/DeleteButton';
 import EmojiItem from '@components/_common/emoji-item/EmojiItem';
 import Icon from '@components/_common/icon/Icon';
 import EmojiPicker from '@components/emoji-picker/EmojiPicker';
-import { getEmojiPickerDirection } from '@components/emoji-picker/EmojiPicker.helper';
+import { getEmojiPickerPosition } from '@components/emoji-picker/EmojiPicker.helper';
 import { Layout } from '@design-system';
 import { useBoundStore } from '@stores/useBoundStore';
 
@@ -26,8 +26,9 @@ function CheckInEmoji({ mood, onDelete, onSelectEmoji }: CheckInEmojiProps) {
       return setEmojiPickerTarget(null);
     }
 
-    const pickerDirection = getEmojiPickerDirection(toggleButtonRef.current);
-    setEmojiPickerTarget({ type: 'CheckIn', id: null, direction: pickerDirection });
+    if (!toggleButtonRef.current) return;
+    const pickerPosition = getEmojiPickerPosition(toggleButtonRef.current);
+    setEmojiPickerTarget({ type: 'CheckIn', id: null, ...pickerPosition });
   };
 
   const handleSelectEmoji = (e: EmojiClickData) => {
@@ -45,6 +46,7 @@ function CheckInEmoji({ mood, onDelete, onSelectEmoji }: CheckInEmojiProps) {
     <Layout.FlexCol w="100%">
       <Layout.FlexRow gap={8} mt={8} alignItems="center">
         <Layout.FlexRow
+          ref={toggleButtonRef}
           alignItems="center"
           justifyContent="center"
           rounded={12}
@@ -65,10 +67,7 @@ function CheckInEmoji({ mood, onDelete, onSelectEmoji }: CheckInEmojiProps) {
         {mood && <DeleteButton onClick={onDelete} size={32} />}
       </Layout.FlexRow>
       {/* emoji toggle popup */}
-      <EmojiPicker
-        onSelectEmoji={handleSelectEmoji}
-        top={(toggleButtonRef.current?.getBoundingClientRect().height ?? 0) + 12}
-      />
+      <EmojiPicker onSelectEmoji={handleSelectEmoji} />
     </Layout.FlexCol>
   );
 }

--- a/src/components/emoji-picker/EmojiPicker.helper.ts
+++ b/src/components/emoji-picker/EmojiPicker.helper.ts
@@ -1,16 +1,15 @@
 import { BOTTOM_TABBAR_HEIGHT, EMOJI_PICKER_HEIGHT } from '@constants/layout';
 import { EmojiPickerTarget } from '@stores/emojiPicker';
 
-export function getEmojiPickerDirection(
-  targetEl: HTMLDivElement | null | undefined,
+export function getEmojiPickerPosition(
+  targetEl: HTMLDivElement,
   pickerHeight = EMOJI_PICKER_HEIGHT.DEFAULT,
-): EmojiPickerTarget['direction'] {
-  if (!targetEl) return 'bottom';
+): Pick<EmojiPickerTarget, 'top'> {
   const { top, height } = targetEl.getBoundingClientRect();
   const bottomMargin = window.innerHeight - top - height - BOTTOM_TABBAR_HEIGHT;
 
-  if (pickerHeight > bottomMargin) return 'top';
-  return 'bottom';
+  if (pickerHeight > bottomMargin) return { top: targetEl.offsetTop - pickerHeight - 10 };
+  return { top: targetEl.offsetTop + height + 10 };
 }
 
 export function getEmojiPickerHeight(useDefaultHeight = true): number {

--- a/src/components/emoji-picker/EmojiPicker.helper.ts
+++ b/src/components/emoji-picker/EmojiPicker.helper.ts
@@ -1,12 +1,17 @@
 import { BOTTOM_TABBAR_HEIGHT, EMOJI_PICKER_HEIGHT } from '@constants/layout';
 import { EmojiPickerTarget } from '@stores/emojiPicker';
 
-export function getEmojiPickerPosition(
-  targetEl: HTMLDivElement,
+export function getEmojiPickerPosition({
+  targetEl,
   pickerHeight = EMOJI_PICKER_HEIGHT.DEFAULT,
-): Pick<EmojiPickerTarget, 'top'> {
+  bottomAreaHeight = BOTTOM_TABBAR_HEIGHT,
+}: {
+  targetEl: HTMLDivElement;
+  pickerHeight?: number;
+  bottomAreaHeight?: number;
+}): Pick<EmojiPickerTarget, 'top'> {
   const { top, height } = targetEl.getBoundingClientRect();
-  const bottomMargin = window.innerHeight - top - height - BOTTOM_TABBAR_HEIGHT;
+  const bottomMargin = window.innerHeight - top - height - bottomAreaHeight;
 
   if (pickerHeight > bottomMargin) return { top: targetEl.offsetTop - pickerHeight - 10 };
   return { top: targetEl.offsetTop + height + 10 };

--- a/src/components/emoji-picker/EmojiPicker.tsx
+++ b/src/components/emoji-picker/EmojiPicker.tsx
@@ -57,11 +57,6 @@ function EmojiPicker({
     enabled: !!(emojiPickerTarget && emojiPickerTarget.type === 'CheckIn'),
   });
 
-  const element = useMemo(
-    () => (createPortalId ? document.getElementById(createPortalId) : null),
-    [createPortalId],
-  );
-
   const content = useMemo(() => {
     const isVisible =
       emojiPickerTarget &&
@@ -103,6 +98,8 @@ function EmojiPicker({
     post?.type,
     selectedEmojis,
   ]);
+
+  const element = createPortalId ? document.getElementById(createPortalId) : null;
 
   if (createPortalId && element) {
     return createPortal(content, element);

--- a/src/components/emoji-picker/EmojiPicker.tsx
+++ b/src/components/emoji-picker/EmojiPicker.tsx
@@ -1,4 +1,6 @@
 import ReactEmojiPicker, { EmojiClickData } from 'emoji-picker-react';
+import { useCallback, useMemo } from 'react';
+import { createPortal } from 'react-dom';
 import { DEFAULT_MARGIN, EMOJI_PICKER_HEIGHT, Z_INDEX } from '@constants/layout';
 import { Layout } from '@design-system';
 import { useDetectOutsideClick } from '@hooks/useDetectOutsideClick';
@@ -14,8 +16,8 @@ interface EmojiPickerProps {
   selectedEmojis?: string[];
   height?: number;
   left?: number;
-  top?: number;
   post?: Response | Note;
+  createPortalId?: string;
 }
 
 function EmojiPicker({
@@ -23,29 +25,30 @@ function EmojiPicker({
   selectedEmojis,
   height = EMOJI_PICKER_HEIGHT.DEFAULT,
   left = DEFAULT_MARGIN,
-  top,
   onUnselectEmoji,
   post,
+  createPortalId,
 }: EmojiPickerProps) {
   const { emojiPickerTarget, setEmojiPickerTarget } = useBoundStore((state) => ({
     emojiPickerTarget: state.emojiPickerTarget,
     setEmojiPickerTarget: state.setEmojiPickerTarget,
   }));
 
-  const unifiedEmojiList = selectedEmojis?.map((e) => getUnifiedEmoji(e)) || [];
+  const handleSelectEmoji = useCallback(
+    (emoji: EmojiClickData, e: MouseEvent) => {
+      e.stopPropagation();
 
-  const handleSelectEmoji = (emoji: EmojiClickData, e: MouseEvent) => {
-    e.stopPropagation();
+      const isAlreadySelected = selectedEmojis?.includes(emoji.emoji);
+      if (!isAlreadySelected) {
+        onSelectEmoji(emoji);
+      } else {
+        onUnselectEmoji?.(emoji);
+      }
 
-    const isAlreadySelected = selectedEmojis?.includes(emoji.emoji);
-    if (!isAlreadySelected) {
-      onSelectEmoji(emoji);
-    } else {
-      onUnselectEmoji?.(emoji);
-    }
-
-    setEmojiPickerTarget(null);
-  };
+      setEmojiPickerTarget(null);
+    },
+    [onSelectEmoji, onUnselectEmoji, selectedEmojis, setEmojiPickerTarget],
+  );
 
   const emojiPickerWrapper = useDetectOutsideClick({
     callback: () => {
@@ -54,33 +57,56 @@ function EmojiPicker({
     enabled: !!(emojiPickerTarget && emojiPickerTarget.type === 'CheckIn'),
   });
 
-  const isVisible =
-    emojiPickerTarget &&
-    (emojiPickerTarget.type === 'CheckIn' ||
-      (emojiPickerTarget.type === post?.type && emojiPickerTarget.id === post?.id));
-
-  if (!isVisible) return null;
-
-  return (
-    <Layout.Absolute
-      ref={emojiPickerWrapper}
-      l={left}
-      mt={emojiPickerTarget.direction === 'top' ? -height : top ?? 0}
-      z={Z_INDEX.EMOJI_PICKER}
-    >
-      {selectedEmojis && <EmojiPickerCustomStyle unifiedList={unifiedEmojiList} />}
-      <ReactEmojiPicker
-        height={height}
-        onEmojiClick={handleSelectEmoji}
-        autoFocusSearch={false}
-        searchDisabled
-        previewConfig={{
-          showPreview: false,
-        }}
-        categories={EMOJI_CATEGORIES}
-        lazyLoadEmojis
-      />
-    </Layout.Absolute>
+  const element = useMemo(
+    () => (createPortalId ? document.getElementById(createPortalId) : null),
+    [createPortalId],
   );
+
+  const content = useMemo(() => {
+    const isVisible =
+      emojiPickerTarget &&
+      (emojiPickerTarget.type === 'CheckIn' ||
+        (emojiPickerTarget.type === post?.type && emojiPickerTarget.id === post?.id));
+
+    if (!isVisible) return null;
+
+    const unifiedEmojiList = selectedEmojis?.map((e) => getUnifiedEmoji(e)) || [];
+
+    return (
+      <Layout.Absolute
+        ref={emojiPickerWrapper}
+        l={left}
+        t={emojiPickerTarget.top}
+        z={Z_INDEX.EMOJI_PICKER}
+      >
+        {selectedEmojis && <EmojiPickerCustomStyle unifiedList={unifiedEmojiList} />}
+        <ReactEmojiPicker
+          height={height}
+          onEmojiClick={handleSelectEmoji}
+          autoFocusSearch={false}
+          searchDisabled
+          previewConfig={{
+            showPreview: false,
+          }}
+          categories={EMOJI_CATEGORIES}
+          lazyLoadEmojis
+        />
+      </Layout.Absolute>
+    );
+  }, [
+    emojiPickerTarget,
+    emojiPickerWrapper,
+    handleSelectEmoji,
+    height,
+    left,
+    post?.id,
+    post?.type,
+    selectedEmojis,
+  ]);
+
+  if (createPortalId && element) {
+    return createPortal(content, element);
+  }
+  return content;
 }
 export default EmojiPicker;

--- a/src/components/response/response-section/ResponseSection.tsx
+++ b/src/components/response/response-section/ResponseSection.tsx
@@ -126,7 +126,8 @@ function ResponseSection({ username }: ResponseSectionProps) {
           </Layout.FlexRow>
         )}
       </S.ResponseSectionWrapper>
-
+      {/** NOTE: 답변 목록에서 이모지가 잘리지 않도록 외부에서 이모지 피커 렌더링 */}
+      <div id="response_section_emoji_picker" style={{ overflow: 'visible' }} />
       {selectPrompt && (
         <SelectPromptSheet visible={selectPrompt} closeBottomSheet={() => setSelectPrompt(false)} />
       )}

--- a/src/stores/emojiPicker.ts
+++ b/src/stores/emojiPicker.ts
@@ -3,7 +3,7 @@ import { SliceStateCreator } from './useBoundStore';
 export interface EmojiPickerTarget {
   type: 'Note' | 'Response' | 'CheckIn';
   id: number | null;
-  direction: 'top' | 'bottom';
+  top?: number;
 }
 interface EmojiPickerState {
   emojiPickerTarget: EmojiPickerTarget | null;


### PR DESCRIPTION
## Issue Number: #1063 

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?
- [x] 데스크탑, 모바일에서의 정상 작동을 확인했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## Testable backend branch name

## What does this PR do?
- 답변 목록에서 이모지 피커가 잘려서 노출되는 버그 수정
  - iOS에서 부모 요소가 x축 스크롤인 경우, 자식요소의 position이 absolute이고, y축으로 부모요소 영역을 overflow되는 경우, 그 영역이 hidden 처리됨.
  - 해당 케이스에서 이모지피커 (자식요소, position: absolute)를 답변목록 스크롤영역(부모요소) 밖에서 렌더링하도록 수정


## Preview Image

https://github.com/user-attachments/assets/5af46629-e8da-489b-a025-c6b714167b54


## Further comments
