### PR TITLE
feat: show mutual friends and shared traits on posts

### DIFF
--- a/src/components/note/note-item/NoteItem.tsx
+++ b/src/components/note/note-item/NoteItem.tsx
@@ -157,10 +157,48 @@ function NoteItem({ note, isMyPage, displayType = 'LIST', refresh }: NoteItemPro
                 </Typo>
                 {!current_user_read && !isMyPage && <UpdatedLabel />}
               </Layout.FlexRow>
-              <Layout.FlexRow alignItems="center" gap={4}>
+              <Layout.FlexRow alignItems="center" gap={4} style={{ flexWrap: 'wrap' }}>
                 <Typo type="label-medium" color="MEDIUM_GRAY">
                   {created_at && convertTimeDiffByString({ day: new Date(created_at) })}
                 </Typo>
+                {!isMyPage &&
+                  author_detail &&
+                  ((author_detail.mutual_friend_count ?? 0) > 0 ||
+                    (author_detail.mutual_interest_count ?? 0) > 0 ||
+                    (author_detail.mutual_persona_count ?? 0) > 0) && (
+                    <>
+                      {(author_detail.mutual_friend_count ?? 0) > 0 && (
+                        <>
+                          <Typo type="label-medium" color="MEDIUM_GRAY">
+                            ·
+                          </Typo>
+                          <Typo type="label-medium" color="DARK_GRAY">
+                            {author_detail.mutual_friend_count} mutual{' '}
+                            {author_detail.mutual_friend_count === 1 ? 'friend' : 'friends'}
+                          </Typo>
+                        </>
+                      )}
+                      {(author_detail.mutual_interest_count ?? 0) +
+                        (author_detail.mutual_persona_count ?? 0) >
+                        0 && (
+                        <>
+                          <Typo type="label-medium" color="MEDIUM_GRAY">
+                            ·
+                          </Typo>
+                          <Typo type="label-medium" color="DARK_GRAY">
+                            {(author_detail.mutual_interest_count ?? 0) +
+                              (author_detail.mutual_persona_count ?? 0)}{' '}
+                            shared{' '}
+                            {(author_detail.mutual_interest_count ?? 0) +
+                              (author_detail.mutual_persona_count ?? 0) ===
+                            1
+                              ? 'trait'
+                              : 'traits'}
+                          </Typo>
+                        </>
+                      )}
+                    </>
+                  )}
               </Layout.FlexRow>
               {/* Visibility scope - only shown on own page */}
               {isMyPage && visibility && (

--- a/src/components/response/response-item/ResponseItem.tsx
+++ b/src/components/response/response-item/ResponseItem.tsx
@@ -162,10 +162,48 @@ function ResponseItem({
                   </Typo>
                 </Layout.FlexRow>
                 {!current_user_read && !isMyPage && <UpdatedLabel />}
-                <Layout.FlexRow alignItems="center" gap={4}>
+                <Layout.FlexRow alignItems="center" gap={4} style={{ flexWrap: 'wrap' }}>
                   <Typo type="label-medium" color="MEDIUM_GRAY">
                     {created_at && convertTimeDiffByString({ day: new Date(created_at) })}
                   </Typo>
+                  {!isMyPage &&
+                    author_detail &&
+                    ((author_detail.mutual_friend_count ?? 0) > 0 ||
+                      (author_detail.mutual_interest_count ?? 0) > 0 ||
+                      (author_detail.mutual_persona_count ?? 0) > 0) && (
+                      <>
+                        {(author_detail.mutual_friend_count ?? 0) > 0 && (
+                          <>
+                            <Typo type="label-medium" color="MEDIUM_GRAY">
+                              ·
+                            </Typo>
+                            <Typo type="label-medium" color="DARK_GRAY">
+                              {author_detail.mutual_friend_count} mutual{' '}
+                              {author_detail.mutual_friend_count === 1 ? 'friend' : 'friends'}
+                            </Typo>
+                          </>
+                        )}
+                        {(author_detail.mutual_interest_count ?? 0) +
+                          (author_detail.mutual_persona_count ?? 0) >
+                          0 && (
+                          <>
+                            <Typo type="label-medium" color="MEDIUM_GRAY">
+                              ·
+                            </Typo>
+                            <Typo type="label-medium" color="DARK_GRAY">
+                              {(author_detail.mutual_interest_count ?? 0) +
+                                (author_detail.mutual_persona_count ?? 0)}{' '}
+                              shared{' '}
+                              {(author_detail.mutual_interest_count ?? 0) +
+                                (author_detail.mutual_persona_count ?? 0) ===
+                              1
+                                ? 'trait'
+                                : 'traits'}
+                            </Typo>
+                          </>
+                        )}
+                      </>
+                    )}
                 </Layout.FlexRow>
                 {/* Visibility scope - only shown on own page */}
                 {isMyPage && visibility && visibility.length > 0 && (


### PR DESCRIPTION
## Summary
- Display mutual friend count and shared trait count on NoteItem and ResponseItem
- Only shown when viewing others' posts (not on own page)
- Formatted as "N mutual friend(s) · N shared trait(s)" with proper pluralization
- Added flex-wrap to metadata row for proper mobile layout

## Test plan
- [ ] Verify mutual friends count appears on others' notes
- [ ] Verify shared traits count appears on others' notes
- [ ] Verify counts do not appear on own posts
- [ ] Verify proper pluralization (1 friend vs 2 friends)
- [ ] Verify layout wraps properly on narrow screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)