### PR TITLE
(#1084) [Bug] 용량 큰 프로필 사진 업로드시 처음에만 에러 토스트 메시지 노출, 그 다음부터는 나오지 않음

### DIFF
--- a/src/routes/settings/EditProfile.tsx
+++ b/src/routes/settings/EditProfile.tsx
@@ -114,7 +114,7 @@ function EditProfile() {
 
       if (typeof imageDataUrl !== 'string') {
         openToast({ message: t('error.read_file_error') || '' });
-        throw new Error(t('error.read_file_error') || '');
+        return;
       }
 
       setOriginalImageFileURL(imageDataUrl);
@@ -123,6 +123,10 @@ function EditProfile() {
       const errMsg = (error as Error)?.message;
       if (!errMsg) return;
       openToast({ message: errMsg });
+      // Reset the file input to allow new file selection
+      if (inputRef.current) {
+        inputRef.current.value = '';
+      }
     }
   };
 


### PR DESCRIPTION
## Issue Number: #1084

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?
- [x] 데스크탑, 모바일에서의 정상 작동을 확인했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## Testable backend branch name

## What does this PR do?

- 용량 큰 이미지 업로드 실패한경우 이미지 input 리셋

## Preview Image

## Further comments
