### PR TITLE
[Bug] 상세 페이지에서 댓글 버튼과 댓글 개수 표시 없애기

### DIFF
--- a/src/components/_common/post-footer/PostFooter.tsx
+++ b/src/components/_common/post-footer/PostFooter.tsx
@@ -163,16 +163,21 @@ function PostFooter({
             </Layout.FlexRow>
           </>
         )}
-        <Icon name="add_comment" size={23} onClick={handleClickCommentIcon} />
+        {displayType === 'LIST' && (
+          <Icon name="add_comment" size={23} onClick={handleClickCommentIcon} />
+        )}
         {sampleUserList?.length > 0 && (
           <Layout.FlexRow onClick={handleClickReactions}>
             <PostReactionList user_sample_list={sampleUserList} />
           </Layout.FlexRow>
         )}
       </Layout.FlexRow>
-      {!!comment_count && displayType === 'LIST' && (
+      {!!comment_count && (
         <Layout.FlexRow>
-          <button type="button" onClick={handleClickCommentText}>
+          <button
+            type="button"
+            onClick={displayType === 'LIST' ? handleClickCommentText : undefined}
+          >
             <Typo type="label-large" color="BLACK" underline>
               {comment_count ?? 0} {t('comments')}
             </Typo>

--- a/src/components/_common/post-footer/PostFooter.tsx
+++ b/src/components/_common/post-footer/PostFooter.tsx
@@ -140,12 +140,13 @@ function PostFooter({
   }, [setEmojiPickerTarget]);
 
   return (
-    <Layout.FlexCol
+    <Layout.FlexRow
       gap={8}
       w="100%"
       style={{
         position: displayType === 'DETAIL' ? 'relative' : undefined,
       }}
+      alignItems="center"
     >
       <Layout.FlexRow gap={10} alignItems="center">
         {!isMyPage && (
@@ -193,7 +194,7 @@ function PostFooter({
         top={(toggleButtonRef?.current?.getBoundingClientRect()?.height ?? 0) + 6}
         post={post}
       />
-    </Layout.FlexCol>
+    </Layout.FlexRow>
   );
 }
 export default PostFooter;

--- a/src/components/_common/post-footer/PostFooterDefault.tsx
+++ b/src/components/_common/post-footer/PostFooterDefault.tsx
@@ -56,7 +56,7 @@ function PostFooterDefault({
   };
 
   return (
-    <Layout.FlexCol gap={8}>
+    <Layout.FlexRow gap={8} alignItems="center">
       <Layout.FlexRow gap={8} alignItems="center">
         {/* 좋아요 리스트 */}
         {isMyPage && likedUserList?.length > 0 && (
@@ -91,7 +91,7 @@ function PostFooterDefault({
           </button>
         </Layout.FlexRow>
       )}
-    </Layout.FlexCol>
+    </Layout.FlexRow>
   );
 }
 

--- a/src/components/_common/post-footer/PostFooterDefault.tsx
+++ b/src/components/_common/post-footer/PostFooterDefault.tsx
@@ -75,11 +75,16 @@ function PostFooterDefault({
             </Typo>
           </button>
         )}
-        <Icon name="add_comment" size={23} onClick={handleClickCommentIcon} />
+        {displayType === 'LIST' && (
+          <Icon name="add_comment" size={23} onClick={handleClickCommentIcon} />
+        )}
       </Layout.FlexRow>
-      {!!comment_count && displayType === 'LIST' && (
+      {!!comment_count && (
         <Layout.FlexRow>
-          <button type="button" onClick={handleClickCommentText}>
+          <button
+            type="button"
+            onClick={displayType === 'LIST' ? handleClickCommentText : undefined}
+          >
             <Typo type="label-large" color="BLACK" underline>
               {comment_count || 0} {t('comments')}
             </Typo>


### PR DESCRIPTION
## Issue Number: #1064 

## Self Check List

- [ ] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [ ] base branch로부터 rebase를 했나요?
- [ ] 데스크탑, 모바일에서의 정상 작동을 확인했나요?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## Testable backend branch name

## What does this PR do?
- post detail 페이지에서 댓글 아이콘 삭제
- post detail 페이지에서 댓글 개수 표기
- post detail 페이지에서 댓글 개수 클릭시 comment bottom modal이 뜨지 않도록 함

## Preview Image
<img width="344" alt="image" src="https://github.com/user-attachments/assets/d179daff-5369-4f48-8b42-4dbdf16b250e" />
<img width="341" alt="image" src="https://github.com/user-attachments/assets/e5c3487d-e74d-4403-9be2-c4cc051157da" />


## Further comments
