### PR TITLE
feat: add friends-only visibility checkboxes on edit profile

### DIFF
--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -111,12 +111,14 @@
         "my": "MY",
         "chats": "Chats",
         "questions": "Questions",
+        "share": "Share",
         "feed": "Feed",
         "discover": "Discover"
     },
     "header": {
         "my": "My Profile",
-        "questions": "Questions"
+        "questions": "Questions",
+        "share": "Share"
     },
     "home": {
         "moment": {
@@ -458,6 +460,12 @@
             "error": {
                 "read_file_error": "Error uploading image. Please try again later."
             },
+            "friends_only": {
+                "interests": "Show interests only to friends",
+                "persona": "Show persona only to friends",
+                "pronouns": "Show pronoun only to friends",
+                "bio": "Show bio only to friends"
+            },
             "placeholders": {
                 "bio": "Bio",
                 "pronoun": "Pronoun",
@@ -555,6 +563,13 @@
         "report_cancel": "Cancel",
         "report_success": "Comment reported",
         "report_error": "A temporary error occurred. Please try again later."
+    },
+    "share_page": {
+        "tmi_placeholder": "eg: TMI of the day",
+        "photo_of_the_day": "Photo of the day",
+        "photo_description": "Post your favourite photo for the day and let everyone know what you are up to",
+        "share_photo": "Share photo",
+        "questions_of_the_day": "Questions of the day"
     },
     "no_contents": {
         "discover": "No posts yet.",

--- a/src/i18n/locales/ko/translation.json
+++ b/src/i18n/locales/ko/translation.json
@@ -111,12 +111,14 @@
     "my": "MY",
     "chats": "채팅",
     "questions": "질문",
+    "share": "공유",
     "feed": "피드",
     "discover": "발견"
   },
   "header": {
     "my": "내 프로필",
-    "questions": "질문"
+    "questions": "질문",
+    "share": "공유"
   },
   "home": {
     "moment": {
@@ -454,6 +456,12 @@
       "error": {
         "read_file_error": "이미지를 불러오는 중 일시적인 오류가 발생했습니다. 잠시 후 다시 시도해주세요."
       },
+      "friends_only": {
+        "interests": "관심사를 친구에게만 보이기",
+        "persona": "페르소나를 친구에게만 보이기",
+        "pronouns": "대명사를 친구에게만 보이기",
+        "bio": "소개를 친구에게만 보이기"
+      },
       "placeholders": {
         "bio": "소개",
         "pronoun": "대명사",
@@ -547,6 +555,13 @@
     "report_cancel": "취소",
     "report_success": "댓글이 성공적으로 신고되었습니다.",
     "report_error": "일시적으로 오류가 발생했습니다. 잠시 후 다시 시도해 주세요."
+  },
+  "share_page": {
+    "tmi_placeholder": "예: 오늘의 TMI",
+    "photo_of_the_day": "오늘의 사진",
+    "photo_description": "오늘의 사진을 공유하고 친구들에게 근황을 알려주세요",
+    "share_photo": "사진 공유",
+    "questions_of_the_day": "오늘의 질문"
   },
   "no_contents": {
     "discover": "아직 게시글이 없습니다.",

--- a/src/routes/settings/EditProfile.tsx
+++ b/src/routes/settings/EditProfile.tsx
@@ -12,7 +12,7 @@ import PersonaChip from '@components/profile/persona/PersonaChip';
 import { StyledEditProfileButton } from '@components/settings/SettingsButtons.styled';
 import SubHeader from '@components/sub-header/SubHeader';
 import { TITLE_HEADER_HEIGHT } from '@constants/layout';
-import { Layout, Typo } from '@design-system';
+import { CheckBox, Layout, Typo } from '@design-system';
 import { MyProfile } from '@models/api/user';
 import { Interest } from '@models/interest';
 import { Persona } from '@models/persona';
@@ -43,12 +43,20 @@ function EditProfile() {
     pronouns: string;
     user_personas: string[];
     user_interests: string[];
+    interests_friends_only: boolean;
+    persona_friends_only: boolean;
+    pronouns_friends_only: boolean;
+    bio_friends_only: boolean;
   }>({
     bio: myProfile?.bio ?? '',
     username: myProfile?.username ?? '',
     pronouns: myProfile?.pronouns ?? '',
     user_personas: (myProfile?.user_personas ?? []).map((p) => p.replace(/^#+/, '')),
     user_interests: (myProfile?.user_interests ?? []).map((i) => i.replace(/^#+/, '')),
+    interests_friends_only: (myProfile as any)?.interests_friends_only ?? false,
+    persona_friends_only: (myProfile as any)?.persona_friends_only ?? false,
+    pronouns_friends_only: (myProfile as any)?.pronouns_friends_only ?? false,
+    bio_friends_only: (myProfile as any)?.bio_friends_only ?? false,
   });
 
   const [usernameError, setUsernameError] = useState<string>();
@@ -82,6 +90,10 @@ function EditProfile() {
       draft.bio !== (myProfile?.bio ?? '') ||
       !arraysEqual(draft.user_personas, originalPersonas) ||
       !arraysEqual(draft.user_interests, originalInterests) ||
+      draft.interests_friends_only !== ((myProfile as any)?.interests_friends_only ?? false) ||
+      draft.persona_friends_only !== ((myProfile as any)?.persona_friends_only ?? false) ||
+      draft.pronouns_friends_only !== ((myProfile as any)?.pronouns_friends_only ?? false) ||
+      draft.bio_friends_only !== ((myProfile as any)?.bio_friends_only ?? false) ||
       imageChanged;
 
     setHasChanges(hasDraftChanged);
@@ -111,6 +123,10 @@ function EditProfile() {
       }
       return prev;
     });
+  };
+
+  const handleToggleVisibility = (field: string) => {
+    setDraft((prev) => ({ ...prev, [field]: !prev[field as keyof typeof prev] }));
   };
 
   const handleClickUpdate = () => {
@@ -243,7 +259,7 @@ function EditProfile() {
           </StyledEditProfileButton>
         </Layout.FlexCol>
       </Layout.FlexCol>
-      <Layout.FlexCol pt={32} ph={24} gap={24} w="100%">
+      <Layout.FlexCol pt={32} ph={24} pb={40} gap={24} w="100%">
         {/* username */}
         <ValidatedInput
           label={t('username')}
@@ -253,6 +269,34 @@ function EditProfile() {
           onChange={handleChangeInput}
           limit={20}
           error={usernameError}
+        />
+
+        {/* pronouns */}
+        <ValidatedInput
+          label={t('pronouns')}
+          name="pronouns"
+          type="text"
+          value={draft.pronouns}
+          onChange={handleChangeInput}
+        />
+        <CheckBox
+          name={String(t('friends_only.pronouns'))}
+          checked={draft.pronouns_friends_only}
+          onChange={() => handleToggleVisibility('pronouns_friends_only')}
+        />
+
+        {/* bio */}
+        <ValidatedTextArea
+          label={t('bio')}
+          name="bio"
+          value={draft.bio}
+          onChange={handleChangeTextArea}
+          limit={120}
+        />
+        <CheckBox
+          name={String(t('friends_only.bio'))}
+          checked={draft.bio_friends_only}
+          onChange={() => handleToggleVisibility('bio_friends_only')}
         />
 
         {/* interests */}
@@ -318,6 +362,11 @@ function EditProfile() {
                 )}
             </Layout.FlexCol>
           </Layout.FlexCol>
+          <CheckBox
+            name={String(t('friends_only.interests'))}
+            checked={draft.interests_friends_only}
+            onChange={() => handleToggleVisibility('interests_friends_only')}
+          />
         </Layout.FlexCol>
 
         {/* persona */}
@@ -392,26 +441,13 @@ function EditProfile() {
                   )}
               </Layout.FlexCol>
             </Layout.FlexCol>
+            <CheckBox
+              name={String(t('friends_only.persona'))}
+              checked={draft.persona_friends_only}
+              onChange={() => handleToggleVisibility('persona_friends_only')}
+            />
           </Layout.FlexCol>
         )}
-
-        {/* pronouns */}
-        <ValidatedInput
-          label={t('pronouns')}
-          name="pronouns"
-          type="text"
-          value={draft.pronouns}
-          onChange={handleChangeInput}
-        />
-
-        {/* bio */}
-        <ValidatedTextArea
-          label={t('bio')}
-          name="bio"
-          value={draft.bio}
-          onChange={handleChangeTextArea}
-          limit={120}
-        />
       </Layout.FlexCol>
       {isEditModalVisible && (
         <ProfileImageEdit


### PR DESCRIPTION
## Summary
- Add "show ___ only to friends" checkbox toggles for interests, persona, pronouns, and bio fields on the Edit Profile page
- Reorder fields: pronouns and bio now appear above the interest/persona chip sections
- Add i18n translations for checkbox labels in both English and Korean

## Test plan
- [ ] Verify all 4 checkboxes render on the edit profile page
- [ ] Verify checkboxes toggle correctly and trigger the Save button state
- [ ] Verify pronouns/bio input styling is unchanged
- [ ] Verify persona checkbox only appears when persona feature flag is enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)