### PR TITLE
(#1029) persona 영역 스크롤대신 collapse 로 변경

### DIFF
--- a/src/components/profile/Profile.tsx
+++ b/src/components/profile/Profile.tsx
@@ -74,6 +74,7 @@ function Profile({ user }: ProfileProps) {
     setShowEditConnectionsModal(true);
   };
 
+  // persona 영역 collapse ui 구현
   const personaContainerRef = useRef<HTMLDivElement | null>(null);
   const [isPersonaContainerExpanded, setIsPersonaContainerExpanded] = useState(false);
   const [isOverflowing, setIsOverflowing] = useState(false);
@@ -239,14 +240,14 @@ function Profile({ user }: ProfileProps) {
                   <PersonaChip key={persona} persona={persona} />
                 ))}
               </Layout.FlexRow>
-              {isOverflowing && (
+              <Layout.LayoutBase style={{ visibility: isOverflowing ? 'visible' : 'hidden' }}>
                 <Icon
                   name={isPersonaContainerExpanded ? 'expand_close' : 'expand_open'}
                   size={24}
                   color="PRIMARY"
                   onClick={() => setIsPersonaContainerExpanded((prev) => !prev)}
                 />
-              )}
+              </Layout.LayoutBase>
             </Layout.FlexRow>
           ) : (
             isMyPage && <PersonaPlaceholder />

--- a/src/components/profile/Profile.tsx
+++ b/src/components/profile/Profile.tsx
@@ -244,7 +244,6 @@ function Profile({ user }: ProfileProps) {
                 <Icon
                   name={isPersonaContainerExpanded ? 'expand_close' : 'expand_open'}
                   size={24}
-                  color="PRIMARY"
                   onClick={() => setIsPersonaContainerExpanded((prev) => !prev)}
                 />
               </Layout.LayoutBase>


### PR DESCRIPTION
## Issue Number: #1029

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?
- [x] 데스크탑, 모바일에서의 정상 작동을 확인했나요?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## Testable backend branch name

## What does this PR do?
- persona 영역 스크롤대신 collapse 로 변경
  - persona 영역이 overflow되는 경우, 한줄만 노출하고 나머지 영역은 숨겨지고, expand 버튼 노출
    - expand 버튼 클릭시 숨겨진 persona 칩 노출.
  - persona 영역이 overflow되지 않는 경우, expand 버튼 미노출
## Preview Image

https://github.com/user-attachments/assets/e8d07f6c-496c-4ac3-8abf-a05cbd70b1b8


## Further comments
