### PR TITLE
feat: TMI of the Day title and GenAI placeholder

### DIFF
--- a/src/components/note/new-note-content/NewNoteContent.tsx
+++ b/src/components/note/new-note-content/NewNoteContent.tsx
@@ -21,9 +21,15 @@ interface NoteInformationProps {
   noteInfo: NewNoteForm;
   setNoteInfo: React.Dispatch<React.SetStateAction<NewNoteForm>>;
   autoOpenImagePicker?: boolean;
+  placeholder?: string;
 }
 
-function NewNoteContent({ noteInfo, setNoteInfo, autoOpenImagePicker }: NoteInformationProps) {
+function NewNoteContent({
+  noteInfo,
+  setNoteInfo,
+  autoOpenImagePicker,
+  placeholder,
+}: NoteInformationProps) {
   const [t] = useTranslation('translation');
   const { openToast } = useBoundStore((state) => ({ openToast: state.openToast }));
   const { myProfile } = useBoundStore((state) => ({ myProfile: state.myProfile }));
@@ -165,7 +171,7 @@ function NewNoteContent({ noteInfo, setNoteInfo, autoOpenImagePicker }: NoteInfo
           {/* Text input */}
           <NoteInput
             value={noteInfo.content}
-            placeholder={t('notes.whats_on_your_mind') || ''}
+            placeholder={placeholder || t('notes.whats_on_your_mind') || ''}
             onChange={handleChangeInput}
             minRows={4}
             maxRows={10}

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -569,7 +569,8 @@
         "report_error": "A temporary error occurred. Please try again later."
     },
     "share_page": {
-        "tmi_placeholder": "eg: TMI of the day",
+        "tmi_of_the_day": "TMI of the day",
+        "tmi_placeholder": "had the best reindeer hotdog today!!!",
         "photo_of_the_day": "Photo of the day",
         "photo_description": "Post your favourite photo for the day and let everyone know what you are up to",
         "share_photo": "Share photo",

--- a/src/i18n/locales/ko/translation.json
+++ b/src/i18n/locales/ko/translation.json
@@ -561,7 +561,8 @@
     "report_error": "일시적으로 오류가 발생했습니다. 잠시 후 다시 시도해 주세요."
   },
   "share_page": {
-    "tmi_placeholder": "예: 오늘의 TMI",
+    "tmi_of_the_day": "오늘의 TMI",
+    "tmi_placeholder": "오늘 인생 핫도그를 먹었다!!!",
     "photo_of_the_day": "오늘의 사진",
     "photo_description": "오늘의 사진을 공유하고 친구들에게 근황을 알려주세요",
     "share_photo": "사진 공유",

--- a/src/routes/notes/NewNote.tsx
+++ b/src/routes/notes/NewNote.tsx
@@ -13,6 +13,7 @@ function NewNote() {
 
   const status = location.state?.status;
   const shareType: ShareType | undefined = location.state?.shareType;
+  const tmiPlaceholder: string | undefined = location.state?.tmiPlaceholder;
   const isEditing = location.state?.post != null;
   // location.state가 없으면 새 노트, 있으면 수정 노트
   const title = !isEditing ? t('new_note') : t('edit_note');
@@ -41,6 +42,7 @@ function NewNote() {
         noteInfo={noteInfo}
         setNoteInfo={setNoteInfo}
         autoOpenImagePicker={shareType === ShareType.PHOTO_OF_THE_DAY}
+        placeholder={tmiPlaceholder}
       />
     </MainScrollContainer>
   );

--- a/src/routes/share/Share.styled.ts
+++ b/src/routes/share/Share.styled.ts
@@ -2,6 +2,9 @@ import styled from 'styled-components';
 
 export const TmiInputBarWrapper = styled.div`
   width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
   background-color: ${({ theme }) => theme.PRIMARY};
   padding: 24px 16px;
 `;

--- a/src/routes/share/Share.tsx
+++ b/src/routes/share/Share.tsx
@@ -11,6 +11,7 @@ import { useRestoreScrollPosition } from '@hooks/useRestoreScrollPosition';
 import { DailyQuestion, ShareType } from '@models/post';
 import { getMe } from '@utils/apis/my';
 import { getTodayQuestions } from '@utils/apis/question';
+import { getTmiPlaceholder } from '@utils/apis/tmi';
 
 import { MainScrollContainer } from '../Root';
 import {
@@ -21,7 +22,7 @@ import {
 } from './Share.styled';
 
 function Share() {
-  const [t] = useTranslation('translation');
+  const [t, i18n] = useTranslation('translation');
   const navigate = useNavigate();
   const { scrollRef } = useRestoreScrollPosition('sharePage');
 
@@ -30,13 +31,20 @@ function Share() {
     getTodayQuestions,
   );
 
+  const { data: tmiPlaceholder } = useSWR(`/user/tmi-placeholder/?lang=${i18n.language}`, () =>
+    getTmiPlaceholder(i18n.language),
+  );
+
   const handleRefresh = useCallback(async () => {
     await Promise.all([mutate(), getMe()]);
   }, [mutate]);
 
   const handleClickTmiInput = () => {
     navigate('/notes/new', {
-      state: { shareType: ShareType.TMI_OF_THE_DAY },
+      state: {
+        shareType: ShareType.TMI_OF_THE_DAY,
+        tmiPlaceholder: tmiPlaceholder || t('share_page.tmi_placeholder'),
+      },
     });
   };
 
@@ -50,13 +58,24 @@ function Share() {
     <MainScrollContainer scrollRef={scrollRef}>
       <PullToRefresh onRefresh={handleRefresh}>
         <Layout.FlexCol w="100%">
-          {/* TMI Input Bar */}
+          {/* TMI of the Day */}
           <TmiInputBarWrapper>
+            <Typo type="head-line" color="WHITE" bold>
+              {t('share_page.tmi_of_the_day')}
+            </Typo>
             <TmiInputBar type="button" onClick={handleClickTmiInput}>
-              <Layout.FlexRow gap={8} alignItems="center">
+              <Layout.FlexRow gap={8} alignItems="center" style={{ flex: 1, minWidth: 0 }}>
                 <SvgIcon name="add_default" size={24} color="PRIMARY" />
-                <Typo type="body-medium" color="DARK_GRAY">
-                  {t('share_page.tmi_placeholder')}
+                <Typo
+                  type="body-medium"
+                  color="MEDIUM_GRAY"
+                  style={{
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {tmiPlaceholder || t('share_page.tmi_placeholder')}
                 </Typo>
               </Layout.FlexRow>
               <SvgIcon name="chat_media_image" size={24} fill="DARK_GRAY" />

--- a/src/utils/apis/tmi.ts
+++ b/src/utils/apis/tmi.ts
@@ -1,0 +1,13 @@
+import axios from './axios';
+
+interface TmiPlaceholderResponse {
+  placeholder: string;
+}
+
+export const getTmiPlaceholder = async (lang: string): Promise<string> => {
+  const shortLang = lang.startsWith('ko') ? 'ko' : 'en';
+  const { data } = await axios.get<TmiPlaceholderResponse>(
+    `/user/tmi-placeholder/?lang=${shortLang}`,
+  );
+  return data.placeholder;
+};


### PR DESCRIPTION
## Summary
- "TMI of the day" is now a title above the input bar, matching "Photo of the day" styling
- Input bar placeholder shows a daily AI-generated example fetched from the backend
- Falls back to a static example ("had the best reindeer hotdog today!!!") if the API is unavailable
- The placeholder carries through to the NewNote text input when composing
- Added `tmi_of_the_day` translation key for EN and KO

## Test plan
- [ ] Open the Share page — "TMI of the day" title appears above the input bar
- [ ] Input bar shows a fun example as placeholder text
- [ ] Click the input bar — NewNote text input shows the same placeholder
- [ ] Verify Korean translation works when language is set to Korean

🤖 Generated with [Claude Code](https://claude.com/claude-code)