### PR TITLE
feat: always show bottom nav on note detail pages

### DIFF
--- a/src/routes/Root.tsx
+++ b/src/routes/Root.tsx
@@ -1,5 +1,5 @@
 import React, { CSSProperties, ReactNode, RefObject, UIEvent, useEffect } from 'react';
-import { Outlet, useLocation } from 'react-router-dom';
+import { Outlet } from 'react-router-dom';
 import { SWRConfig } from 'swr';
 import NotiPermissionBanner, {
   NOTI_PERMISSION_BANNER_HEIGHT,
@@ -21,7 +21,6 @@ function Root() {
   const { isMobile } = getMobileDeviceInfo();
   const { initializeFcm } = useFcm();
   const postMessage = usePostAppMessage();
-  const location = useLocation();
 
   useAsyncEffect(async () => {
     if (isMobile) return;
@@ -42,19 +41,13 @@ function Root() {
     console.debug('featureFlags', featureFlags);
   }, [featureFlags]);
 
-  // NoteDetail 페이지일 때 Tab 숨기기
-  // 경로 패턴: /notes/:noteId 또는 /users/:username/notes/:noteId
-  const isNoteDetailPage =
-    /^\/notes\/\d+/.test(location.pathname) ||
-    /^\/users\/[^/]+\/notes\/\d+/.test(location.pathname);
-
   return (
     <SWRConfig value={{ provider: () => new Map() }}>
       <Layout.FlexRow justifyContent="center" bgColor="BLACK" w="100%">
         <RootContainer w="100%" bgColor="WHITE" id="root-container">
           <Header />
           <Outlet />
-          {!isNoteDetailPage && <Tab />}
+          <Tab />
         </RootContainer>
       </Layout.FlexRow>
     </SWRConfig>

--- a/src/routes/notes/NoteDetail.tsx
+++ b/src/routes/notes/NoteDetail.tsx
@@ -8,7 +8,7 @@ import CommentList from '@components/comment-list/CommentList';
 import NoteItem from '@components/note/note-item/NoteItem';
 import NoteLoader from '@components/note/note-loader/NoteLoader';
 import SubHeader from '@components/sub-header/SubHeader';
-import { TITLE_HEADER_HEIGHT } from '@constants/layout';
+import { BOTTOM_TABBAR_HEIGHT, TITLE_HEADER_HEIGHT } from '@constants/layout';
 import { Layout } from '@design-system';
 import useAsyncEffect from '@hooks/useAsyncEffect';
 import { FetchState } from '@models/api/common';
@@ -55,7 +55,7 @@ export function NoteDetail() {
   };
 
   return (
-    <MainScrollContainer pb={0}>
+    <MainScrollContainer>
       <SubHeader
         title={
           noteDetail.data
@@ -85,7 +85,7 @@ export function NoteDetail() {
             setReload={setReload}
             inputFocus={inputFocus}
             setInputFocus={setInputFocus}
-            bottomOffset={0}
+            bottomOffset={BOTTOM_TABBAR_HEIGHT}
           />
         </Layout.FlexCol>
       )}


### PR DESCRIPTION
## Summary
- Remove the isNoteDetailPage condition that hid the bottom Tab component on note detail pages
- Add BOTTOM_TABBAR_HEIGHT offset to comment list on NoteDetail to prevent the comment input from overlapping the tab bar
- Improves navigation usability — users can now navigate away from post detail pages without using the back button

## Test plan
- [ ] Verify bottom navigation tab bar is visible on note detail pages
- [ ] Verify comment input area does not overlap with the tab bar
- [ ] Verify tab navigation works correctly from note detail pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)