### PR TITLE
feat: improve Discover interest/persona sections and card layout

### DIFF
--- a/src/components/discover/SelectInterestSection/SelectInterestSection.styled.ts
+++ b/src/components/discover/SelectInterestSection/SelectInterestSection.styled.ts
@@ -1,14 +1,12 @@
 import styled from 'styled-components';
-import { SCREEN_WIDTH } from '@constants/layout';
 import { Colors, Layout } from '@design-system';
 
 export const SelectInterestSectionWrapper = styled(Layout.FlexCol)`
-  background-color: ${Colors.TERTIARY_PINK};
+  background-color: ${Colors.TERTIARY_BLUE};
   border-radius: 16px;
   padding: 24px 0px;
   gap: 20px;
-  width: ${SCREEN_WIDTH - 32}px;
-  max-width: 100%;
+  width: 100%;
   box-sizing: border-box;
   overflow: hidden;
 `;
@@ -28,33 +26,20 @@ export const Title = styled.h2`
 
 export const InterestGrid = styled.div`
   display: flex;
-  flex-direction: column;
+  flex-wrap: wrap;
   gap: 8px;
   width: 100%;
-  max-width: 100%;
-  overflow-x: auto;
-  overflow-y: hidden;
   box-sizing: border-box;
   padding: 0 16px;
-
-  /* 스크롤바 숨김 */
-  &::-webkit-scrollbar {
-    display: none;
-  }
-  -ms-overflow-style: none;
-  scrollbar-width: none;
-
-  /* 터치 스크롤 활성화 */
-  -webkit-overflow-scrolling: touch;
 `;
 
-export const InterestRow = styled.div`
+export const ExpandToggle = styled.div`
   display: flex;
-  flex-wrap: nowrap;
-  gap: 8px;
-  min-width: max-content;
-  flex-shrink: 0;
-  box-sizing: border-box;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  padding: 4px 0;
+  cursor: pointer;
 `;
 
 export const SaveButtonWrapper = styled.div`

--- a/src/components/discover/SelectInterestSection/SelectInterestSection.tsx
+++ b/src/components/discover/SelectInterestSection/SelectInterestSection.tsx
@@ -2,8 +2,13 @@ import { useEffect, useState } from 'react';
 import HashTagPill from '@components/_common/hash-tag-pill/HashTagPill';
 import Icon from '@components/_common/icon/Icon';
 import { Button, Typo } from '@design-system';
+import { MyProfile } from '@models/api/user';
 import { InterestItem } from '@models/discover';
+import { useBoundStore } from '@stores/useBoundStore';
+import { editProfile } from '@utils/apis/my';
 import * as S from './SelectInterestSection.styled';
+
+const COLLAPSED_COUNT = 10;
 
 interface SelectInterestSectionProps {
   interestList?: InterestItem[];
@@ -16,10 +21,14 @@ function SelectInterestSection({
   isSaved = false,
   onSave,
 }: SelectInterestSectionProps) {
+  const { updateMyProfile, openToast } = useBoundStore((state) => ({
+    updateMyProfile: state.updateMyProfile,
+    openToast: state.openToast,
+  }));
   const [selectedInterests, setSelectedInterests] = useState<string[]>([]);
+  const [isExpanded, setIsExpanded] = useState(false);
 
   useEffect(() => {
-    // API에서 받은 데이터로 초기 선택 상태 설정
     const initialSelected = interestList
       .filter((item) => item.is_selected)
       .map((item) => item.content);
@@ -37,35 +46,42 @@ function SelectInterestSection({
 
   const handleSave = () => {
     onSave?.();
-    // TODO: 실제 저장 API 연동
+
+    editProfile({
+      profile: {
+        user_interests: selectedInterests,
+      },
+      onSuccess: (data: MyProfile) => {
+        updateMyProfile({ ...data });
+      },
+      onError: (error) => {
+        if (error.detail) openToast({ message: error.detail });
+      },
+    });
   };
 
-  // 관심사를 3줄로 나누기
-  const interestsPerRow = Math.ceil(interestList.length / 3);
-  const interestRows = [
-    interestList.slice(0, interestsPerRow),
-    interestList.slice(interestsPerRow, interestsPerRow * 2),
-    interestList.slice(interestsPerRow * 2, interestsPerRow * 3),
-  ];
+  const displayList = isExpanded ? interestList : interestList.slice(0, COLLAPSED_COUNT);
 
   return (
     <S.SelectInterestSectionWrapper>
       <S.Title>Select your interests</S.Title>
 
       <S.InterestGrid>
-        {interestRows.map((row) => (
-          <S.InterestRow key={row.map((i) => i.content).join(',')}>
-            {row.map((interestItem) => (
-              <HashTagPill
-                key={interestItem.content}
-                isSelected={selectedInterests.includes(interestItem.content)}
-                onClick={() => handleToggleInterest(interestItem.content)}
-                label={interestItem.content}
-              />
-            ))}
-          </S.InterestRow>
+        {displayList.map((interestItem) => (
+          <HashTagPill
+            key={interestItem.content}
+            isSelected={selectedInterests.includes(interestItem.content)}
+            onClick={() => handleToggleInterest(interestItem.content)}
+            label={interestItem.content}
+          />
         ))}
       </S.InterestGrid>
+
+      {interestList.length > COLLAPSED_COUNT && (
+        <S.ExpandToggle onClick={() => setIsExpanded(!isExpanded)}>
+          <Icon name={isExpanded ? 'chevron_up' : 'chevron_down'} size={20} />
+        </S.ExpandToggle>
+      )}
 
       {!isSaved ? (
         <S.SaveButtonWrapper>

--- a/src/components/discover/SelectPersonaSection/SelectPersonaSection.styled.ts
+++ b/src/components/discover/SelectPersonaSection/SelectPersonaSection.styled.ts
@@ -1,14 +1,12 @@
 import styled from 'styled-components';
-import { SCREEN_WIDTH } from '@constants/layout';
 import { Colors, Layout } from '@design-system';
 
 export const SelectPersonaSectionWrapper = styled(Layout.FlexCol)`
-  background-color: ${Colors.TERTIARY_BLUE};
+  background-color: ${Colors.PRIMARY};
   border-radius: 16px;
   padding: 24px 0px;
   gap: 20px;
-  width: ${SCREEN_WIDTH - 32}px;
-  max-width: 100%;
+  width: 100%;
   box-sizing: border-box;
   overflow: hidden;
 `;
@@ -28,33 +26,20 @@ export const Title = styled.h2`
 
 export const PersonaGrid = styled.div`
   display: flex;
-  flex-direction: column;
+  flex-wrap: wrap;
   gap: 8px;
   width: 100%;
-  max-width: 100%;
-  overflow-x: auto;
-  overflow-y: hidden;
   box-sizing: border-box;
   padding: 0 16px;
-
-  /* 스크롤바 숨김 */
-  &::-webkit-scrollbar {
-    display: none;
-  }
-  -ms-overflow-style: none;
-  scrollbar-width: none;
-
-  /* 터치 스크롤 활성화 */
-  -webkit-overflow-scrolling: touch;
 `;
 
-export const PersonaRow = styled.div`
+export const ExpandToggle = styled.div`
   display: flex;
-  flex-wrap: nowrap;
-  gap: 8px;
-  min-width: max-content;
-  flex-shrink: 0;
-  box-sizing: border-box;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  padding: 4px 0;
+  cursor: pointer;
 `;
 
 export const FriendsSection = styled(Layout.FlexRow)`

--- a/src/components/discover/SelectPersonaSection/SelectPersonaSection.tsx
+++ b/src/components/discover/SelectPersonaSection/SelectPersonaSection.tsx
@@ -10,6 +10,8 @@ import { useBoundStore } from '@stores/useBoundStore';
 import { editProfile } from '@utils/apis/my';
 import * as S from './SelectPersonaSection.styled';
 
+const COLLAPSED_COUNT = 10;
+
 // Mock data: 친구 프로필 이미지들 (처음 2개)
 const friendProfiles = friendList.slice(0, 1);
 const additionalFriendsCount = 6;
@@ -30,9 +32,9 @@ function SelectPersonaSection({
     openToast: state.openToast,
   }));
   const [selectedPersonas, setSelectedPersonas] = useState<string[]>([]);
+  const [isExpanded, setIsExpanded] = useState(false);
 
   useEffect(() => {
-    // API에서 받은 데이터로 초기 선택 상태 설정
     const initialSelected = personaList.filter((item) => item.is_selected).map((item) => item.key);
     setSelectedPersonas(initialSelected);
   }, [personaList]);
@@ -62,32 +64,28 @@ function SelectPersonaSection({
     });
   };
 
-  // Persona를 3줄로 나누기
-  const personasPerRow = Math.ceil(personaList.length / 3);
-  const personaRows = [
-    personaList.slice(0, personasPerRow),
-    personaList.slice(personasPerRow, personasPerRow * 2),
-    personaList.slice(personasPerRow * 2, personasPerRow * 3),
-  ];
+  const displayList = isExpanded ? personaList : personaList.slice(0, COLLAPSED_COUNT);
 
   return (
     <S.SelectPersonaSectionWrapper>
       <S.Title>Select your Persona</S.Title>
 
       <S.PersonaGrid>
-        {personaRows.map((row) => (
-          <S.PersonaRow key={row.map((p) => p.key).join(',')}>
-            {row.map((personaItem) => (
-              <HashTagPill
-                key={personaItem.key}
-                isSelected={selectedPersonas.includes(personaItem.key)}
-                onClick={() => handleTogglePersona(personaItem.key)}
-                label={personaItem.label}
-              />
-            ))}
-          </S.PersonaRow>
+        {displayList.map((personaItem) => (
+          <HashTagPill
+            key={personaItem.key}
+            isSelected={selectedPersonas.includes(personaItem.key)}
+            onClick={() => handleTogglePersona(personaItem.key)}
+            label={personaItem.label}
+          />
         ))}
       </S.PersonaGrid>
+
+      {personaList.length > COLLAPSED_COUNT && (
+        <S.ExpandToggle onClick={() => setIsExpanded(!isExpanded)}>
+          <Icon name={isExpanded ? 'chevron_up' : 'chevron_down'} size={20} />
+        </S.ExpandToggle>
+      )}
 
       <S.FriendsSection>
         <S.FriendsProfileList>

--- a/src/routes/discover/Discover.styled.ts
+++ b/src/routes/discover/Discover.styled.ts
@@ -13,6 +13,9 @@ export const ScrollableFilterRow = styled(Layout.FlexRow)`
 `;
 
 export const AnimatedCardWrapper = styled.div<{ $isAnimating: boolean }>`
+  width: 100%;
+  max-width: 100%;
+  overflow: hidden;
   transition: transform 0.5s ease-in-out, opacity 0.5s ease-in-out;
   transform: translateX(0);
   opacity: 1;


### PR DESCRIPTION
## Summary
- Refactor Interest and Persona sections from horizontal scroll rows to flex-wrap grid with expand/collapse toggle
- Wire up Save button to `editProfile` API for persisting interest selections
- Fix AnimatedCardWrapper overflow causing horizontal scroll on mobile
- Update section background colors for visual distinction

## Test plan
- [ ] Verify interest/persona sections display as wrapped grid (not horizontal scroll)
- [ ] Verify expand/collapse toggle shows first 10 items when collapsed
- [ ] Verify Save button persists selections via API
- [ ] Verify no horizontal overflow on mobile discover page

🤖 Generated with [Claude Code](https://claude.com/claude-code)