### PR TITLE
feat: replace Questions tab with Share tab and update visibility

### DIFF
--- a/public/icons/share_active.svg
+++ b/public/icons/share_active.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Heart shape representing sharing/connection -->
+  <path d="M12 21.35L10.55 20.03C5.4 15.36 2 12.28 2 8.5C2 5.42 4.42 3 7.5 3C9.24 3 10.91 3.81 12 5.09C13.09 3.81 14.76 3 16.5 3C19.58 3 22 5.42 22 8.5C22 12.28 18.6 15.36 13.45 20.04L12 21.35Z" fill="#8700FF"/>
+</svg>

--- a/public/icons/share_inactive.svg
+++ b/public/icons/share_inactive.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Heart shape representing sharing/connection -->
+  <path d="M12 21.35L10.55 20.03C5.4 15.36 2 12.28 2 8.5C2 5.42 4.42 3 7.5 3C9.24 3 10.91 3.81 12 5.09C13.09 3.81 14.76 3 16.5 3C19.58 3 22 5.42 22 8.5C22 12.28 18.6 15.36 13.45 20.04L12 21.35Z" fill="#A0A0A0"/>
+</svg>

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -17,9 +17,11 @@ function Header() {
     case '/feed':
       return <CommonHeader title={t('nav_tab.feed')} />;
     case '/discover':
-      return <CommonHeader title={t('nav_tab.discover')} />;
+      return <CommonHeader title={t('header.discover')} />;
     case '/my':
       return <CommonHeader title={t('header.my')} />;
+    case '/share':
+      return <CommonHeader title={t('header.share')} />;
     case '/questions':
       return <CommonHeader title={t('header.questions')} />;
     case '/chats':

--- a/src/components/header/side-menu/SideMenu.tsx
+++ b/src/components/header/side-menu/SideMenu.tsx
@@ -19,7 +19,7 @@ import { useBoundStore } from '@stores/useBoundStore';
 
 const SIDE_MENU_LIST = [
   { key: 'explore_friends', path: '/friends/explore' },
-  // { key: 'questions', path: '/questions' },
+  { key: 'questions', path: '/questions' },
   { key: 'settings', path: '/settings' },
 ];
 

--- a/src/components/note/new-note-content/NewNoteContent.tsx
+++ b/src/components/note/new-note-content/NewNoteContent.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, useRef, useState } from 'react';
+import React, { ChangeEvent, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import ProfileImage from '@components/_common/profile-image/ProfileImage';
 import { DEFAULT_MARGIN } from '@constants/layout';
@@ -20,9 +20,10 @@ import { NoteInput } from './NoteInputBox.styled';
 interface NoteInformationProps {
   noteInfo: NewNoteForm;
   setNoteInfo: React.Dispatch<React.SetStateAction<NewNoteForm>>;
+  autoOpenImagePicker?: boolean;
 }
 
-function NewNoteContent({ noteInfo, setNoteInfo }: NoteInformationProps) {
+function NewNoteContent({ noteInfo, setNoteInfo, autoOpenImagePicker }: NoteInformationProps) {
   const [t] = useTranslation('translation');
   const { openToast } = useBoundStore((state) => ({ openToast: state.openToast }));
   const { myProfile } = useBoundStore((state) => ({ myProfile: state.myProfile }));
@@ -35,6 +36,16 @@ function NewNoteContent({ noteInfo, setNoteInfo }: NoteInformationProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const { isAndroid } = getMobileDeviceInfo();
   const postMessage = usePostAppMessage();
+  const hasAutoOpenedRef = useRef(false);
+
+  useEffect(() => {
+    if (autoOpenImagePicker && !hasAutoOpenedRef.current) {
+      hasAutoOpenedRef.current = true;
+      // Delay slightly to ensure DOM is ready
+      const timer = setTimeout(() => onClickAdd(), 100);
+      return () => clearTimeout(timer);
+    }
+  }, [autoOpenImagePicker]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // 앱에서 파일 선택 완료 시 호출되는 콜백
   const handleFileSelected = async (data: FileSelectedData) => {
@@ -190,9 +201,9 @@ function NewNoteContent({ noteInfo, setNoteInfo }: NoteInformationProps) {
                 selectedVisibilities={noteInfo.visibility}
                 onChange={handleChangeVisibility}
                 availableVisibilities={[
-                  PostVisibility.FRIENDS,
+                  PostVisibility.ONLY_ME,
                   PostVisibility.CLOSE_FRIENDS,
-                  PostVisibility.FOLLOWER,
+                  PostVisibility.FRIENDS,
                   PostVisibility.PUBLIC,
                 ]}
               />

--- a/src/components/note/visibility-multi-select/VisibilityMultiSelect.tsx
+++ b/src/components/note/visibility-multi-select/VisibilityMultiSelect.tsx
@@ -17,29 +17,8 @@ function VisibilityMultiSelect({
   const [t] = useTranslation('translation');
 
   const handleToggleVisibility = (value: PostVisibility) => {
-    if (selectedVisibilities.includes(value)) {
-      // 체크 해제된 경우 배열에서 제거
-      if (value === PostVisibility.FRIENDS) {
-        // Friends를 해제할 때는 Friends만 제거 (Close Friends는 유지)
-        onChange(selectedVisibilities.filter((v) => v !== PostVisibility.FRIENDS));
-        return;
-      }
-      onChange(selectedVisibilities.filter((v) => v !== value));
-      return;
-    }
-
-    // 체크된 경우 배열에 추가
-    if (value === PostVisibility.FRIENDS) {
-      // Friends를 선택할 때는 Close Friends도 자동으로 선택
-      const newVisibilities = [...selectedVisibilities, PostVisibility.FRIENDS];
-      if (!newVisibilities.includes(PostVisibility.CLOSE_FRIENDS)) {
-        newVisibilities.push(PostVisibility.CLOSE_FRIENDS);
-      }
-      onChange(newVisibilities);
-      return;
-    }
-
-    onChange([...selectedVisibilities, value]);
+    // Single-select: clicking an option selects only that one
+    onChange([value]);
   };
 
   return (

--- a/src/components/tab/Tab.tsx
+++ b/src/components/tab/Tab.tsx
@@ -11,7 +11,7 @@ import { NavTabItem, StyledTabItem, TabWrapper } from './Tab.styled';
 
 interface TabItemProps {
   to: string;
-  type: 'friends' | 'my' | 'questions' | 'feed' | 'discover' | 'chats';
+  type: 'friends' | 'my' | 'share' | 'feed' | 'discover' | 'chats';
   size?: number;
   end?: boolean;
 }
@@ -78,8 +78,7 @@ export default function Tab() {
   const showFloatingButton =
     location.pathname === '/friends' ||
     location.pathname === '/feed' ||
-    location.pathname === '/my' ||
-    location.pathname === '/questions';
+    location.pathname === '/my';
 
   return (
     <TabWrapper>
@@ -88,7 +87,7 @@ export default function Tab() {
           <>
             <TabItem to="/friends" type="friends" size={28} />
             <TabItem to="/discover" type="discover" size={28} />
-            <TabItem to="/questions" type="questions" size={28} />
+            <TabItem to="/share" type="share" size={28} />
           </>
         ) : featureFlags?.friendFeed ? (
           <TabItem to="/feed" type="friends" size={28} />

--- a/src/design-system/SvgIcon/icons.ts
+++ b/src/design-system/SvgIcon/icons.ts
@@ -139,6 +139,8 @@ const questions_active = 'questions_active';
 const questions_inactive = 'questions_inactive';
 const discover_active = 'discover_active';
 const discover_inactive = 'discover_inactive';
+const share_active = 'share_active';
+const share_inactive = 'share_inactive';
 
 const delete_button = 'delete_button';
 const top_navigation_friend = 'top_navigation_friend';
@@ -292,7 +294,9 @@ export {
   search,
   search_black,
   sent_by,
+  share_active,
   share_default,
+  share_inactive,
   spotify,
   star,
   star_outline,

--- a/src/hooks/useRestoreScrollPosition.tsx
+++ b/src/hooks/useRestoreScrollPosition.tsx
@@ -6,6 +6,7 @@ const SESSION_STORAGE_KEY = 'WHOAMI_TODAY_SCROLL_POSITION';
 export interface ScrollPositionStore {
   friendsPage?: number;
   questionsPage?: number;
+  sharePage?: number;
   myPage?: number;
   userPage?: number;
   feeds?: number;

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -118,7 +118,8 @@
     "header": {
         "my": "My Profile",
         "questions": "Questions",
-        "share": "Share"
+        "share": "Share",
+        "discover": "Daily Discover"
     },
     "home": {
         "moment": {

--- a/src/i18n/locales/ko/translation.json
+++ b/src/i18n/locales/ko/translation.json
@@ -118,7 +118,8 @@
   "header": {
     "my": "내 프로필",
     "questions": "질문",
-    "share": "공유"
+    "share": "공유",
+    "discover": "오늘의 발견"
   },
   "home": {
     "moment": {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -54,6 +54,7 @@ import DeleteAccount from './routes/settings/DeleteAccount';
 import EditProfile from './routes/settings/EditProfile';
 import ResetPassword from './routes/settings/ResetPassword';
 import Settings from './routes/settings/Settings';
+import Share from './routes/share/Share';
 import Email from './routes/sign-up/Email';
 import Info from './routes/sign-up/Info';
 import NotiSettings from './routes/sign-up/NotiSettings';
@@ -111,6 +112,10 @@ const router = createBrowserRouter([
       {
         path: 'feed',
         children: [{ path: '', element: <FriendsFeed /> }],
+      },
+      {
+        path: 'share',
+        children: [{ path: '', element: <Share /> }],
       },
       {
         path: 'questions',

--- a/src/models/post.ts
+++ b/src/models/post.ts
@@ -115,12 +115,14 @@ export interface Note extends ContentsCommon {
   current_user_read: boolean;
   is_edited: boolean;
   visibility: PostVisibility;
+  share_type?: ShareType;
 }
 
 export interface NewNoteForm {
   content: string;
   images?: CroppedImg[];
   visibility: PostVisibility[];
+  share_type?: ShareType;
 }
 // Response list for questions
 /** deprecated */
@@ -189,11 +191,17 @@ export type RecentPost = {
   comment_count: number | null;
 };
 
+export enum ShareType {
+  REGULAR = 'regular',
+  TMI_OF_THE_DAY = 'tmi_of_the_day',
+  PHOTO_OF_THE_DAY = 'photo_of_the_day',
+}
+
 export enum PostVisibility {
-  FRIENDS = 'friends',
+  ONLY_ME = 'only_me',
   CLOSE_FRIENDS = 'close_friends',
-  FOLLOWER = 'follower', // 팔로워만 볼 수 있음
-  PUBLIC = 'public', // 모두 볼 수 있음
+  FRIENDS = 'friends',
+  PUBLIC = 'public',
 }
 
 export interface SelectInterest extends ContentsCommon {

--- a/src/routes/notes/NewNote.tsx
+++ b/src/routes/notes/NewNote.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 import NewNoteHeader from '@components/note/new-note-header/NewNoteHeader';
-import { NewNoteForm } from '@models/post';
+import { NewNoteForm, ShareType } from '@models/post';
 import { convertImagesToFiles } from '@utils/convertImageToFiles';
 import NewNoteContent from '../../components/note/new-note-content/NewNoteContent';
 import { MainScrollContainer } from '../Root';
@@ -12,29 +12,36 @@ function NewNote() {
   const [t] = useTranslation('translation', { keyPrefix: 'notes.note_header' });
 
   const status = location.state?.status;
+  const shareType: ShareType | undefined = location.state?.shareType;
+  const isEditing = location.state?.post != null;
   // location.state가 없으면 새 노트, 있으면 수정 노트
-  const title = !location.state ? t('new_note') : t('edit_note');
-  const noteId = location.state?.post.id || '';
-  const content = location.state?.post.content || '';
-  const visibility = location.state?.post.visibility || [];
-  const images = useMemo(() => location.state?.post.images || [], [location.state?.post.images]);
+  const title = !isEditing ? t('new_note') : t('edit_note');
+  const noteId = location.state?.post?.id || '';
+  const content = location.state?.post?.content || '';
+  const visibility = location.state?.post?.visibility || [];
+  const images = useMemo(() => location.state?.post?.images || [], [location.state?.post?.images]);
 
   const [noteInfo, setNoteInfo] = useState<NewNoteForm>({
     content,
     images: [],
     visibility,
+    share_type: shareType,
   });
 
   useEffect(() => {
-    if (location.state) {
+    if (isEditing) {
       convertImagesToFiles(images, setNoteInfo);
     }
-  }, [images, location.state]);
+  }, [images, isEditing]);
 
   return (
     <MainScrollContainer>
       <NewNoteHeader noteId={noteId} title={title} noteInfo={noteInfo} status={status} />
-      <NewNoteContent noteInfo={noteInfo} setNoteInfo={setNoteInfo} />
+      <NewNoteContent
+        noteInfo={noteInfo}
+        setNoteInfo={setNoteInfo}
+        autoOpenImagePicker={shareType === ShareType.PHOTO_OF_THE_DAY}
+      />
     </MainScrollContainer>
   );
 }

--- a/src/routes/responses/NewResponse.tsx
+++ b/src/routes/responses/NewResponse.tsx
@@ -194,9 +194,9 @@ function NewResponse() {
               selectedVisibilities={visibilityList}
               onChange={handleChangeVisibility}
               availableVisibilities={[
-                PostVisibility.FRIENDS,
+                PostVisibility.ONLY_ME,
                 PostVisibility.CLOSE_FRIENDS,
-                PostVisibility.FOLLOWER,
+                PostVisibility.FRIENDS,
                 PostVisibility.PUBLIC,
               ]}
             />

--- a/src/routes/share/Share.styled.ts
+++ b/src/routes/share/Share.styled.ts
@@ -1,0 +1,42 @@
+import styled from 'styled-components';
+
+export const TmiInputBarWrapper = styled.div`
+  width: 100%;
+  background-color: ${({ theme }) => theme.PRIMARY};
+  padding: 24px 16px;
+`;
+
+export const TmiInputBar = styled.button`
+  width: 100%;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 20px;
+  background-color: ${({ theme }) => theme.WHITE};
+  border: 1.4px solid ${({ theme }) => theme.LIGHT_GRAY};
+  border-radius: 30px;
+  cursor: pointer;
+`;
+
+export const PhotoOfTheDayCard = styled.button`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  background-color: ${({ theme }) => theme.TERTIARY_PINK};
+  border-radius: 12px;
+  cursor: pointer;
+  text-align: left;
+`;
+
+export const SharePhotoButton = styled.div`
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px 12px;
+  background-color: ${({ theme }) => theme.DARK};
+  border-radius: 12px;
+`;

--- a/src/routes/share/Share.tsx
+++ b/src/routes/share/Share.tsx
@@ -1,0 +1,110 @@
+import { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import useSWR from 'swr';
+
+import PromptCard from '@components/_common/prompt/PromptCard';
+import PullToRefresh from '@components/_common/pull-to-refresh/PullToRefresh';
+import { DEFAULT_MARGIN } from '@constants/layout';
+import { Layout, SvgIcon, Typo } from '@design-system';
+import { useRestoreScrollPosition } from '@hooks/useRestoreScrollPosition';
+import { DailyQuestion, ShareType } from '@models/post';
+import { getMe } from '@utils/apis/my';
+import { getTodayQuestions } from '@utils/apis/question';
+
+import { MainScrollContainer } from '../Root';
+import {
+  PhotoOfTheDayCard,
+  SharePhotoButton,
+  TmiInputBar,
+  TmiInputBarWrapper,
+} from './Share.styled';
+
+function Share() {
+  const [t] = useTranslation('translation');
+  const navigate = useNavigate();
+  const { scrollRef } = useRestoreScrollPosition('sharePage');
+
+  const { data: todayQuestions, mutate } = useSWR<DailyQuestion[]>(
+    '/qna/questions/daily/',
+    getTodayQuestions,
+  );
+
+  const handleRefresh = useCallback(async () => {
+    await Promise.all([mutate(), getMe()]);
+  }, [mutate]);
+
+  const handleClickTmiInput = () => {
+    navigate('/notes/new', {
+      state: { shareType: ShareType.TMI_OF_THE_DAY },
+    });
+  };
+
+  const handleClickSharePhoto = () => {
+    navigate('/notes/new', {
+      state: { shareType: ShareType.PHOTO_OF_THE_DAY },
+    });
+  };
+
+  return (
+    <MainScrollContainer scrollRef={scrollRef}>
+      <PullToRefresh onRefresh={handleRefresh}>
+        <Layout.FlexCol w="100%">
+          {/* TMI Input Bar */}
+          <TmiInputBarWrapper>
+            <TmiInputBar type="button" onClick={handleClickTmiInput}>
+              <Layout.FlexRow gap={8} alignItems="center">
+                <SvgIcon name="add_default" size={24} color="PRIMARY" />
+                <Typo type="body-medium" color="DARK_GRAY">
+                  {t('share_page.tmi_placeholder')}
+                </Typo>
+              </Layout.FlexRow>
+              <SvgIcon name="chat_media_image" size={24} fill="DARK_GRAY" />
+            </TmiInputBar>
+          </TmiInputBarWrapper>
+
+          <Layout.FlexCol pv={14} w="100%" ph={DEFAULT_MARGIN} gap={20} pb={100}>
+            {/* Photo of the Day Card */}
+            <PhotoOfTheDayCard type="button" onClick={handleClickSharePhoto}>
+              <Typo type="head-line" color="WHITE" bold>
+                {t('share_page.photo_of_the_day')}
+              </Typo>
+              <Typo type="body-medium" color="WHITE">
+                {t('share_page.photo_description')}
+              </Typo>
+              <SharePhotoButton>
+                <Typo type="body-large" color="WHITE">
+                  {t('share_page.share_photo')}
+                </Typo>
+              </SharePhotoButton>
+            </PhotoOfTheDayCard>
+
+            {/* Questions of the Day */}
+            <Layout.FlexCol w="100%" gap={10}>
+              <Typo type="body-large" color="BLACK" bold>
+                {t('share_page.questions_of_the_day')}
+              </Typo>
+              {todayQuestions && todayQuestions.length > 0 ? (
+                todayQuestions.map((question) => (
+                  <PromptCard
+                    key={question.id}
+                    id={question.id}
+                    content={question.content}
+                    widthMode="full"
+                    authorDetail={question.author_detail}
+                  />
+                ))
+              ) : (
+                <Typo type="body-medium" color="MEDIUM_GRAY">
+                  {t('no_contents.question')}
+                </Typo>
+              )}
+            </Layout.FlexCol>
+          </Layout.FlexCol>
+        </Layout.FlexCol>
+      </PullToRefresh>
+    </MainScrollContainer>
+  );
+}
+
+export default Share;

--- a/src/utils/apis/note.ts
+++ b/src/utils/apis/note.ts
@@ -1,5 +1,5 @@
 import { PaginationResponse } from '@models/api/common';
-import { Comment, Like, NewNoteForm, Note, PostReaction, PostVisibility } from '@models/post';
+import { Comment, Like, NewNoteForm, Note, PostReaction } from '@models/post';
 import axios, { axiosFormDataInstance } from '@utils/apis/axios';
 import { objectFormDataSerializer } from '@utils/validateHelpers';
 
@@ -44,11 +44,10 @@ export const postNote = async (noteData: NewNoteForm) => {
     });
   }
   if (noteData.visibility && noteData.visibility.length > 0) {
-    // Note API: 'followers'(복수). PostVisibility.FOLLOWER='follower' → 'followers' 변환
-    const noteVisibility = noteData.visibility.map((v) =>
-      v === PostVisibility.FOLLOWER ? 'followers' : v,
-    );
-    formData.append('visibility', JSON.stringify(noteVisibility));
+    formData.append('visibility', JSON.stringify(noteData.visibility));
+  }
+  if (noteData.share_type) {
+    formData.append('share_type', noteData.share_type);
   }
 
   const { data } = await axiosFormDataInstance.post<Note>(`notes/`, formData);
@@ -73,11 +72,7 @@ export const patchNote = async (noteId: number, noteData: NewNoteForm) => {
     });
   }
   if (noteData.visibility && noteData.visibility.length > 0) {
-    // Note API: form-data에 JSON 문자열로 배열 전송. 'follower' → 'followers' 변환
-    const noteVisibility = noteData.visibility.map((v) =>
-      v === PostVisibility.FOLLOWER ? 'followers' : v,
-    );
-    formData.append('visibility', JSON.stringify(noteVisibility));
+    formData.append('visibility', JSON.stringify(noteData.visibility));
   }
 
   const { data } = await axiosFormDataInstance.patch<Note>(`notes/${noteId}/`, formData);


### PR DESCRIPTION
## Summary
- Replace Questions tab with Share tab featuring TMI of the Day and Photo of the Day sharing options
- Add heart icon (filled SVG) for the Share tab in bottom navigation
- Update visibility options from (Friends, Close Friends, Followers, Public) to (Only Me, Close Friends, Friends, Public) with single-select behavior
- Add ShareType enum and share_type field to Note model/API
- Add Daily Discover as separate page header title distinct from nav tab label
- Move Questions link to side menu

## Test plan
- [ ] Verify Share tab appears in bottom navigation with heart icon
- [ ] Verify TMI of the Day and Photo of the Day options work on Share page
- [ ] Verify visibility selector shows Only Me, Close Friends, Friends, Public
- [ ] Verify only one visibility option can be selected at a time
- [ ] Verify posting with each visibility option works end-to-end
- [ ] Verify Questions page is accessible from side menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)