### PR TITLE
(#1106) 노티 페이지로 복귀시 이전 스크롤위치 복구

### DIFF
--- a/src/components/header/common-header/CommonHeader.tsx
+++ b/src/components/header/common-header/CommonHeader.tsx
@@ -3,6 +3,7 @@ import { useSearchParams } from 'react-router-dom';
 import Icon from '@components/_common/icon/Icon';
 import IconNudge from '@components/_common/icon-nudge/IconNudge';
 import { Layout } from '@design-system';
+import { resetScrollPosition } from '@hooks/useRestoreScrollPosition';
 import { useBoundStore } from '@stores/useBoundStore';
 import { getMe } from '@utils/apis/my';
 import { Noti } from '../Header.styled';
@@ -38,7 +39,11 @@ function CommonHeader({ title }: CommonHeaderProps) {
         rightButtons={
           <>
             <Noti to="/notifications">
-              <Icon name="notification" size={44} />
+              <Icon
+                name="notification"
+                size={44}
+                onClick={() => resetScrollPosition('notificationsPage')}
+              />
               <Layout.Absolute t={4} r={4}>
                 {!!myProfile?.unread_noti_cnt && (
                   <IconNudge size={18} count={myProfile?.unread_noti_cnt} />

--- a/src/hooks/useRestoreScrollPosition.tsx
+++ b/src/hooks/useRestoreScrollPosition.tsx
@@ -12,6 +12,7 @@ export interface ScrollPositionStore {
   friendsDetail?: number;
   friendsFeed?: number;
   commentsPage?: number;
+  notificationsPage?: number;
 }
 
 export function useRestoreScrollPosition(key: keyof ScrollPositionStore) {

--- a/src/routes/Notifications.tsx
+++ b/src/routes/Notifications.tsx
@@ -8,6 +8,7 @@ import TopContainer from '@components/notification/TopContainer/TopContainer';
 import SubHeader from '@components/sub-header/SubHeader';
 import { Layout, Typo } from '@design-system';
 import useAsyncEffect from '@hooks/useAsyncEffect';
+import { useRestoreScrollPosition } from '@hooks/useRestoreScrollPosition';
 import { useSWRInfiniteScroll } from '@hooks/useSWRInfiniteScroll';
 import { Notification } from '@models/notification';
 import { useBoundStore } from '@stores/useBoundStore';
@@ -99,8 +100,10 @@ function Notifications() {
     await fetchRequests();
   }, [featureFlags]);
 
+  const { scrollRef } = useRestoreScrollPosition('notificationsPage');
+
   return (
-    <MainScrollContainer>
+    <MainScrollContainer scrollRef={scrollRef}>
       <SubHeader title={t('title')} />
       <PullToRefresh onRefresh={handleRefresh}>
         <Layout.FlexCol w="100%">

--- a/src/routes/Notifications.tsx
+++ b/src/routes/Notifications.tsx
@@ -8,12 +8,12 @@ import TopContainer from '@components/notification/TopContainer/TopContainer';
 import SubHeader from '@components/sub-header/SubHeader';
 import { Layout, Typo } from '@design-system';
 import useAsyncEffect from '@hooks/useAsyncEffect';
-import useInfiniteScroll from '@hooks/useInfiniteScroll';
+import { useSWRInfiniteScroll } from '@hooks/useSWRInfiniteScroll';
 import { Notification } from '@models/notification';
 import { useBoundStore } from '@stores/useBoundStore';
 import { UserSelector } from '@stores/user';
 import { getResponseRequests } from '@utils/apis/my';
-import { getNotifications, readAllNotifications } from '@utils/apis/notification';
+import { readAllNotifications } from '@utils/apis/notification';
 import { getFriendRequests } from '@utils/apis/user';
 import { MainScrollContainer } from './Root';
 
@@ -21,14 +21,10 @@ function Notifications() {
   const navigate = useNavigate();
 
   const [t] = useTranslation('translation', { keyPrefix: 'notifications' });
-  const [notifications, setNotifications] = useState<Notification[]>([]);
-  const [nextPage, setNextPage] = useState<string | null | undefined>(undefined);
+
   const [friendRequests, setFriendRequests] = useState<number | null>(null);
   const [responseRequests, setResponseRequests] = useState<number | null>(null);
-  const { isLoading, targetRef, setIsLoading } = useInfiniteScroll<HTMLDivElement>(async () => {
-    if (nextPage === null) return setIsLoading(false);
-    await fetchNotifications(nextPage ?? null);
-  });
+
   const { featureFlags } = useBoundStore(UserSelector);
 
   const { openToast, updateMyProfile } = useBoundStore((state) => ({
@@ -36,17 +32,19 @@ function Notifications() {
     updateMyProfile: state.updateMyProfile,
   }));
 
-  const fetchNotifications = async (page: string | null) => {
-    const { results, next } = await getNotifications(page);
-    if (!results) return;
-    setNextPage(next);
-    if (page === null) {
-      setNotifications(results);
-    } else {
-      setNotifications([...notifications, ...results]);
-    }
-    setIsLoading(false);
-  };
+  const {
+    targetRef,
+    data: allNotifications,
+    isLoading: isNotificationsLoading,
+    mutate: mutateNotifications,
+    isLoadingMore: isNotificationsLoadingMore,
+  } = useSWRInfiniteScroll<Notification>({
+    key: '/notifications/',
+  });
+
+  const flatNotifications = allNotifications?.flatMap((page) => page.results ?? []) ?? [];
+  const recentNotifications = flatNotifications.filter((n) => n.is_recent);
+  const restNotifications = flatNotifications.filter((n) => !n.is_recent);
 
   const fetchRequests = async () => {
     try {
@@ -70,7 +68,7 @@ function Notifications() {
 
   const handleRefresh = async () => {
     try {
-      await Promise.all([fetchNotifications(null), fetchRequests()]);
+      await Promise.all([mutateNotifications(), fetchRequests()]);
     } catch (error) {
       console.error('Error refreshing data:', error);
       openToast({ message: t('temporary_error') });
@@ -80,7 +78,13 @@ function Notifications() {
   const handleReadAll = async () => {
     try {
       await readAllNotifications();
-      setNotifications(notifications.map((n) => ({ ...n, is_read: true })));
+      mutateNotifications(
+        allNotifications?.map((prev) => ({
+          ...prev,
+          results: prev.results?.map((n) => ({ ...n, is_read: true })) ?? [],
+        })) ?? [],
+        { revalidate: false },
+      );
       updateMyProfile({
         unread_noti: false,
       });
@@ -90,15 +94,9 @@ function Notifications() {
     }
   };
 
-  const recentNotifications = notifications.filter((n) => n.is_recent);
-  const restNotifications = notifications.filter((n) => !n.is_recent);
-
   useAsyncEffect(async () => {
-    if (featureFlags?.questionResponseFeature) {
-      await Promise.all([fetchNotifications(null), fetchRequests()]);
-    } else {
-      await fetchNotifications(null);
-    }
+    if (!featureFlags?.questionResponseFeature) return;
+    await fetchRequests();
   }, [featureFlags]);
 
   return (
@@ -131,35 +129,43 @@ function Notifications() {
               </Typo>
             </button>
           </Layout.FlexRow>
-
-          {/* Last 7 days */}
-          {recentNotifications.length > 0 && (
-            <>
-              <Layout.FlexRow pv={8} ph={16}>
-                <Typo type="title-medium">{t('last_7_days')}</Typo>
-              </Layout.FlexRow>
-              {recentNotifications.map((noti) => (
-                <NotificationItem item={noti} key={noti.id} />
-              ))}
-            </>
-          )}
-          {/* Rest of notifications */}
-          {restNotifications.length > 0 && (
-            <>
-              <Layout.FlexRow mt={8} pv={8} ph={16}>
-                <Typo type="title-medium">{t('earlier')}</Typo>
-              </Layout.FlexRow>
-              {restNotifications.map((noti) => (
-                <NotificationItem item={noti} key={noti.id} />
-              ))}
-            </>
-          )}
-          <div ref={targetRef} />
-          {isLoading && (
+          {/** Notifications */}
+          {isNotificationsLoading ? (
             <Layout.FlexRow w="100%" h={40}>
               <Loader />
             </Layout.FlexRow>
-          )}
+          ) : allNotifications?.[0] && allNotifications[0].count > 0 ? (
+            <>
+              {/* Last 7 days */}
+              {recentNotifications.length > 0 && (
+                <>
+                  <Layout.FlexRow pv={8} ph={16}>
+                    <Typo type="title-medium">{t('last_7_days')}</Typo>
+                  </Layout.FlexRow>
+                  {recentNotifications.map((noti) => (
+                    <NotificationItem item={noti} key={noti.id} />
+                  ))}
+                </>
+              )}
+              {/* Rest of notifications */}
+              {restNotifications.length > 0 && (
+                <>
+                  <Layout.FlexRow mt={8} pv={8} ph={16}>
+                    <Typo type="title-medium">{t('earlier')}</Typo>
+                  </Layout.FlexRow>
+                  {restNotifications.map((noti) => (
+                    <NotificationItem item={noti} key={noti.id} />
+                  ))}
+                </>
+              )}
+              <div ref={targetRef} />
+              {isNotificationsLoadingMore && (
+                <Layout.FlexRow w="100%" h={40}>
+                  <Loader />
+                </Layout.FlexRow>
+              )}
+            </>
+          ) : null}
         </Layout.FlexCol>
       </PullToRefresh>
     </MainScrollContainer>


### PR DESCRIPTION
## Issue Number: #1106

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?
- [x] 데스크탑, 모바일에서의 정상 작동을 확인했나요?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## Testable backend branch name

## What does this PR do?
- 노티 페이지로 복귀시 이전 스크롤위치 복구
  - Step1) `useSWRInfiniteScroll` 적용
  - Step2) `useRestoreScrollPosition` 적용
    - Noti 아이콘 클릭하여 노티 페이지 진입시 스크롤 위치 리셋 (맨위로 진입) / 그 이외에는 이전 스크롤 위치 복구

## Preview Image

https://github.com/user-attachments/assets/d7faba4e-c146-4c7f-a32f-62fd1089bb06


## Further comments
