### PR TITLE
fix: only fetch Spotify track when bottom sheet is visible

### DIFF
--- a/src/components/check-in/check-in-detail-bottom-sheet/CheckInDetailBottomSheet.tsx
+++ b/src/components/check-in/check-in-detail-bottom-sheet/CheckInDetailBottomSheet.tsx
@@ -40,7 +40,7 @@ function CheckInDetailBottomSheet({
   const [trackData, setTrackData] = useState<Track | null>(null);
 
   useEffect(() => {
-    if (!trackId) {
+    if (!visible || !trackId) {
       setTrackData(null);
       return;
     }
@@ -49,7 +49,7 @@ function CheckInDetailBottomSheet({
       .getTrack(trackId)
       .then(setTrackData)
       .catch(() => setTrackData(null));
-  }, [trackId]);
+  }, [visible, trackId]);
 
   const handleClickGoToSpotify = () => {
     if (!trackData) return;


### PR DESCRIPTION
## Summary
- Guard Spotify track data fetch with `visible` check in CheckInDetailBottomSheet
- Prevents unnecessary API calls when the bottom sheet is not shown
- Add `visible` to useEffect dependency array for proper cleanup

## Test plan
- [ ] Verify Spotify track data loads when bottom sheet opens
- [ ] Verify no Spotify API calls when bottom sheet is hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)