### PR TITLE
feat: client-side discover filtering using category field

### DIFF
--- a/src/models/discover.ts
+++ b/src/models/discover.ts
@@ -70,10 +70,12 @@ export interface DiscoverMusicTrack {
 export type DiscoverResultItem =
   | {
       type: 'Response';
+      category?: string;
       body: ResponseCardBody;
     }
   | {
       type: 'Note';
+      category?: string;
       body: NoteCardBody;
     }
   | {

--- a/src/routes/discover/Discover.tsx
+++ b/src/routes/discover/Discover.tsx
@@ -47,9 +47,8 @@ function Discover() {
   const discoverFilterList = [DiscoverFilter.MUTUAL_FRIENDS, DiscoverFilter.MUTUAL_TRAITS];
   const { scrollRef } = useRestoreScrollPosition('discoverPage');
 
-  // Build query string with filters
-  const filterQuery = selectedFilter.length > 0 ? `?filter=${selectedFilter.join(',')}` : '';
-  const swrKey = `/user/discover/${filterQuery}`;
+  // SWR key is stable — filtering is done client-side to avoid refetch issues
+  const swrKey = '/user/discover/';
 
   const {
     targetRef,
@@ -75,10 +74,21 @@ function Discover() {
     }));
   }, [discoverData]);
 
+  // Client-side filtering by category
+  const filterItem = useCallback(
+    (item: DiscoverResultItem): boolean => {
+      if (selectedFilter.length === 0) return true;
+      // Non-post items (Question, Interest, Persona) always show
+      if (item.type !== 'Response' && item.type !== 'Note') return true;
+      return selectedFilter.includes(item.category as DiscoverFilter);
+    },
+    [selectedFilter],
+  );
+
   const handleRefresh = useCallback(async () => {
-    await Promise.all([getDiscoverFeed(null, selectedFilter), getMe()]);
+    await Promise.all([getDiscoverFeed(null), getMe()]);
     mutate();
-  }, [mutate, selectedFilter]);
+  }, [mutate]);
 
   const renderDiscoverItem = useCallback(
     (item: DiscoverResultItem, index: number) => {
@@ -139,6 +149,14 @@ function Discover() {
     ],
   );
 
+  // Check if there are any visible items after filtering
+  const hasVisibleItems = useMemo(() => {
+    if (!discoverData) return false;
+    return discoverData.some((page) =>
+      page.results?.some((item) => filterItem(item) && renderDiscoverItem(item, 0) !== null),
+    );
+  }, [discoverData, filterItem, renderDiscoverItem]);
+
   return (
     <>
       <S.HideScrollbarGlobalStyle />
@@ -187,12 +205,12 @@ function Discover() {
                   <NoteLoader />
                   <NoteLoader />
                 </div>
-              ) : discoverData?.[0] &&
-                discoverData[0].results &&
-                discoverData[0].results.length > 0 ? (
+              ) : hasVisibleItems ? (
                 <Layout.FlexCol gap={20} w="100%">
-                  {discoverData.map((page) =>
-                    page.results?.map((item, index) => renderDiscoverItem(item, index)),
+                  {discoverData?.map((page) =>
+                    page.results
+                      ?.filter(filterItem)
+                      .map((item, index) => renderDiscoverItem(item, index)),
                   )}
                   <div ref={targetRef} />
                   {isLoadingMore && <NoteLoader />}

--- a/src/utils/apis/discover.ts
+++ b/src/utils/apis/discover.ts
@@ -1,17 +1,13 @@
 import { PaginationResponse } from '@models/api/common';
-import { DiscoverFilter, DiscoverResultItem } from '@models/discover';
+import { DiscoverResultItem } from '@models/discover';
 import axios from './axios';
 
-export const getDiscoverFeed = async (page: string | null, filters?: DiscoverFilter[]) => {
+export const getDiscoverFeed = async (page: string | null) => {
   const requestPage = page ? page.split('page=')[1] : null;
   const params = new URLSearchParams();
 
   if (requestPage) {
     params.append('page', requestPage);
-  }
-
-  if (filters && filters.length > 0) {
-    params.append('filter', filters.join(','));
   }
 
   const queryString = params.toString();


### PR DESCRIPTION
## Summary
- Use stable SWR key (no filter in URL) to prevent refetch on filter change
- Filter Response/Note items client-side by `category` field from API
- Remove filter query param from API calls
- Fixes filter clicks causing empty states and lost likes/comments

## Test plan
- [ ] Click Mutual Friends / Mutual Traits filter chips — items filter instantly
- [ ] Likes/comments on posts persist when toggling filters
- [ ] Music section stays visible when filtering
- [ ] Injected cards (Question, Interest, Persona) remain visible with filters

🤖 Generated with [Claude Code](https://claude.com/claude-code)