### PR TITLE
(#1060) input 자동 수정 옵션 끄기

### DIFF
--- a/src/components/ping/ping-message-input/PingMessageInput.tsx
+++ b/src/components/ping/ping-message-input/PingMessageInput.tsx
@@ -117,6 +117,7 @@ function PingMessageInput({ insertPing, userId }: Props) {
             value={messageInput}
             autoCorrect="off"
             autoCapitalize="off"
+            spellCheck={false}
             onChange={handleChangeMessage}
             onKeyDown={handleKeyDownInput}
           />

--- a/src/components/ping/ping-message-input/PingMessageInput.tsx
+++ b/src/components/ping/ping-message-input/PingMessageInput.tsx
@@ -115,6 +115,8 @@ function PingMessageInput({ insertPing, userId }: Props) {
             maxLength={MAX_LENGTH}
             placeholder={t('input_placeholder') || ''}
             value={messageInput}
+            autoCorrect="off"
+            autoCapitalize="off"
             onChange={handleChangeMessage}
             onKeyDown={handleKeyDownInput}
           />


### PR DESCRIPTION
## Issue Number: #1060

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?
- [x] 데스크탑, 모바일에서의 정상 작동을 확인했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## Testable backend branch name

## What does this PR do?
iOS에서 첫 영어 알파벳이 무시되는 케이스가 있는데, 의심되는 인풋 옵션 비활성화
로컬에서는 재현안되서 배포되면 확인해볼 예정

## Preview Image

## Further comments
