### PR TITLE
feat: wire up Spotify music on Discover page with oEmbed fallback

### DIFF
--- a/src/components/friends/shared-playlist/SharedPlaylistSection.tsx
+++ b/src/components/friends/shared-playlist/SharedPlaylistSection.tsx
@@ -1,6 +1,7 @@
 import { Track } from '@spotify/web-api-ts-sdk';
-import { useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
 import ProfileImage from '@components/_common/profile-image/ProfileImage';
 import SharedPlaylistBottomSheet from '@components/friends/shared-playlist-bottom-sheet/SharedPlaylistBottomSheet';
 import MusicDetailBottomSheet from '@components/music/music-detail-bottom-sheet/MusicDetailBottomSheet';
@@ -29,11 +30,18 @@ interface TrackCardItemProps {
 
 function TrackCardItem({ track }: TrackCardItemProps) {
   const [trackData, setTrackData] = useState<Track | null>(null);
+  const [trackError, setTrackError] = useState(false);
   const spotifyManager = SpotifyManager.getInstance();
   const [showMusicDetail, setShowMusicDetail] = useState(false);
+  const navigate = useNavigate();
 
   const handleClickTrack = () => {
     setShowMusicDetail(true);
+  };
+
+  const handleClickProfile = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    navigate(`/users/${track.sharedBy.username}`);
   };
 
   useEffect(() => {
@@ -45,6 +53,7 @@ function TrackCardItem({ track }: TrackCardItemProps) {
       setTrackData(track.track);
       return;
     }
+    setTrackError(false);
     spotifyManager
       .getTrack(track.track)
       .then((data) => {
@@ -52,24 +61,25 @@ function TrackCardItem({ track }: TrackCardItemProps) {
       })
       .catch(() => {
         setTrackData(null);
+        setTrackError(true);
       });
   }, [spotifyManager, track.track]);
 
   const albumArtUrl = trackData?.album?.images?.[0]?.url;
-  const isLoadingTrack = typeof track.track === 'string' && trackData === null;
+  const isLoadingTrack = typeof track.track === 'string' && trackData === null && !trackError;
 
-  // Reserve space with placeholder until Spotify track data loads (avoids profile images showing first, then album art shifting layout)
+  const ALBUM_SIZE = 100;
+  const PROFILE_SIZE = 28;
+  const PROFILE_BORDER = 2;
+
+  // Reserve space with placeholder until Spotify track data loads
   if (isLoadingTrack) {
     return (
       <PlaylistCard as="div" style={{ cursor: 'default' }}>
-        <Layout.LayoutBase
-          p={5}
+        <div
           style={{
-            width: 76,
-            height: 76,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
+            width: ALBUM_SIZE,
+            height: ALBUM_SIZE,
             backgroundColor: '#EEE6F4',
             borderRadius: 12,
           }}
@@ -80,55 +90,54 @@ function TrackCardItem({ track }: TrackCardItemProps) {
 
   return (
     <PlaylistCard onClick={handleClickTrack}>
-      {/* Album Art Background */}
-      <Layout.LayoutBase
-        p={5}
+      {/* Album Art */}
+      <div
         style={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
+          width: ALBUM_SIZE,
+          height: ALBUM_SIZE,
           backgroundColor: '#EEE6F4',
           borderRadius: 12,
+          overflow: 'hidden',
         }}
       >
         {albumArtUrl && (
           <img
             src={albumArtUrl}
             alt={track.name}
-            width={76}
-            height={76}
-            style={{ objectFit: 'cover', borderRadius: 12 }}
+            width={ALBUM_SIZE}
+            height={ALBUM_SIZE}
+            style={{ objectFit: 'cover', display: 'block' }}
           />
         )}
-      </Layout.LayoutBase>
+      </div>
 
-      {/* Overlaid Profile Picture - positioned relative to PlaylistCard */}
+      {/* Overlaid Profile Picture */}
       <div
+        role="button"
+        tabIndex={0}
+        onClick={handleClickProfile}
+        onKeyDown={(e) => e.key === 'Enter' && handleClickProfile(e as unknown as React.MouseEvent)}
         style={{
           position: 'absolute',
-          top: -10,
-          right: -10,
+          top: -6,
+          right: -6,
           zIndex: 10,
+          cursor: 'pointer',
+          width: PROFILE_SIZE + PROFILE_BORDER * 2,
+          height: PROFILE_SIZE + PROFILE_BORDER * 2,
+          padding: PROFILE_BORDER,
+          backgroundColor: '#FFFFFF',
+          borderRadius: '50%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
         }}
       >
-        <div
-          style={{
-            width: 47,
-            height: 47,
-            padding: 3,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            backgroundColor: '#D9D9D9',
-            borderRadius: '50%',
-          }}
-        >
-          <ProfileImage
-            imageUrl={track.sharedBy.profileImageUrl}
-            username={track.sharedBy.username}
-            size={41}
-          />
-        </div>
+        <ProfileImage
+          imageUrl={track.sharedBy.profileImageUrl}
+          username={track.sharedBy.username}
+          size={PROFILE_SIZE}
+        />
       </div>
       <MusicDetailBottomSheet
         visible={showMusicDetail}

--- a/src/libs/SpotifyManager.ts
+++ b/src/libs/SpotifyManager.ts
@@ -16,6 +16,12 @@ class SpotifyManager {
   initialize = async () => {
     const clientId = SPOTIFY_CLIENT_ID;
     const clientSecret = SPOTIFY_CLIENT_SECRET;
+
+    if (!clientId || !clientSecret) {
+      console.warn('Spotify credentials not configured. Using oEmbed fallback.');
+      return;
+    }
+
     const scopes = ['user-read-private'];
 
     try {
@@ -52,18 +58,41 @@ class SpotifyManager {
     }
   };
 
+  /**
+   * Fetch track info via Spotify oEmbed API (no auth required).
+   * Returns a partial Track-like object with album art, title, and Spotify URL.
+   */
+  // eslint-disable-next-line class-methods-use-this
+  private getTrackViaOEmbed = async (trackId: string): Promise<Track> => {
+    const res = await fetch(
+      `https://open.spotify.com/oembed?url=https://open.spotify.com/track/${trackId}`,
+    );
+    if (!res.ok) throw new Error('oEmbed fetch failed');
+    const data = await res.json();
+
+    return {
+      name: data.title || '',
+      album: {
+        images: [{ url: data.thumbnail_url, height: 300, width: 300 }],
+      },
+      artists: [{ name: '' }],
+      external_urls: { spotify: `https://open.spotify.com/track/${trackId}` },
+    } as unknown as Track;
+  };
+
   getTrack = async (trackId: string): Promise<Track> => {
-    if (!this.spotifyApi) {
-      throw new Error('SpotifyApi is not initialized.');
+    // Try SDK first if available
+    if (this.spotifyApi) {
+      try {
+        const res = await this.spotifyApi.makeRequest('GET', `tracks/${trackId}`);
+        return res as Track;
+      } catch (error) {
+        console.warn('Spotify SDK failed, trying oEmbed fallback:', error);
+      }
     }
 
-    try {
-      const res = await this.spotifyApi.makeRequest('GET', `tracks/${trackId}`);
-      return res as Track;
-    } catch (error) {
-      console.error('Error searching music:', error);
-      throw error;
-    }
+    // Fallback to oEmbed (no auth required)
+    return this.getTrackViaOEmbed(trackId);
   };
 }
 

--- a/src/models/discover.ts
+++ b/src/models/discover.ts
@@ -1,4 +1,4 @@
-import { AdminAuthor, Response } from './post';
+import { AdminAuthor, Note, Response } from './post';
 import { User } from './user';
 
 export enum DiscoverFilter {
@@ -9,12 +9,15 @@ export enum DiscoverFilter {
 
 export const DiscoverFilterLabel = {
   [DiscoverFilter.follow]: 'People I follow',
-  [DiscoverFilter.MUTUAL_FRIENDS]: 'People I have mutual friends with',
-  [DiscoverFilter.MUTUAL_TRAITS]: 'People I have mutual traits with',
+  [DiscoverFilter.MUTUAL_FRIENDS]: 'Mutual Friends',
+  [DiscoverFilter.MUTUAL_TRAITS]: 'Mutual Traits',
 };
 
 // Response Card Body (type: "Response")
 export type ResponseCardBody = Response;
+
+// Note Card Body (type: "Note")
+export type NoteCardBody = Note;
 
 // Question Card Body (type: "Question")
 export interface QuestionCardBody {
@@ -49,11 +52,29 @@ export interface PersonaCardBody {
   list: PersonaItem[];
 }
 
+// Music Track in Discover Feed
+export interface DiscoverMusicTrack {
+  id: number;
+  user: {
+    id: number;
+    username: string;
+    profile_pic?: string | null;
+    url: string;
+    profile_image?: string | null;
+  };
+  track_id: string;
+  created_at: string;
+}
+
 // Discover Result Item (discriminated union)
 export type DiscoverResultItem =
   | {
       type: 'Response';
       body: ResponseCardBody;
+    }
+  | {
+      type: 'Note';
+      body: NoteCardBody;
     }
   | {
       type: 'Question';

--- a/src/routes/discover/Discover.tsx
+++ b/src/routes/discover/Discover.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import FilterChip from '@components/_common/filter-chip/FilterChip';
 import PullToRefresh from '@components/_common/pull-to-refresh/PullToRefresh';
@@ -9,6 +9,7 @@ import SharedPlaylistSection, {
   SharedTrack,
 } from '@components/friends/shared-playlist/SharedPlaylistSection';
 import { FLOATING_BUTTON_SIZE } from '@components/header/floating-button/FloatingButton.styled';
+import NoteItem from '@components/note/note-item/NoteItem';
 import NoteLoader from '@components/note/note-loader/NoteLoader';
 import ResponseItem from '@components/response/response-item/ResponseItem';
 import { SCREEN_WIDTH } from '@constants/layout';
@@ -16,51 +17,32 @@ import { Layout, Typo } from '@design-system';
 import { useRestoreScrollPosition } from '@hooks/useRestoreScrollPosition';
 import { useSaveAndHide } from '@hooks/useSaveAndHide';
 import { useSWRInfiniteScroll } from '@hooks/useSWRInfiniteScroll';
-import { DiscoverFilter, DiscoverFilterLabel, DiscoverResultItem } from '@models/discover';
-import { PlaylistSong } from '@models/playlist';
+import {
+  DiscoverFilter,
+  DiscoverFilterLabel,
+  DiscoverMusicTrack,
+  DiscoverResultItem,
+} from '@models/discover';
 import { getDiscoverFeed } from '@utils/apis/discover';
 import { getMe } from '@utils/apis/my';
-import { getPlaylistFeed } from '@utils/apis/playlist';
 import { MainScrollContainer } from 'src/routes/Root';
 import * as S from './Discover.styled';
 
 function Discover() {
   const [t] = useTranslation('translation');
   const [selectedFilter, setSelectedFilter] = useState<DiscoverFilter[]>([]);
-  const [playlistTracks, setPlaylistTracks] = useState<SharedTrack[]>([]);
-  const [isPlaylistLoading, setIsPlaylistLoading] = useState(true);
+  const {
+    isSaved: isInterestSaved,
+    showCard: showInterestCard,
+    isAnimating: isInterestAnimating,
+    handleSave: handleInterestSave,
+  } = useSaveAndHide();
   const {
     isSaved: isPersonaSaved,
     showCard: showPersonaCard,
     isAnimating: isPersonaAnimating,
     handleSave: handlePersonaSave,
   } = useSaveAndHide();
-
-  const fetchPlaylistFeed = useCallback(async () => {
-    try {
-      setIsPlaylistLoading(true);
-      const songs = await getPlaylistFeed();
-      const transformedTracks: SharedTrack[] = songs.map((song: PlaylistSong) => ({
-        id: song.id,
-        name: '',
-        track: song.track_id,
-        sharedBy: {
-          id: song.user.id,
-          username: song.user.username,
-          profileImageUrl: song.user.profile_image || null,
-        },
-      }));
-      setPlaylistTracks(transformedTracks);
-    } catch {
-      setPlaylistTracks([]);
-    } finally {
-      setIsPlaylistLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    fetchPlaylistFeed();
-  }, [fetchPlaylistFeed]);
 
   const discoverFilterList = [DiscoverFilter.MUTUAL_FRIENDS, DiscoverFilter.MUTUAL_TRAITS];
   const { scrollRef } = useRestoreScrollPosition('discoverPage');
@@ -77,16 +59,40 @@ function Discover() {
     mutate,
   } = useSWRInfiniteScroll<DiscoverResultItem>({ key: swrKey });
 
+  // Extract music tracks from the first page of the discover API response
+  const musicTracks: SharedTrack[] = useMemo(() => {
+    const firstPage = discoverData?.[0] as Record<string, unknown> | undefined;
+    const tracks = (firstPage?.music_tracks ?? []) as DiscoverMusicTrack[];
+    return tracks.map((song) => ({
+      id: song.id,
+      name: '',
+      track: song.track_id,
+      sharedBy: {
+        id: song.user.id,
+        username: song.user.username,
+        profileImageUrl: song.user.profile_image || null,
+      },
+    }));
+  }, [discoverData]);
+
   const handleRefresh = useCallback(async () => {
-    await Promise.all([getDiscoverFeed(null, selectedFilter), getMe(), fetchPlaylistFeed()]);
+    await Promise.all([getDiscoverFeed(null, selectedFilter), getMe()]);
     mutate();
-  }, [mutate, selectedFilter, fetchPlaylistFeed]);
+  }, [mutate, selectedFilter]);
 
   const renderDiscoverItem = useCallback(
     (item: DiscoverResultItem, index: number) => {
       switch (item.type) {
         case 'Response':
-          return <ResponseItem key={`response-${item.body.id}`} response={item.body} />;
+          return (
+            <ResponseItem
+              key={`response-${item.body.id}`}
+              response={item.body}
+              displayType="FEED"
+            />
+          );
+        case 'Note':
+          return <NoteItem key={`note-${item.body.id}`} note={item.body} isMyPage={false} />;
         case 'Question':
           return (
             <HighlightQuestionSection
@@ -97,13 +103,16 @@ function Discover() {
             />
           );
         case 'Interest':
-          return (
-            <SelectInterestSection
-              key={`interest-${index}`}
-              interestList={item.body.list}
-              isSaved={item.body.list.every((interest) => interest.is_selected)}
-            />
-          );
+          return showInterestCard ? (
+            <S.AnimatedCardWrapper key={`interest-${index}`} $isAnimating={isInterestAnimating}>
+              <SelectInterestSection
+                key={`interest-${index}`}
+                interestList={item.body.list}
+                isSaved={isInterestSaved}
+                onSave={handleInterestSave}
+              />
+            </S.AnimatedCardWrapper>
+          ) : null;
         case 'Persona':
           return showPersonaCard ? (
             <S.AnimatedCardWrapper key={`persona-${index}`} $isAnimating={isPersonaAnimating}>
@@ -118,7 +127,16 @@ function Discover() {
           return null;
       }
     },
-    [isPersonaSaved, showPersonaCard, handlePersonaSave, isPersonaAnimating],
+    [
+      isInterestSaved,
+      showInterestCard,
+      handleInterestSave,
+      isInterestAnimating,
+      isPersonaSaved,
+      showPersonaCard,
+      handlePersonaSave,
+      isPersonaAnimating,
+    ],
   );
 
   return (
@@ -152,7 +170,7 @@ function Discover() {
             </S.ScrollableFilterRow>
 
             {/* Shared Playlist */}
-            {!isPlaylistLoading && <SharedPlaylistSection tracks={playlistTracks} />}
+            {!isLoading && <SharedPlaylistSection tracks={musicTracks} />}
 
             {/* Discover Feed */}
             <Layout.FlexCol gap={20} mh={20} alignItems="center" w={SCREEN_WIDTH - 40}>
@@ -172,7 +190,7 @@ function Discover() {
               ) : discoverData?.[0] &&
                 discoverData[0].results &&
                 discoverData[0].results.length > 0 ? (
-                <Layout.FlexCol gap={20} mh={16}>
+                <Layout.FlexCol gap={20} w="100%">
                   {discoverData.map((page) =>
                     page.results?.map((item, index) => renderDiscoverItem(item, index)),
                   )}


### PR DESCRIPTION
## Summary
- Extract `music_tracks` from discover API response instead of separate playlist fetch
- Add oEmbed fallback to `SpotifyManager` for when Spotify credentials are unavailable
- Update `SharedPlaylistSection` UI to match Figma prototype (100px album art, 28px profile overlay with white border)
- Add `DiscoverMusicTrack` type and `Note` support to discover models

## Test plan
- [ ] Verify Discover page shows Spotify music section with album art from oEmbed
- [ ] Verify clicking album art opens MusicDetailBottomSheet
- [ ] Verify profile overlay on album art navigates to user profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)