### PR TITLE
feat: fix friend feed music click and add mood emoji

### DIFF
--- a/src/components/check-in/my-check-in-card/MyCheckInCard.tsx
+++ b/src/components/check-in/my-check-in-card/MyCheckInCard.tsx
@@ -1,43 +1,24 @@
-import { Track } from '@spotify/web-api-ts-sdk';
-import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import EmojiItem from '@components/_common/emoji-item/EmojiItem';
 import SpotifyMusic from '@components/music/spotify-music/SpotifyMusic';
 import SocialBatteryChip from '@components/profile/social-batter-chip/SocialBatteryChip';
 import { Layout, SvgIcon } from '@design-system';
-import { usePostAppMessage } from '@hooks/useAppMessage';
 import useAsyncEffect from '@hooks/useAsyncEffect';
-import SpotifyManager from '@libs/SpotifyManager';
 import { SocialBattery } from '@models/checkIn';
 import { useBoundStore } from '@stores/useBoundStore';
 import { Container } from './MyCheckInCard.styled';
 
 function MyCheckInCard() {
   const navigate = useNavigate();
-  const postMessage = usePostAppMessage();
 
   const { checkIn, fetchCheckIn } = useBoundStore((state) => ({
     checkIn: state.checkIn,
     fetchCheckIn: state.fetchCheckIn,
   }));
 
-  const [trackData, setTrackData] = useState<Track | null>(null);
-
   useAsyncEffect(async () => {
     await fetchCheckIn();
   }, []);
-
-  useEffect(() => {
-    if (!checkIn?.track_id) {
-      setTrackData(null);
-      return;
-    }
-    const spotifyManager = SpotifyManager.getInstance();
-    spotifyManager
-      .getTrack(checkIn.track_id)
-      .then(setTrackData)
-      .catch(() => setTrackData(null));
-  }, [checkIn?.track_id]);
 
   const { social_battery, track_id, mood, description } = checkIn || {};
 
@@ -47,16 +28,6 @@ function MyCheckInCard() {
     navigate('/check-in/edit');
   };
 
-  const handleClickMusic = () => {
-    if (!trackData) return;
-    const url = trackData.external_urls.spotify;
-    if (window.ReactNativeWebView) {
-      postMessage('OPEN_BROWSER', { url });
-    } else {
-      window.open(url, '_blank');
-    }
-  };
-
   if (!hasCheckIn) return null;
 
   return (
@@ -64,12 +35,12 @@ function MyCheckInCard() {
       <Layout.FlexRow w="100%" style={{ flexWrap: 'wrap' }} gap={4} alignItems="center">
         {/* Music chip */}
         {track_id && (
-          <Layout.FlexRow onClick={handleClickMusic} style={{ minWidth: 0, cursor: 'pointer' }}>
+          <Layout.FlexRow style={{ minWidth: 0, cursor: 'pointer' }}>
             <SpotifyMusic
               track={track_id}
               useAlbumImg
               fontType="body-small"
-              onClick={handleClickMusic}
+              onClick={handleClickEdit}
             />
           </Layout.FlexRow>
         )}

--- a/src/components/friends/friend-item-with-updates/FriendItemWithUpdates.tsx
+++ b/src/components/friends/friend-item-with-updates/FriendItemWithUpdates.tsx
@@ -1,5 +1,6 @@
 import { MouseEvent, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import EmojiItem from '@components/_common/emoji-item/EmojiItem';
 import Icon from '@components/_common/icon/Icon';
 import ProfileImage from '@components/_common/profile-image/ProfileImage';
 import CheckInDetailBottomSheet from '@components/check-in/check-in-detail-bottom-sheet/CheckInDetailBottomSheet';
@@ -8,8 +9,6 @@ import EditConnectionsBottomSheet from '@components/profile/edit-connections/Edi
 import SocialBatteryChip from '@components/profile/social-batter-chip/SocialBatteryChip';
 import { FeatureFlagKey } from '@constants/featureFlag';
 import { Layout, SvgIcon, Typo } from '@design-system';
-import { usePostAppMessage } from '@hooks/useAppMessage';
-import SpotifyManager from '@libs/SpotifyManager';
 import { Connection, UpdatedProfile } from '@models/api/friends';
 import { SocialBattery } from '@models/checkIn';
 import { RecentPost } from '@models/post';
@@ -32,12 +31,12 @@ function FriendItemWithUpdates({ user, recentPost, onConnectionChanged }: Props)
     unread_ping_count,
     track_id,
     description,
+    mood,
     social_battery,
     connection_status,
   } = user;
 
   const navigate = useNavigate();
-  const postMessage = usePostAppMessage();
   const { featureFlags } = useBoundStore(UserSelector);
 
   const [isEditConnectionsBottomSheetVisible, setIsEditConnectionsBottomSheetVisible] =
@@ -59,22 +58,6 @@ function FriendItemWithUpdates({ user, recentPost, onConnectionChanged }: Props)
     if (featureFlags?.[FeatureFlagKey.FRIEND_REQUEST_TYPE]) {
       setIsEditConnectionsBottomSheetVisible(true);
     }
-  };
-
-  const handleClickMusic = () => {
-    if (!track_id) return;
-    const spotifyManager = SpotifyManager.getInstance();
-    spotifyManager
-      .getTrack(track_id)
-      .then((trackData) => {
-        const url = trackData.external_urls.spotify;
-        if (window.ReactNativeWebView) {
-          postMessage('OPEN_BROWSER', { url });
-        } else {
-          window.open(url, '_blank');
-        }
-      })
-      .catch(() => {});
   };
 
   const handleClickCheckInChip = () => {
@@ -140,15 +123,16 @@ function FriendItemWithUpdates({ user, recentPost, onConnectionChanged }: Props)
             <Layout.FlexRow style={{ minWidth: 0, flex: 1, overflow: 'hidden' }}>
               <SpotifyMusic
                 track={track_id}
+                sharer={user}
                 fontType="label-large"
                 useAlbumImg
-                onClick={handleClickMusic}
+                useDetailBottomSheet
               />
             </Layout.FlexRow>
           )}
         </Layout.FlexRow>
         <Layout.FlexRow style={{ flexWrap: 'wrap' }} gap={4}>
-          {description && (
+          {(mood || description) && (
             <Layout.FlexRow
               bgColor="WHITE"
               gap={4}
@@ -160,7 +144,15 @@ function FriendItemWithUpdates({ user, recentPost, onConnectionChanged }: Props)
               style={{ flexShrink: 0, cursor: 'pointer' }}
               onClick={handleClickCheckInChip}
             >
-              <Typo type="label-large">{description}</Typo>
+              {mood && (
+                <EmojiItem
+                  emojiString={mood}
+                  size={16}
+                  bgColor="TRANSPARENT"
+                  outline="TRANSPARENT"
+                />
+              )}
+              {description && <Typo type="label-large">{description}</Typo>}
             </Layout.FlexRow>
           )}
           {hasNewPost && (
@@ -187,7 +179,7 @@ function FriendItemWithUpdates({ user, recentPost, onConnectionChanged }: Props)
         username={username}
         profileImage={profile_image}
         socialBattery={social_battery}
-        trackId={track_id}
+        mood={mood}
         description={description}
       />
 

--- a/src/models/api/friends.ts
+++ b/src/models/api/friends.ts
@@ -21,6 +21,7 @@ export interface UpdatedProfile extends User {
   unread_cnt: number;
   track_id?: string;
   description: string;
+  mood?: string;
   unread_ping_count: number;
   social_battery?: SocialBattery | null;
   recent_post?: RecentPost;


### PR DESCRIPTION
## Summary
- **MyCheckInCard**: Clicking the Spotify music chip now navigates to check-in edit page instead of trying to `window.open()` (which was blocked in preview)
- **FriendItemWithUpdates**: Friend's music chip now opens `MusicDetailBottomSheet` instead of `window.open()`, showing album art, track info, and "Listen on Spotify" button
- **Mood emoji**: Added mood emoji display on friend items alongside the description chip
- **CheckInDetailBottomSheet**: Removed duplicate Spotify track display (now handled by SpotifyMusic's own bottom sheet)

## Test plan
- [ ] Click own music chip on Friends page → navigates to /check-in/edit
- [ ] Click friend's music chip → opens MusicDetailBottomSheet with track details
- [ ] Click social battery/description → opens CheckInDetailBottomSheet without Spotify section
- [ ] Verify mood emoji appears next to description on friend items

🤖 Generated with [Claude Code](https://claude.com/claude-code)