### PR TITLE
feat: tab restructure and Check-In tab with 2x2 grid

### DIFF
--- a/public/icons/update_active.svg
+++ b/public/icons/update_active.svg
@@ -1,0 +1,6 @@
+<svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="2" y="2" width="10" height="10" rx="3" fill="#8700FF"/>
+  <rect x="16" y="2" width="10" height="10" rx="3" fill="#8700FF"/>
+  <rect x="2" y="16" width="10" height="10" rx="3" fill="#8700FF"/>
+  <rect x="16" y="16" width="10" height="10" rx="3" fill="#8700FF"/>
+</svg>

--- a/public/icons/update_inactive.svg
+++ b/public/icons/update_inactive.svg
@@ -1,0 +1,6 @@
+<svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="2.5" y="2.5" width="9" height="9" rx="2.5" stroke="#C4C4C4" stroke-width="1"/>
+  <rect x="16.5" y="2.5" width="9" height="9" rx="2.5" stroke="#C4C4C4" stroke-width="1"/>
+  <rect x="2.5" y="16.5" width="9" height="9" rx="2.5" stroke="#C4C4C4" stroke-width="1"/>
+  <rect x="16.5" y="16.5" width="9" height="9" rx="2.5" stroke="#C4C4C4" stroke-width="1"/>
+</svg>

--- a/src/components/check-in/my-check-in-card/MyCheckInCard.tsx
+++ b/src/components/check-in/my-check-in-card/MyCheckInCard.tsx
@@ -31,14 +31,21 @@ function MyCheckInCard() {
     <Container>
       {/* Row 1: Profile + username + social battery */}
       <Layout.FlexRow w="100%" gap={7} alignItems="center">
-        <ProfileImage
-          imageUrl={myProfile?.profile_image}
-          username={myProfile?.username}
-          size={36}
-        />
-        <Typo type="label-large" ellipsis={{ enabled: true, maxWidth: 100 }}>
-          {myProfile?.username || ''}
-        </Typo>
+        <Layout.FlexRow
+          gap={7}
+          alignItems="center"
+          style={{ cursor: 'pointer' }}
+          onClick={() => navigate('/my')}
+        >
+          <ProfileImage
+            imageUrl={myProfile?.profile_image}
+            username={myProfile?.username}
+            size={36}
+          />
+          <Typo type="label-large" ellipsis={{ enabled: true, maxWidth: 100 }}>
+            {myProfile?.username || ''}
+          </Typo>
+        </Layout.FlexRow>
         {social_battery && Object.values(SocialBattery).includes(social_battery) ? (
           <SocialBatteryChip
             socialBattery={social_battery}

--- a/src/components/check-in/update-quadrant/BatteryEditor.tsx
+++ b/src/components/check-in/update-quadrant/BatteryEditor.tsx
@@ -1,0 +1,41 @@
+import VisibilityToggle from '@components/check-in/visibility-toggle/VisibilityToggle';
+import SocialBatteryChip from '@components/profile/social-batter-chip/SocialBatteryChip';
+import { Layout } from '@design-system';
+import { ComponentVisibility, SocialBattery } from '@models/checkIn';
+import EditorPopup from './EditorPopup';
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  value: SocialBattery | null;
+  onChange: (value: SocialBattery | null) => void;
+  visibility: ComponentVisibility;
+  onVisibilityChange: (v: ComponentVisibility) => void;
+}
+
+const BATTERY_OPTIONS = Object.values(SocialBattery);
+
+export default function BatteryEditor({
+  isOpen,
+  onClose,
+  value,
+  onChange,
+  visibility,
+  onVisibilityChange,
+}: Props) {
+  return (
+    <EditorPopup isOpen={isOpen} onClose={onClose} title="Social Battery">
+      <Layout.FlexRow w="100%" gap={8} mb={16} style={{ flexWrap: 'wrap' }}>
+        {BATTERY_OPTIONS.map((battery) => (
+          <SocialBatteryChip
+            key={battery}
+            socialBattery={battery}
+            isSelected={value === battery}
+            onSelect={(b) => onChange(value === b ? null : b)}
+          />
+        ))}
+      </Layout.FlexRow>
+      <VisibilityToggle value={visibility} onChange={onVisibilityChange} />
+    </EditorPopup>
+  );
+}

--- a/src/components/check-in/update-quadrant/EditorPopup.tsx
+++ b/src/components/check-in/update-quadrant/EditorPopup.tsx
@@ -17,7 +17,7 @@ function EditorPopup({ isOpen, onClose, title, children }: PropsWithChildren<Edi
       <Content onClick={(e) => e.stopPropagation()}>
         <Layout.FlexRow w="100%" justifyContent="space-between" alignItems="center" mb={12}>
           <Typo type="title-medium">{title}</Typo>
-          <CloseButton onClick={onClose}>Done</CloseButton>
+          <CloseButton onClick={onClose}>Share</CloseButton>
         </Layout.FlexRow>
         {children}
       </Content>

--- a/src/components/check-in/update-quadrant/EditorPopup.tsx
+++ b/src/components/check-in/update-quadrant/EditorPopup.tsx
@@ -1,0 +1,61 @@
+import { PropsWithChildren } from 'react';
+import styled from 'styled-components';
+import { Z_INDEX } from '@constants/layout';
+import { Colors, Layout, Typo } from '@design-system';
+
+interface EditorPopupProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+}
+
+function EditorPopup({ isOpen, onClose, title, children }: PropsWithChildren<EditorPopupProps>) {
+  if (!isOpen) return null;
+
+  return (
+    <Overlay onClick={onClose}>
+      <Content onClick={(e) => e.stopPropagation()}>
+        <Layout.FlexRow w="100%" justifyContent="space-between" alignItems="center" mb={12}>
+          <Typo type="title-medium">{title}</Typo>
+          <CloseButton onClick={onClose}>Done</CloseButton>
+        </Layout.FlexRow>
+        {children}
+      </Content>
+    </Overlay>
+  );
+}
+
+const Overlay = styled(Layout.FlexCol)`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: ${Z_INDEX.COMMENT_LIKES_POPUP};
+  justify-content: center;
+  align-items: center;
+`;
+
+const Content = styled.div`
+  position: relative;
+  width: 85%;
+  max-width: 400px;
+  max-height: 70vh;
+  padding: 20px;
+  border-radius: 16px;
+  background-color: ${Colors.WHITE};
+  overflow-y: auto;
+`;
+
+const CloseButton = styled.button`
+  background: none;
+  border: none;
+  color: ${Colors.PRIMARY};
+  font-size: 16px;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 4px 8px;
+`;
+
+export default EditorPopup;

--- a/src/components/check-in/update-quadrant/MoodEditor.tsx
+++ b/src/components/check-in/update-quadrant/MoodEditor.tsx
@@ -1,0 +1,68 @@
+import EmojiPicker, { EmojiClickData } from 'emoji-picker-react';
+import { useCallback } from 'react';
+import EmojiItem from '@components/_common/emoji-item/EmojiItem';
+import VisibilityToggle from '@components/check-in/visibility-toggle/VisibilityToggle';
+import { Layout, SvgIcon, Typo } from '@design-system';
+import { ComponentVisibility } from '@models/checkIn';
+import EditorPopup from './EditorPopup';
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  value: string;
+  onChange: (value: string) => void;
+  visibility: ComponentVisibility;
+  onVisibilityChange: (v: ComponentVisibility) => void;
+}
+
+export default function MoodEditor({
+  isOpen,
+  onClose,
+  value,
+  onChange,
+  visibility,
+  onVisibilityChange,
+}: Props) {
+  const handleEmojiClick = useCallback(
+    (emojiData: EmojiClickData) => {
+      onChange(emojiData.emoji);
+    },
+    [onChange],
+  );
+
+  return (
+    <EditorPopup isOpen={isOpen} onClose={onClose} title="Mood">
+      <Layout.FlexCol w="100%" alignItems="center" gap={12} mb={16}>
+        {value ? (
+          <Layout.FlexRow gap={12} alignItems="center">
+            <EmojiItem emojiString={value} size={48} bgColor="TRANSPARENT" outline="TRANSPARENT" />
+            <Layout.FlexRow
+              style={{ cursor: 'pointer' }}
+              onClick={() => onChange('')}
+              alignItems="center"
+              gap={4}
+            >
+              <SvgIcon name="delete_button" size={20} />
+              <Typo type="label-medium" color="MEDIUM_GRAY">
+                Clear
+              </Typo>
+            </Layout.FlexRow>
+          </Layout.FlexRow>
+        ) : (
+          <Typo type="body-medium" color="MEDIUM_GRAY">
+            Pick an emoji
+          </Typo>
+        )}
+        <EmojiPicker
+          onEmojiClick={handleEmojiClick}
+          width="100%"
+          height={280}
+          searchDisabled
+          skinTonesDisabled
+          previewConfig={{ showPreview: false }}
+        />
+      </Layout.FlexCol>
+      <VisibilityToggle value={visibility} onChange={onVisibilityChange} />
+    </EditorPopup>
+  );
+}

--- a/src/components/check-in/update-quadrant/SongEditor.tsx
+++ b/src/components/check-in/update-quadrant/SongEditor.tsx
@@ -1,8 +1,12 @@
+import { Track } from '@spotify/web-api-ts-sdk';
 import { useState } from 'react';
+import SearchInput from '@components/_common/search-input/SearchInput';
 import VisibilityToggle from '@components/check-in/visibility-toggle/VisibilityToggle';
-import SongSearchBottomSheet from '@components/music/music-search-bottom-sheet/MusicSearchBottomSheet';
+import MusicItem from '@components/music/music-search-bottom-sheet/music-item/MusicItem';
 import SpotifyMusic from '@components/music/spotify-music/SpotifyMusic';
 import { Layout, SvgIcon, Typo } from '@design-system';
+import useAsyncEffect from '@hooks/useAsyncEffect';
+import SpotifyManager from '@libs/SpotifyManager';
 import { ComponentVisibility } from '@models/checkIn';
 import EditorPopup from './EditorPopup';
 
@@ -23,69 +27,71 @@ export default function SongEditor({
   visibility,
   onVisibilityChange,
 }: Props) {
-  const [showSearch, setShowSearch] = useState(false);
+  const [query, setQuery] = useState('');
+  const [trackList, setTrackList] = useState<Track[]>([]);
+  const spotifyManager = SpotifyManager.getInstance();
 
-  const handleSelect = (id: string) => {
-    onChange(id);
-    setShowSearch(false);
+  useAsyncEffect(async () => {
+    if (!query) {
+      setTrackList([]);
+      return;
+    }
+    const tracks = await spotifyManager.searchMusic(query, 10, 0);
+    setTrackList(tracks);
+  }, [query]);
+
+  const handleSelectTrack = (track: Track) => {
+    onChange(track.id);
+    setQuery('');
+    setTrackList([]);
   };
 
   return (
-    <>
-      <EditorPopup isOpen={isOpen} onClose={onClose} title="Song">
-        <Layout.FlexCol w="100%" gap={12} mb={16}>
-          {trackId ? (
-            <Layout.FlexRow w="100%" gap={8} alignItems="center">
-              <Layout.FlexRow style={{ flex: 1, minWidth: 0 }}>
-                <SpotifyMusic track={trackId} useAlbumImg fontType="label-large" />
-              </Layout.FlexRow>
-              <Layout.FlexRow
-                style={{ cursor: 'pointer', flexShrink: 0 }}
-                onClick={() => onChange('')}
-                alignItems="center"
-                gap={4}
-              >
-                <SvgIcon name="delete_button" size={20} />
-              </Layout.FlexRow>
+    <EditorPopup isOpen={isOpen} onClose={onClose} title="Song">
+      <Layout.FlexCol w="100%" gap={12} mb={16}>
+        {trackId && (
+          <Layout.FlexRow w="100%" gap={8} alignItems="center">
+            <Layout.FlexRow style={{ flex: 1, minWidth: 0 }}>
+              <SpotifyMusic track={trackId} useAlbumImg fontType="label-large" />
             </Layout.FlexRow>
-          ) : (
             <Layout.FlexRow
-              w="100%"
-              pv={12}
-              ph={16}
-              rounded={12}
-              outline="LIGHT_GRAY"
+              style={{ cursor: 'pointer', flexShrink: 0 }}
+              onClick={() => onChange('')}
               alignItems="center"
-              gap={8}
-              style={{ cursor: 'pointer' }}
-              onClick={() => setShowSearch(true)}
             >
-              <SvgIcon name="search_black" size={20} />
-              <Typo type="body-medium" color="LIGHT_GRAY">
-                Search for a song
-              </Typo>
+              <SvgIcon name="delete_button" size={20} />
             </Layout.FlexRow>
-          )}
-          {trackId && (
-            <Layout.FlexRow
-              w="100%"
-              justifyContent="center"
-              style={{ cursor: 'pointer' }}
-              onClick={() => setShowSearch(true)}
-            >
-              <Typo type="label-medium" color="PRIMARY">
-                Change song
-              </Typo>
-            </Layout.FlexRow>
-          )}
-        </Layout.FlexCol>
-        <VisibilityToggle value={visibility} onChange={onVisibilityChange} />
-      </EditorPopup>
-      <SongSearchBottomSheet
-        visible={showSearch}
-        closeBottomSheet={() => setShowSearch(false)}
-        onSelect={handleSelect}
-      />
-    </>
+          </Layout.FlexRow>
+        )}
+
+        <SearchInput
+          query={query}
+          setQuery={setQuery}
+          autoFocus={false}
+          fontSize={14}
+          placeholder="Search for a song, album, or artist..."
+        />
+
+        {trackList.length > 0 && (
+          <Layout.FlexCol w="100%" gap={8} style={{ maxHeight: 200, overflowY: 'auto' }}>
+            {trackList.map((track) => (
+              <MusicItem
+                key={track.id}
+                track={track}
+                onSelect={handleSelectTrack}
+                selected={trackId === track.id}
+              />
+            ))}
+          </Layout.FlexCol>
+        )}
+
+        {query && trackList.length === 0 && (
+          <Typo type="body-small" color="MEDIUM_GRAY" textAlign="center">
+            No results found
+          </Typo>
+        )}
+      </Layout.FlexCol>
+      <VisibilityToggle value={visibility} onChange={onVisibilityChange} />
+    </EditorPopup>
   );
 }

--- a/src/components/check-in/update-quadrant/SongEditor.tsx
+++ b/src/components/check-in/update-quadrant/SongEditor.tsx
@@ -3,8 +3,7 @@ import { useState } from 'react';
 import SearchInput from '@components/_common/search-input/SearchInput';
 import VisibilityToggle from '@components/check-in/visibility-toggle/VisibilityToggle';
 import MusicItem from '@components/music/music-search-bottom-sheet/music-item/MusicItem';
-import SpotifyMusic from '@components/music/spotify-music/SpotifyMusic';
-import { Layout, SvgIcon, Typo } from '@design-system';
+import { Layout, Typo } from '@design-system';
 import useAsyncEffect from '@hooks/useAsyncEffect';
 import SpotifyManager from '@libs/SpotifyManager';
 import { ComponentVisibility } from '@models/checkIn';
@@ -49,29 +48,13 @@ export default function SongEditor({
   }, [query]);
 
   const handleSelectTrack = (track: Track) => {
-    onChange(track.id);
-    setQuery('');
-    setTrackList([]);
+    // Toggle: tap selected track to deselect, tap new track to select
+    onChange(trackId === track.id ? '' : track.id);
   };
 
   return (
     <EditorPopup isOpen={isOpen} onClose={onClose} title="Song">
       <Layout.FlexCol w="100%" gap={12} mb={16}>
-        {trackId && (
-          <Layout.FlexRow w="100%" gap={8} alignItems="center">
-            <Layout.FlexRow style={{ flex: 1, minWidth: 0 }}>
-              <SpotifyMusic track={trackId} useAlbumImg fontType="label-large" />
-            </Layout.FlexRow>
-            <Layout.FlexRow
-              style={{ cursor: 'pointer', flexShrink: 0 }}
-              onClick={() => onChange('')}
-              alignItems="center"
-            >
-              <SvgIcon name="delete_button" size={20} />
-            </Layout.FlexRow>
-          </Layout.FlexRow>
-        )}
-
         <SearchInput
           query={query}
           setQuery={setQuery}
@@ -81,7 +64,7 @@ export default function SongEditor({
         />
 
         {trackList.length > 0 && (
-          <Layout.FlexCol w="100%" gap={8} style={{ maxHeight: 200, overflowY: 'auto' }}>
+          <Layout.FlexCol w="100%" gap={8} style={{ maxHeight: 250, overflowY: 'auto' }}>
             {trackList.map((track) => (
               <MusicItem
                 key={track.id}

--- a/src/components/check-in/update-quadrant/SongEditor.tsx
+++ b/src/components/check-in/update-quadrant/SongEditor.tsx
@@ -60,7 +60,7 @@ export default function SongEditor({
               style={{ cursor: 'pointer' }}
               onClick={() => setShowSearch(true)}
             >
-              <SvgIcon name="search" size={20} />
+              <SvgIcon name="search_black" size={20} />
               <Typo type="body-medium" color="LIGHT_GRAY">
                 Search for a song
               </Typo>

--- a/src/components/check-in/update-quadrant/SongEditor.tsx
+++ b/src/components/check-in/update-quadrant/SongEditor.tsx
@@ -29,15 +29,23 @@ export default function SongEditor({
 }: Props) {
   const [query, setQuery] = useState('');
   const [trackList, setTrackList] = useState<Track[]>([]);
+  const [searchError, setSearchError] = useState('');
   const spotifyManager = SpotifyManager.getInstance();
 
   useAsyncEffect(async () => {
     if (!query) {
       setTrackList([]);
+      setSearchError('');
       return;
     }
-    const tracks = await spotifyManager.searchMusic(query, 10, 0);
-    setTrackList(tracks);
+    try {
+      const tracks = await spotifyManager.searchMusic(query, 10, 0);
+      setTrackList(tracks);
+      setSearchError('');
+    } catch {
+      setTrackList([]);
+      setSearchError('Search unavailable');
+    }
   }, [query]);
 
   const handleSelectTrack = (track: Track) => {
@@ -85,7 +93,12 @@ export default function SongEditor({
           </Layout.FlexCol>
         )}
 
-        {query && trackList.length === 0 && (
+        {searchError && (
+          <Typo type="body-small" color="MEDIUM_GRAY" textAlign="center">
+            {searchError}
+          </Typo>
+        )}
+        {query && !searchError && trackList.length === 0 && (
           <Typo type="body-small" color="MEDIUM_GRAY" textAlign="center">
             No results found
           </Typo>

--- a/src/components/check-in/update-quadrant/SongEditor.tsx
+++ b/src/components/check-in/update-quadrant/SongEditor.tsx
@@ -1,0 +1,91 @@
+import { useState } from 'react';
+import VisibilityToggle from '@components/check-in/visibility-toggle/VisibilityToggle';
+import SongSearchBottomSheet from '@components/music/music-search-bottom-sheet/MusicSearchBottomSheet';
+import SpotifyMusic from '@components/music/spotify-music/SpotifyMusic';
+import { Layout, SvgIcon, Typo } from '@design-system';
+import { ComponentVisibility } from '@models/checkIn';
+import EditorPopup from './EditorPopup';
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  trackId: string;
+  onChange: (trackId: string) => void;
+  visibility: ComponentVisibility;
+  onVisibilityChange: (v: ComponentVisibility) => void;
+}
+
+export default function SongEditor({
+  isOpen,
+  onClose,
+  trackId,
+  onChange,
+  visibility,
+  onVisibilityChange,
+}: Props) {
+  const [showSearch, setShowSearch] = useState(false);
+
+  const handleSelect = (id: string) => {
+    onChange(id);
+    setShowSearch(false);
+  };
+
+  return (
+    <>
+      <EditorPopup isOpen={isOpen} onClose={onClose} title="Song">
+        <Layout.FlexCol w="100%" gap={12} mb={16}>
+          {trackId ? (
+            <Layout.FlexRow w="100%" gap={8} alignItems="center">
+              <Layout.FlexRow style={{ flex: 1, minWidth: 0 }}>
+                <SpotifyMusic track={trackId} useAlbumImg fontType="label-large" />
+              </Layout.FlexRow>
+              <Layout.FlexRow
+                style={{ cursor: 'pointer', flexShrink: 0 }}
+                onClick={() => onChange('')}
+                alignItems="center"
+                gap={4}
+              >
+                <SvgIcon name="delete_button" size={20} />
+              </Layout.FlexRow>
+            </Layout.FlexRow>
+          ) : (
+            <Layout.FlexRow
+              w="100%"
+              pv={12}
+              ph={16}
+              rounded={12}
+              outline="LIGHT_GRAY"
+              alignItems="center"
+              gap={8}
+              style={{ cursor: 'pointer' }}
+              onClick={() => setShowSearch(true)}
+            >
+              <SvgIcon name="search" size={20} />
+              <Typo type="body-medium" color="LIGHT_GRAY">
+                Search for a song
+              </Typo>
+            </Layout.FlexRow>
+          )}
+          {trackId && (
+            <Layout.FlexRow
+              w="100%"
+              justifyContent="center"
+              style={{ cursor: 'pointer' }}
+              onClick={() => setShowSearch(true)}
+            >
+              <Typo type="label-medium" color="PRIMARY">
+                Change song
+              </Typo>
+            </Layout.FlexRow>
+          )}
+        </Layout.FlexCol>
+        <VisibilityToggle value={visibility} onChange={onVisibilityChange} />
+      </EditorPopup>
+      <SongSearchBottomSheet
+        visible={showSearch}
+        closeBottomSheet={() => setShowSearch(false)}
+        onSelect={handleSelect}
+      />
+    </>
+  );
+}

--- a/src/components/check-in/update-quadrant/ThoughtEditor.tsx
+++ b/src/components/check-in/update-quadrant/ThoughtEditor.tsx
@@ -1,0 +1,71 @@
+import { ChangeEvent } from 'react';
+import styled from 'styled-components';
+import VisibilityToggle from '@components/check-in/visibility-toggle/VisibilityToggle';
+import { Colors, Layout, Typo } from '@design-system';
+import { ComponentVisibility } from '@models/checkIn';
+import EditorPopup from './EditorPopup';
+
+const MAX_LENGTH = 100;
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  value: string;
+  onChange: (value: string) => void;
+  visibility: ComponentVisibility;
+  onVisibilityChange: (v: ComponentVisibility) => void;
+}
+
+export default function ThoughtEditor({
+  isOpen,
+  onClose,
+  value,
+  onChange,
+  visibility,
+  onVisibilityChange,
+}: Props) {
+  const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+    if (e.target.value.length <= MAX_LENGTH) {
+      onChange(e.target.value);
+    }
+  };
+
+  return (
+    <EditorPopup isOpen={isOpen} onClose={onClose} title="Thought Snippet">
+      <Layout.FlexCol w="100%" gap={8} mb={16}>
+        <StyledTextArea
+          value={value}
+          onChange={handleChange}
+          placeholder="What's on your mind?"
+          rows={3}
+          maxLength={MAX_LENGTH}
+        />
+        <Layout.FlexRow w="100%" justifyContent="flex-end">
+          <Typo type="label-small" color="MEDIUM_GRAY">
+            {value.length}/{MAX_LENGTH}
+          </Typo>
+        </Layout.FlexRow>
+      </Layout.FlexCol>
+      <VisibilityToggle value={visibility} onChange={onVisibilityChange} />
+    </EditorPopup>
+  );
+}
+
+const StyledTextArea = styled.textarea`
+  width: 100%;
+  border: 1px solid ${Colors.LIGHT_GRAY};
+  border-radius: 12px;
+  padding: 12px;
+  font-size: 16px;
+  font-family: inherit;
+  resize: none;
+  outline: none;
+
+  &:focus {
+    border-color: ${Colors.PRIMARY};
+  }
+
+  &::placeholder {
+    color: ${Colors.LIGHT_GRAY};
+  }
+`;

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 import ChatsHeader from './chats-header/ChatsHeader';
+import CheckInHeader from './check-in-header/CheckInHeader';
 import CommonHeader from './common-header/CommonHeader';
 import FriendHeader from './friends-header/FriendsHeader';
 
@@ -20,6 +21,8 @@ function Header() {
       return <CommonHeader title={t('header.discover')} />;
     case '/my':
       return <CommonHeader title={t('header.my')} />;
+    case '/update':
+      return <CheckInHeader />;
     case '/share':
       return <CommonHeader title={t('header.share')} />;
     case '/questions':

--- a/src/components/header/check-in-header/CheckInHeader.tsx
+++ b/src/components/header/check-in-header/CheckInHeader.tsx
@@ -1,0 +1,70 @@
+import { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import Icon from '@components/_common/icon/Icon';
+import IconNudge from '@components/_common/icon-nudge/IconNudge';
+import { Layout, Typo } from '@design-system';
+import { resetScrollPosition } from '@hooks/useRestoreScrollPosition';
+import { useBoundStore } from '@stores/useBoundStore';
+import { getMe } from '@utils/apis/my';
+import { Noti } from '../Header.styled';
+import MainHeader from '../MainHeader';
+import SideMenu from '../side-menu/SideMenu';
+
+function CheckInHeader() {
+  const [searchParams] = useSearchParams();
+  const initialShowSideMenu = searchParams.get('show_side_menu') === 'true' || false;
+  const [showSideMenu, setShowSideMenu] = useState(initialShowSideMenu);
+
+  const { myProfile, checkInSaveHandler, checkInSaving } = useBoundStore((state) => ({
+    myProfile: state.myProfile,
+    checkInSaveHandler: state.checkInSaveHandler,
+    checkInSaving: state.checkInSaving,
+  }));
+
+  useEffect(() => {
+    getMe();
+  }, []);
+
+  const handleSave = () => {
+    if (checkInSaveHandler && !checkInSaving) {
+      checkInSaveHandler();
+    }
+  };
+
+  return (
+    <>
+      <MainHeader
+        title="Check-In"
+        rightButtons={
+          <>
+            <button type="button" onClick={handleSave} disabled={checkInSaving}>
+              <Typo
+                type="title-large"
+                color={checkInSaving ? 'MEDIUM_GRAY' : 'PRIMARY'}
+                fontWeight={600}
+              >
+                {checkInSaving ? 'Saving...' : 'Save'}
+              </Typo>
+            </button>
+            <Noti to="/notifications">
+              <Icon
+                name="notification"
+                size={44}
+                onClick={() => resetScrollPosition('notificationsPage')}
+              />
+              <Layout.Absolute t={4} r={4}>
+                {!!myProfile?.unread_noti_cnt && (
+                  <IconNudge size={18} count={myProfile?.unread_noti_cnt} />
+                )}
+              </Layout.Absolute>
+            </Noti>
+            <Icon name="hamburger" size={44} onClick={() => setShowSideMenu(true)} />
+          </>
+        }
+      />
+      {showSideMenu && <SideMenu closeSideMenu={() => setShowSideMenu(false)} />}
+    </>
+  );
+}
+
+export default CheckInHeader;

--- a/src/components/tab/Tab.tsx
+++ b/src/components/tab/Tab.tsx
@@ -11,7 +11,7 @@ import { NavTabItem, StyledTabItem, TabWrapper } from './Tab.styled';
 
 interface TabItemProps {
   to: string;
-  type: 'friends' | 'my' | 'share' | 'feed' | 'discover' | 'chats';
+  type: 'friends' | 'my' | 'share' | 'feed' | 'discover' | 'chats' | 'update';
   size?: number;
   end?: boolean;
 }
@@ -75,10 +75,7 @@ export default function Tab() {
 
   const { featureFlags } = useBoundStore(UserSelector);
 
-  const showFloatingButton =
-    location.pathname === '/friends' ||
-    location.pathname === '/feed' ||
-    location.pathname === '/my';
+  const showFloatingButton = location.pathname === '/friends' || location.pathname === '/feed';
 
   return (
     <TabWrapper>
@@ -86,14 +83,14 @@ export default function Tab() {
         {featureFlags?.friendList ? (
           <>
             <TabItem to="/friends" type="friends" size={28} />
-            <TabItem to="/discover" type="discover" size={28} />
+            <TabItem to="/update" type="update" size={28} />
             <TabItem to="/share" type="share" size={28} />
+            <TabItem to="/discover" type="discover" size={28} />
           </>
         ) : featureFlags?.friendFeed ? (
           <TabItem to="/feed" type="friends" size={28} />
         ) : null}
         {featureFlags?.pingTab && <TabItem to="/my/pings" type="chats" size={28} />}
-        <TabItem to="/my" type="my" size={28} end />
       </Layout.FlexRow>
       {showFloatingButton && <FloatingButton />}
     </TabWrapper>

--- a/src/design-system/SvgIcon/icons.ts
+++ b/src/design-system/SvgIcon/icons.ts
@@ -141,6 +141,8 @@ const discover_active = 'discover_active';
 const discover_inactive = 'discover_inactive';
 const share_active = 'share_active';
 const share_inactive = 'share_inactive';
+const update_active = 'update_active';
+const update_inactive = 'update_inactive';
 
 const delete_button = 'delete_button';
 const top_navigation_friend = 'top_navigation_friend';
@@ -307,4 +309,6 @@ export {
   top_navigation_edit,
   top_navigation_friend,
   trash_can,
+  update_active,
+  update_inactive,
 };

--- a/src/hooks/useRestoreScrollPosition.tsx
+++ b/src/hooks/useRestoreScrollPosition.tsx
@@ -17,6 +17,7 @@ export interface ScrollPositionStore {
   feedPage?: number;
   discoverPage?: number;
   chatsPage?: number;
+  updatePage?: number;
 }
 
 export function useRestoreScrollPosition(key: keyof ScrollPositionStore) {

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -113,7 +113,8 @@
         "questions": "Questions",
         "share": "Share",
         "feed": "Feed",
-        "discover": "Discover"
+        "discover": "Discover",
+        "update": "Update"
     },
     "header": {
         "my": "My Profile",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -114,7 +114,7 @@
         "share": "Share",
         "feed": "Feed",
         "discover": "Discover",
-        "update": "Update"
+        "update": "Check-In"
     },
     "header": {
         "my": "My Profile",

--- a/src/i18n/locales/ko/translation.json
+++ b/src/i18n/locales/ko/translation.json
@@ -114,7 +114,7 @@
     "share": "공유",
     "feed": "피드",
     "discover": "발견",
-    "update": "업데이트"
+    "update": "체크인"
   },
   "header": {
     "my": "내 프로필",

--- a/src/i18n/locales/ko/translation.json
+++ b/src/i18n/locales/ko/translation.json
@@ -113,7 +113,8 @@
     "questions": "질문",
     "share": "공유",
     "feed": "피드",
-    "discover": "발견"
+    "discover": "발견",
+    "update": "업데이트"
   },
   "header": {
     "my": "내 프로필",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -64,6 +64,7 @@ import Password from './routes/sign-up/Password';
 import SignIn from './routes/SignIn';
 import SignUp from './routes/SignUp';
 import SuggestQuestions from './routes/SuggestQuestions';
+import UpdateCheckin from './routes/update/UpdateCheckin';
 import UserPage from './routes/UserPage';
 
 const router = createBrowserRouter([
@@ -122,6 +123,10 @@ const router = createBrowserRouter([
           { path: '', element: <Share /> },
           { path: 'photo', element: <PhotoOfTheDayFlow /> },
         ],
+      },
+      {
+        path: 'update',
+        children: [{ path: '', element: <UpdateCheckin /> }],
       },
       {
         path: 'questions',

--- a/src/models/checkIn.ts
+++ b/src/models/checkIn.ts
@@ -16,7 +16,8 @@ export enum ComponentVisibility {
 
 export const DEFAULT_VISIBILITY = {
   song: ComponentVisibility.PUBLIC,
-  status: ComponentVisibility.FRIENDS,
+  mood: ComponentVisibility.FRIENDS,
+  thought: ComponentVisibility.FRIENDS,
   battery: ComponentVisibility.FRIENDS,
 };
 
@@ -30,8 +31,13 @@ export type CheckInBase = {
   track_id: string;
   current_user_read: boolean;
   song_visibility?: ComponentVisibility;
-  status_visibility?: ComponentVisibility;
+  mood_visibility?: ComponentVisibility;
+  thought_visibility?: ComponentVisibility;
   battery_visibility?: ComponentVisibility;
+  battery_updated_at?: string;
+  mood_updated_at?: string;
+  song_updated_at?: string;
+  thought_updated_at?: string;
 };
 
 export type MyCheckIn = CheckInBase & {

--- a/src/routes/check-in/CheckInEdit.tsx
+++ b/src/routes/check-in/CheckInEdit.tsx
@@ -50,7 +50,7 @@ function CheckInEdit() {
     DEFAULT_VISIBILITY.song,
   );
   const [statusVisibility, setStatusVisibility] = useState<ComponentVisibility>(
-    DEFAULT_VISIBILITY.status,
+    DEFAULT_VISIBILITY.mood,
   );
   const [batteryVisibility, setBatteryVisibility] = useState<ComponentVisibility>(
     DEFAULT_VISIBILITY.battery,
@@ -80,13 +80,14 @@ function CheckInEdit() {
       mood: checkInForm.mood,
       track_id: checkInForm.track_id,
       song_visibility: songVisibility,
-      status_visibility: statusVisibility,
+      mood_visibility: statusVisibility,
+      thought_visibility: statusVisibility,
       battery_visibility: batteryVisibility,
     });
     if (window.ReactNativeWebView) {
       sendMessage('WIDGET_DATA_UPDATED', {});
     }
-    return navigate('/my');
+    return navigate('/update');
   };
 
   useEffect(() => {
@@ -99,7 +100,7 @@ function CheckInEdit() {
     if (!myCheckIn) return;
     setCheckInForm(myCheckIn);
     if (myCheckIn.song_visibility) setSongVisibility(myCheckIn.song_visibility);
-    if (myCheckIn.status_visibility) setStatusVisibility(myCheckIn.status_visibility);
+    if (myCheckIn.mood_visibility) setStatusVisibility(myCheckIn.mood_visibility);
     if (myCheckIn.battery_visibility) setBatteryVisibility(myCheckIn.battery_visibility);
   }, []);
 

--- a/src/routes/share/Share.styled.ts
+++ b/src/routes/share/Share.styled.ts
@@ -43,3 +43,11 @@ export const SharePhotoButton = styled.div`
   background-color: ${({ theme }) => theme.DARK};
   border-radius: 12px;
 `;
+
+export const SectionCard = styled.div`
+  width: 100%;
+  padding: 16px;
+  background-color: ${({ theme }) => theme.WHITE};
+  border-radius: 12px;
+  border: 1px solid ${({ theme }) => theme.LIGHT_GRAY};
+`;

--- a/src/routes/share/Share.tsx
+++ b/src/routes/share/Share.tsx
@@ -1,35 +1,25 @@
-import { ChangeEvent, useCallback, useRef, useState } from 'react';
+import { ChangeEvent, useCallback, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import useSWR from 'swr';
 import PromptCard from '@components/_common/prompt/PromptCard';
 import PullToRefresh from '@components/_common/pull-to-refresh/PullToRefresh';
 import MissionOfTheDay from '@components/share/MissionOfTheDay';
-import ThoughtSnippetInput from '@components/share/ThoughtSnippetInput';
 import { DEFAULT_MARGIN } from '@constants/layout';
-import { Layout, SvgIcon, Typo } from '@design-system';
+import { Button, Layout, Typo } from '@design-system';
 import { useRestoreScrollPosition } from '@hooks/useRestoreScrollPosition';
-import { DailyQuestion, PostVisibility, ShareType } from '@models/post';
+import { DailyQuestion } from '@models/post';
 import { getMe } from '@utils/apis/my';
-import { postNote } from '@utils/apis/note';
 import { getTodayQuestions } from '@utils/apis/question';
-import { getTmiPlaceholder } from '@utils/apis/tmi';
 import { MainScrollContainer } from '../Root';
-import {
-  PhotoOfTheDayCard,
-  SharePhotoButton,
-  TmiInputBar,
-  TmiInputBarWrapper,
-} from './Share.styled';
+import { PhotoOfTheDayCard, SectionCard, SharePhotoButton } from './Share.styled';
 
-type ShareTab = 'snippets' | 'photo' | 'mission';
+const MAX_VISIBLE_QUESTIONS = 3;
 
 function Share() {
-  const [t, i18n] = useTranslation('translation');
+  const [t] = useTranslation('translation');
   const navigate = useNavigate();
   const { scrollRef } = useRestoreScrollPosition('sharePage');
-  const [activeTab, setActiveTab] = useState<ShareTab>('snippets');
-  const [isSnippetInputVisible, setIsSnippetInputVisible] = useState(false);
   const photoInputRef = useRef<HTMLInputElement>(null);
 
   const { data: todayQuestions, mutate } = useSWR<DailyQuestion[]>(
@@ -37,32 +27,11 @@ function Share() {
     getTodayQuestions,
   );
 
-  const { data: tmiPlaceholder } = useSWR(`/user/tmi-placeholder/?lang=${i18n.language}`, () =>
-    getTmiPlaceholder(i18n.language),
-  );
-
   const handleRefresh = useCallback(async () => {
     await Promise.all([mutate(), getMe()]);
   }, [mutate]);
 
-  const handleClickTmiInput = () => {
-    setIsSnippetInputVisible(true);
-  };
-
-  const handleSnippetSubmit = async (content: string) => {
-    try {
-      await postNote({
-        content,
-        share_type: ShareType.TMI_OF_THE_DAY,
-        visibility: [PostVisibility.FRIENDS],
-      });
-    } catch {
-      // Error handled by toast
-    }
-  };
-
   const handleClickSharePhoto = () => {
-    // Open file picker directly — no separate page
     photoInputRef.current?.click();
   };
 
@@ -71,153 +40,89 @@ function Share() {
     const file = e.target.files[0];
     const reader = new FileReader();
     reader.onload = () => {
-      // Navigate to photo flow with the image already loaded
       navigate('/share/photo', { state: { imageDataUrl: reader.result as string } });
     };
     reader.readAsDataURL(file);
-    // Reset input so same file can be re-selected
     if (photoInputRef.current) photoInputRef.current.value = '';
   };
 
   const handleDoMission = (mission: { prompt: string; type: string }) => {
     if (mission.type === 'song') {
-      navigate('/check-in/edit?focus=song');
+      navigate('/update');
     } else {
-      // Route to full note creation with mission prompt as placeholder
       navigate('/notes/new', {
         state: { tmiPlaceholder: mission.prompt },
       });
     }
   };
 
-  const TABS: { key: ShareTab; label: string }[] = [
-    { key: 'snippets', label: 'Thought Snippets' },
-    { key: 'photo', label: 'Photo' },
-    { key: 'mission', label: 'Mission' },
-  ];
+  const visibleQuestions = todayQuestions?.slice(0, MAX_VISIBLE_QUESTIONS) ?? [];
 
   return (
     <MainScrollContainer scrollRef={scrollRef}>
       <PullToRefresh onRefresh={handleRefresh}>
-        <Layout.FlexCol w="100%">
-          {/* Tab bar */}
-          <Layout.FlexRow
-            w="100%"
-            justifyContent="space-evenly"
-            style={{
-              borderBottom: '1px solid #E0E0E0',
-              position: 'sticky',
-              top: 0,
-              backgroundColor: 'white',
-              zIndex: 10,
-            }}
-          >
-            {TABS.map((tab) => (
-              <Layout.FlexCol
-                key={tab.key}
-                alignItems="center"
-                pv={12}
-                ph={8}
-                style={{
-                  cursor: 'pointer',
-                  borderBottom:
-                    activeTab === tab.key ? '2px solid #8700FF' : '2px solid transparent',
-                  flex: 1,
-                }}
-                onClick={() => setActiveTab(tab.key)}
-              >
-                <Typo
-                  type="label-large"
-                  color={activeTab === tab.key ? 'PRIMARY' : 'MEDIUM_GRAY'}
-                  fontWeight={activeTab === tab.key ? 600 : 400}
-                  textAlign="center"
-                >
-                  {tab.label}
-                </Typo>
+        <Layout.FlexCol w="100%" ph={DEFAULT_MARGIN} pv={16} gap={16} pb={100}>
+          {/* Section 1: Photo of the Day */}
+          <PhotoOfTheDayCard type="button" onClick={handleClickSharePhoto}>
+            <Typo type="head-line" color="WHITE" bold>
+              {t('share_page.photo_of_the_day')}
+            </Typo>
+            <Typo type="body-medium" color="WHITE">
+              {t('share_page.photo_description')}
+            </Typo>
+            <SharePhotoButton>
+              <Typo type="body-large" color="WHITE">
+                {t('share_page.share_photo')}
+              </Typo>
+            </SharePhotoButton>
+          </PhotoOfTheDayCard>
+          <input
+            ref={photoInputRef}
+            type="file"
+            accept="image/jpeg, image/png"
+            onChange={handlePhotoFileSelected}
+            style={{ display: 'none' }}
+          />
+
+          {/* Section 2: Mission of the Day */}
+          <SectionCard>
+            <MissionOfTheDay onDoMission={handleDoMission} />
+          </SectionCard>
+
+          {/* Section 3: Questions of the Day */}
+          <SectionCard>
+            <Typo type="title-medium" mb={12}>
+              Questions of the Day
+            </Typo>
+            {visibleQuestions.length > 0 ? (
+              <Layout.FlexCol w="100%" gap={10}>
+                {visibleQuestions.map((question) => (
+                  <PromptCard
+                    key={question.id}
+                    id={question.id}
+                    content={question.content}
+                    widthMode="full"
+                    authorDetail={question.author_detail}
+                  />
+                ))}
               </Layout.FlexCol>
-            ))}
-          </Layout.FlexRow>
-
-          {/* Tab content */}
-          {activeTab === 'snippets' && (
-            <Layout.FlexCol w="100%">
-              <TmiInputBarWrapper>
-                <Typo type="head-line" color="WHITE" bold>
-                  Thought Snippets
-                </Typo>
-                <TmiInputBar type="button" onClick={handleClickTmiInput}>
-                  <Layout.FlexRow gap={8} alignItems="center" style={{ flex: 1, minWidth: 0 }}>
-                    <SvgIcon name="add_default" size={24} color="PRIMARY" />
-                    <Typo type="body-medium" color="MEDIUM_GRAY" ellipsis={{ enabled: true }}>
-                      {tmiPlaceholder || t('share_page.tmi_placeholder')}
-                    </Typo>
-                  </Layout.FlexRow>
-                </TmiInputBar>
-              </TmiInputBarWrapper>
-
-              <Layout.FlexCol pv={14} w="100%" ph={DEFAULT_MARGIN} gap={20} pb={100}>
-                <Layout.FlexCol w="100%" gap={10}>
-                  <Typo type="body-large" color="BLACK" bold>
-                    {t('share_page.questions_of_the_day')}
-                  </Typo>
-                  {todayQuestions && todayQuestions.length > 0 ? (
-                    todayQuestions.map((question) => (
-                      <PromptCard
-                        key={question.id}
-                        id={question.id}
-                        content={question.content}
-                        widthMode="full"
-                        authorDetail={question.author_detail}
-                      />
-                    ))
-                  ) : (
-                    <Typo type="body-medium" color="MEDIUM_GRAY">
-                      {t('no_contents.question')}
-                    </Typo>
-                  )}
-                </Layout.FlexCol>
-              </Layout.FlexCol>
-            </Layout.FlexCol>
-          )}
-
-          {activeTab === 'photo' && (
-            <Layout.FlexCol pv={14} w="100%" ph={DEFAULT_MARGIN} gap={20} pb={100}>
-              <PhotoOfTheDayCard type="button" onClick={handleClickSharePhoto}>
-                <Typo type="head-line" color="WHITE" bold>
-                  {t('share_page.photo_of_the_day')}
-                </Typo>
-                <Typo type="body-medium" color="WHITE">
-                  {t('share_page.photo_description')}
-                </Typo>
-                <SharePhotoButton>
-                  <Typo type="body-large" color="WHITE">
-                    {t('share_page.share_photo')}
-                  </Typo>
-                </SharePhotoButton>
-              </PhotoOfTheDayCard>
-              <input
-                ref={photoInputRef}
-                type="file"
-                accept="image/jpeg, image/png"
-                onChange={handlePhotoFileSelected}
-                style={{ display: 'none' }}
-              />
-            </Layout.FlexCol>
-          )}
-
-          {activeTab === 'mission' && (
-            <Layout.FlexCol pv={14} w="100%" ph={DEFAULT_MARGIN} gap={20} pb={100}>
-              <MissionOfTheDay onDoMission={handleDoMission} />
-            </Layout.FlexCol>
-          )}
+            ) : (
+              <Typo type="body-medium" color="MEDIUM_GRAY">
+                {t('no_contents.question')}
+              </Typo>
+            )}
+            {todayQuestions && todayQuestions.length > MAX_VISIBLE_QUESTIONS && (
+              <Layout.FlexRow w="100%" justifyContent="center" mt={12}>
+                <Button.Tertiary
+                  text="See all questions"
+                  status="normal"
+                  onClick={() => navigate('/questions')}
+                />
+              </Layout.FlexRow>
+            )}
+          </SectionCard>
         </Layout.FlexCol>
       </PullToRefresh>
-
-      <ThoughtSnippetInput
-        visible={isSnippetInputVisible}
-        onClose={() => setIsSnippetInputVisible(false)}
-        onSubmit={handleSnippetSubmit}
-      />
     </MainScrollContainer>
   );
 }

--- a/src/routes/update/UpdateCheckin.styled.ts
+++ b/src/routes/update/UpdateCheckin.styled.ts
@@ -8,7 +8,8 @@ export const GridContainer = styled.div`
   gap: 12px;
   padding: 16px;
   width: 100%;
-  aspect-ratio: 1;
+  height: calc(100vh - 200px);
+  max-height: 500px;
 `;
 
 export const QuadrantCard = styled.div<{ $isEmpty?: boolean; $isArchived?: boolean }>`

--- a/src/routes/update/UpdateCheckin.styled.ts
+++ b/src/routes/update/UpdateCheckin.styled.ts
@@ -6,10 +6,9 @@ export const GridContainer = styled.div`
   grid-template-columns: 1fr 1fr;
   grid-template-rows: 1fr 1fr;
   gap: 12px;
-  padding: 16px;
+  padding: 12px;
   width: 100%;
-  height: calc(100vh - 200px);
-  max-height: 500px;
+  flex: 1;
 `;
 
 export const QuadrantCard = styled.div<{ $isEmpty?: boolean; $isArchived?: boolean }>`
@@ -66,9 +65,4 @@ export const QuadrantLabel = styled.span`
   font-size: 12px;
   color: ${Colors.MEDIUM_GRAY};
   font-weight: 500;
-`;
-
-export const SaveButtonWrapper = styled.div`
-  padding: 0 16px 16px 16px;
-  width: 100%;
 `;

--- a/src/routes/update/UpdateCheckin.styled.ts
+++ b/src/routes/update/UpdateCheckin.styled.ts
@@ -1,0 +1,73 @@
+import styled from 'styled-components';
+import { Colors } from '@design-system';
+
+export const GridContainer = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: 1fr 1fr;
+  gap: 12px;
+  padding: 16px;
+  width: 100%;
+  aspect-ratio: 1;
+`;
+
+export const QuadrantCard = styled.div<{ $isEmpty?: boolean; $isArchived?: boolean }>`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 12px;
+  border-radius: 16px;
+  cursor: pointer;
+  position: relative;
+  overflow: hidden;
+  transition: transform 0.1s ease;
+
+  ${({ $isEmpty, $isArchived }) => {
+    if ($isEmpty) {
+      return `
+        border: 1.5px dashed ${Colors.LIGHT_GRAY};
+        background-color: #FAFAFA;
+      `;
+    }
+    if ($isArchived) {
+      return `
+        border: 1px solid ${Colors.LIGHT_GRAY};
+        background-color: ${Colors.WHITE};
+        opacity: 0.6;
+      `;
+    }
+    return `
+      border: 1px solid ${Colors.LIGHT_GRAY};
+      background-color: ${Colors.WHITE};
+    `;
+  }}
+
+  &:active {
+    transform: scale(0.97);
+  }
+`;
+
+export const ArchivedBadge = styled.div`
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background-color: ${Colors.MEDIUM_GRAY};
+  color: ${Colors.WHITE};
+  font-size: 10px;
+  font-weight: 600;
+  padding: 2px 6px;
+  border-radius: 4px;
+`;
+
+export const QuadrantLabel = styled.span`
+  font-size: 12px;
+  color: ${Colors.MEDIUM_GRAY};
+  font-weight: 500;
+`;
+
+export const SaveButtonWrapper = styled.div`
+  padding: 0 16px 16px 16px;
+  width: 100%;
+`;

--- a/src/routes/update/UpdateCheckin.tsx
+++ b/src/routes/update/UpdateCheckin.tsx
@@ -1,15 +1,252 @@
+import { useCallback, useMemo, useState } from 'react';
+import EmojiItem from '@components/_common/emoji-item/EmojiItem';
 import MainContainer from '@components/_common/main-container/MainContainer';
-import { Layout, Typo } from '@design-system';
+import BatteryEditor from '@components/check-in/update-quadrant/BatteryEditor';
+import MoodEditor from '@components/check-in/update-quadrant/MoodEditor';
+import SongEditor from '@components/check-in/update-quadrant/SongEditor';
+import ThoughtEditor from '@components/check-in/update-quadrant/ThoughtEditor';
+import SpotifyMusic from '@components/music/spotify-music/SpotifyMusic';
+import { SocialBatteryChipAssets } from '@components/profile/social-batter-chip/SocialBatteryChip.contants';
+import { Button, Layout, SvgIcon, Typo } from '@design-system';
+import { usePostAppMessage } from '@hooks/useAppMessage';
+import useAsyncEffect from '@hooks/useAsyncEffect';
+import { ComponentVisibility, DEFAULT_VISIBILITY, SocialBattery } from '@models/checkIn';
+import { useBoundStore } from '@stores/useBoundStore';
+import { postCheckIn } from '@utils/apis/checkIn';
+import {
+  ArchivedBadge,
+  GridContainer,
+  QuadrantCard,
+  QuadrantLabel,
+  SaveButtonWrapper,
+} from './UpdateCheckin.styled';
+
+type EditorTarget = 'battery' | 'mood' | 'song' | 'thought' | null;
+
+const ARCHIVE_THRESHOLD_MS = 12 * 60 * 60 * 1000; // 12 hours
+
+function isArchived(updatedAt?: string): boolean {
+  if (!updatedAt) return false;
+  return Date.now() - new Date(updatedAt).getTime() > ARCHIVE_THRESHOLD_MS;
+}
 
 export default function UpdateCheckin() {
+  const { checkIn, fetchCheckIn } = useBoundStore((state) => ({
+    checkIn: state.checkIn,
+    fetchCheckIn: state.fetchCheckIn,
+  }));
+
+  const sendMessage = usePostAppMessage();
+
+  const [activeEditor, setActiveEditor] = useState<EditorTarget>(null);
+  const [saving, setSaving] = useState(false);
+
+  // Draft state for all 4 components
+  const [battery, setBattery] = useState<SocialBattery | null>(null);
+  const [mood, setMood] = useState('');
+  const [trackId, setTrackId] = useState('');
+  const [thought, setThought] = useState('');
+
+  // Per-component visibility
+  const [batteryVis, setBatteryVis] = useState<ComponentVisibility>(DEFAULT_VISIBILITY.battery);
+  const [moodVis, setMoodVis] = useState<ComponentVisibility>(DEFAULT_VISIBILITY.mood);
+  const [songVis, setSongVis] = useState<ComponentVisibility>(DEFAULT_VISIBILITY.song);
+  const [thoughtVis, setThoughtVis] = useState<ComponentVisibility>(DEFAULT_VISIBILITY.thought);
+
+  // Load existing check-in data
+  useAsyncEffect(async () => {
+    const ci = await fetchCheckIn();
+    if (!ci) return;
+    setBattery(ci.social_battery || null);
+    setMood(ci.mood || '');
+    setTrackId(ci.track_id || '');
+    setThought(ci.description || '');
+    if (ci.battery_visibility) setBatteryVis(ci.battery_visibility);
+    if (ci.mood_visibility) setMoodVis(ci.mood_visibility);
+    if (ci.song_visibility) setSongVis(ci.song_visibility);
+    if (ci.thought_visibility) setThoughtVis(ci.thought_visibility);
+  }, []);
+
+  // Detect archived state per component
+  const batteryArchived = useMemo(
+    () => !!battery && isArchived(checkIn?.battery_updated_at),
+    [battery, checkIn?.battery_updated_at],
+  );
+  const moodArchived = useMemo(
+    () => !!mood && isArchived(checkIn?.mood_updated_at),
+    [mood, checkIn?.mood_updated_at],
+  );
+  const songArchived = useMemo(
+    () => !!trackId && isArchived(checkIn?.song_updated_at),
+    [trackId, checkIn?.song_updated_at],
+  );
+  const thoughtArchived = useMemo(
+    () => !!thought && isArchived(checkIn?.thought_updated_at),
+    [thought, checkIn?.thought_updated_at],
+  );
+
+  const handleSave = useCallback(async () => {
+    setSaving(true);
+    try {
+      await postCheckIn({
+        social_battery: battery,
+        mood,
+        description: thought,
+        track_id: trackId,
+        battery_visibility: batteryVis,
+        mood_visibility: moodVis,
+        song_visibility: songVis,
+        thought_visibility: thoughtVis,
+      });
+      if (window.ReactNativeWebView) {
+        sendMessage('WIDGET_DATA_UPDATED', {});
+      }
+      await fetchCheckIn();
+    } finally {
+      setSaving(false);
+    }
+  }, [
+    battery,
+    mood,
+    thought,
+    trackId,
+    batteryVis,
+    moodVis,
+    songVis,
+    thoughtVis,
+    fetchCheckIn,
+    sendMessage,
+  ]);
+
   return (
     <MainContainer>
-      <Layout.FlexCol w="100%" alignItems="center" justifyContent="center" pv={40}>
-        <Typo type="title-large">Update</Typo>
-        <Typo type="body-medium" color="MEDIUM_GRAY" mt={8}>
-          Check-in grid coming soon
-        </Typo>
-      </Layout.FlexCol>
+      <GridContainer>
+        {/* Top-Left: Social Battery */}
+        <QuadrantCard
+          $isEmpty={!battery}
+          $isArchived={batteryArchived}
+          onClick={() => setActiveEditor('battery')}
+        >
+          {batteryArchived && <ArchivedBadge>Only Me</ArchivedBadge>}
+          {battery ? (
+            <>
+              <span style={{ fontSize: 40, lineHeight: 1 }}>
+                {SocialBatteryChipAssets[battery]?.emoji || ''}
+              </span>
+              <QuadrantLabel>Social Battery</QuadrantLabel>
+            </>
+          ) : (
+            <>
+              <SvgIcon name="add_reaction_default" size={32} />
+              <QuadrantLabel>Social Battery</QuadrantLabel>
+            </>
+          )}
+        </QuadrantCard>
+
+        {/* Top-Right: Mood */}
+        <QuadrantCard
+          $isEmpty={!mood}
+          $isArchived={moodArchived}
+          onClick={() => setActiveEditor('mood')}
+        >
+          {moodArchived && <ArchivedBadge>Only Me</ArchivedBadge>}
+          {mood ? (
+            <>
+              <EmojiItem emojiString={mood} size={40} bgColor="TRANSPARENT" outline="TRANSPARENT" />
+              <QuadrantLabel>Mood</QuadrantLabel>
+            </>
+          ) : (
+            <>
+              <SvgIcon name="add_reaction_default" size={32} />
+              <QuadrantLabel>Mood</QuadrantLabel>
+            </>
+          )}
+        </QuadrantCard>
+
+        {/* Bottom-Left: Song */}
+        <QuadrantCard
+          $isEmpty={!trackId}
+          $isArchived={songArchived}
+          onClick={() => setActiveEditor('song')}
+        >
+          {songArchived && <ArchivedBadge>Only Me</ArchivedBadge>}
+          {trackId ? (
+            <Layout.FlexCol w="100%" alignItems="center" gap={4}>
+              <SpotifyMusic track={trackId} useAlbumImg fontType="label-small" />
+              <QuadrantLabel>Song</QuadrantLabel>
+            </Layout.FlexCol>
+          ) : (
+            <>
+              <SvgIcon name="spotify" size={32} />
+              <QuadrantLabel>Song</QuadrantLabel>
+            </>
+          )}
+        </QuadrantCard>
+
+        {/* Bottom-Right: Thought Snippet */}
+        <QuadrantCard
+          $isEmpty={!thought}
+          $isArchived={thoughtArchived}
+          onClick={() => setActiveEditor('thought')}
+        >
+          {thoughtArchived && <ArchivedBadge>Only Me</ArchivedBadge>}
+          {thought ? (
+            <Layout.FlexCol w="100%" alignItems="center" gap={4} ph={4}>
+              <Typo type="body-medium" numberOfLines={3} textAlign="center">
+                {thought}
+              </Typo>
+              <QuadrantLabel>Thought Snippet</QuadrantLabel>
+            </Layout.FlexCol>
+          ) : (
+            <>
+              <SvgIcon name="edit_outline" size={32} />
+              <QuadrantLabel>Thought Snippet</QuadrantLabel>
+            </>
+          )}
+        </QuadrantCard>
+      </GridContainer>
+
+      <SaveButtonWrapper>
+        <Button.Primary
+          text={saving ? 'Saving...' : 'Save'}
+          status={saving ? 'disabled' : 'normal'}
+          onClick={handleSave}
+        />
+      </SaveButtonWrapper>
+
+      {/* Editor Popups */}
+      <BatteryEditor
+        isOpen={activeEditor === 'battery'}
+        onClose={() => setActiveEditor(null)}
+        value={battery}
+        onChange={setBattery}
+        visibility={batteryVis}
+        onVisibilityChange={setBatteryVis}
+      />
+      <MoodEditor
+        isOpen={activeEditor === 'mood'}
+        onClose={() => setActiveEditor(null)}
+        value={mood}
+        onChange={setMood}
+        visibility={moodVis}
+        onVisibilityChange={setMoodVis}
+      />
+      <SongEditor
+        isOpen={activeEditor === 'song'}
+        onClose={() => setActiveEditor(null)}
+        trackId={trackId}
+        onChange={setTrackId}
+        visibility={songVis}
+        onVisibilityChange={setSongVis}
+      />
+      <ThoughtEditor
+        isOpen={activeEditor === 'thought'}
+        onClose={() => setActiveEditor(null)}
+        value={thought}
+        onChange={setThought}
+        visibility={thoughtVis}
+        onVisibilityChange={setThoughtVis}
+      />
     </MainContainer>
   );
 }

--- a/src/routes/update/UpdateCheckin.tsx
+++ b/src/routes/update/UpdateCheckin.tsx
@@ -1,14 +1,15 @@
+import { Track } from '@spotify/web-api-ts-sdk';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import EmojiItem from '@components/_common/emoji-item/EmojiItem';
 import BatteryEditor from '@components/check-in/update-quadrant/BatteryEditor';
 import MoodEditor from '@components/check-in/update-quadrant/MoodEditor';
 import SongEditor from '@components/check-in/update-quadrant/SongEditor';
 import ThoughtEditor from '@components/check-in/update-quadrant/ThoughtEditor';
-import SpotifyMusic from '@components/music/spotify-music/SpotifyMusic';
 import { SocialBatteryChipAssets } from '@components/profile/social-batter-chip/SocialBatteryChip.contants';
 import { Layout, SvgIcon, Typo } from '@design-system';
 import { usePostAppMessage } from '@hooks/useAppMessage';
 import useAsyncEffect from '@hooks/useAsyncEffect';
+import SpotifyManager from '@libs/SpotifyManager';
 import { ComponentVisibility, DEFAULT_VISIBILITY, SocialBattery } from '@models/checkIn';
 import { useBoundStore } from '@stores/useBoundStore';
 import { postCheckIn } from '@utils/apis/checkIn';
@@ -47,6 +48,21 @@ export default function UpdateCheckin() {
   const [moodVis, setMoodVis] = useState<ComponentVisibility>(DEFAULT_VISIBILITY.mood);
   const [songVis, setSongVis] = useState<ComponentVisibility>(DEFAULT_VISIBILITY.song);
   const [thoughtVis, setThoughtVis] = useState<ComponentVisibility>(DEFAULT_VISIBILITY.thought);
+
+  // Track data for song quadrant display
+  const [trackData, setTrackData] = useState<Track | null>(null);
+  const spotifyManager = SpotifyManager.getInstance();
+
+  useEffect(() => {
+    if (!trackId) {
+      setTrackData(null);
+      return;
+    }
+    spotifyManager
+      .getTrack(trackId)
+      .then(setTrackData)
+      .catch(() => setTrackData(null));
+  }, [trackId, spotifyManager]);
 
   useAsyncEffect(async () => {
     const ci = await fetchCheckIn();
@@ -170,10 +186,21 @@ export default function UpdateCheckin() {
           onClick={() => setActiveEditor('song')}
         >
           {songArchived && <ArchivedBadge>Only Me</ArchivedBadge>}
-          {trackId ? (
-            <Layout.FlexCol w="100%" alignItems="center" gap={4}>
-              <SpotifyMusic track={trackId} useAlbumImg fontType="label-small" />
-              <QuadrantLabel>Song</QuadrantLabel>
+          {trackId && trackData ? (
+            <Layout.FlexCol w="100%" alignItems="center" gap={6}>
+              {trackData.album?.images?.[0]?.url && (
+                <img
+                  src={trackData.album.images[0].url}
+                  alt="album"
+                  style={{ width: 56, height: 56, borderRadius: 8, objectFit: 'cover' }}
+                />
+              )}
+              <Typo type="label-medium" numberOfLines={1} textAlign="center">
+                {trackData.name}
+              </Typo>
+              <Typo type="label-small" color="MEDIUM_GRAY" numberOfLines={1} textAlign="center">
+                {trackData.artists?.[0]?.name || ''}
+              </Typo>
             </Layout.FlexCol>
           ) : (
             <>

--- a/src/routes/update/UpdateCheckin.tsx
+++ b/src/routes/update/UpdateCheckin.tsx
@@ -1,5 +1,6 @@
 import { Track } from '@spotify/web-api-ts-sdk';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import EmojiItem from '@components/_common/emoji-item/EmojiItem';
 import BatteryEditor from '@components/check-in/update-quadrant/BatteryEditor';
 import MoodEditor from '@components/check-in/update-quadrant/MoodEditor';
@@ -26,6 +27,8 @@ function isArchived(updatedAt?: string): boolean {
 }
 
 export default function UpdateCheckin() {
+  const [t] = useTranslation('translation', { keyPrefix: 'social_battery' });
+
   const { checkIn, fetchCheckIn, setCheckInSaveHandler, setCheckInSaving } = useBoundStore(
     (state) => ({
       checkIn: state.checkIn,
@@ -145,12 +148,17 @@ export default function UpdateCheckin() {
         >
           {batteryArchived && <ArchivedBadge>Only Me</ArchivedBadge>}
           {battery ? (
-            <>
+            <Layout.FlexCol alignItems="center" gap={6}>
               <span style={{ fontSize: 40, lineHeight: 1 }}>
                 {SocialBatteryChipAssets[battery]?.emoji || ''}
               </span>
-              <QuadrantLabel>Social Battery</QuadrantLabel>
-            </>
+              <Typo type="label-medium" numberOfLines={1} textAlign="center">
+                {t(battery)}
+              </Typo>
+              <Typo type="label-medium" color="MEDIUM_GRAY" numberOfLines={1} textAlign="center">
+                Social Battery
+              </Typo>
+            </Layout.FlexCol>
           ) : (
             <>
               <SvgIcon name="add_reaction_default" size={32} />
@@ -198,7 +206,7 @@ export default function UpdateCheckin() {
               <Typo type="label-medium" numberOfLines={1} textAlign="center">
                 {trackData.name}
               </Typo>
-              <Typo type="label-small" color="MEDIUM_GRAY" numberOfLines={1} textAlign="center">
+              <Typo type="label-medium" color="MEDIUM_GRAY" numberOfLines={1} textAlign="center">
                 {trackData.artists?.[0]?.name || ''}
               </Typo>
             </Layout.FlexCol>

--- a/src/routes/update/UpdateCheckin.tsx
+++ b/src/routes/update/UpdateCheckin.tsx
@@ -13,7 +13,7 @@ import useAsyncEffect from '@hooks/useAsyncEffect';
 import SpotifyManager from '@libs/SpotifyManager';
 import { ComponentVisibility, DEFAULT_VISIBILITY, SocialBattery } from '@models/checkIn';
 import { useBoundStore } from '@stores/useBoundStore';
-import { postCheckIn } from '@utils/apis/checkIn';
+import { getActiveSong, postCheckIn, postSong } from '@utils/apis/checkIn';
 import { MainScrollContainer } from '../Root';
 import { ArchivedBadge, GridContainer, QuadrantCard, QuadrantLabel } from './UpdateCheckin.styled';
 
@@ -68,16 +68,19 @@ export default function UpdateCheckin() {
   }, [trackId, spotifyManager]);
 
   useAsyncEffect(async () => {
-    const ci = await fetchCheckIn();
-    if (!ci) return;
-    setBattery(ci.social_battery || null);
-    setMood(ci.mood || '');
-    setTrackId(ci.track_id || '');
-    setThought(ci.description || '');
-    if (ci.battery_visibility) setBatteryVis(ci.battery_visibility);
-    if (ci.mood_visibility) setMoodVis(ci.mood_visibility);
-    if (ci.song_visibility) setSongVis(ci.song_visibility);
-    if (ci.thought_visibility) setThoughtVis(ci.thought_visibility);
+    const [ci, activeSong] = await Promise.all([fetchCheckIn(), getActiveSong()]);
+    if (ci) {
+      setBattery(ci.social_battery || null);
+      setMood(ci.mood || '');
+      setThought(ci.description || '');
+      if (ci.battery_visibility) setBatteryVis(ci.battery_visibility);
+      if (ci.mood_visibility) setMoodVis(ci.mood_visibility);
+      if (ci.song_visibility) setSongVis(ci.song_visibility);
+      if (ci.thought_visibility) setThoughtVis(ci.thought_visibility);
+    }
+    if (activeSong) {
+      setTrackId(activeSong.track_id || '');
+    }
   }, []);
 
   const batteryArchived = useMemo(
@@ -100,16 +103,23 @@ export default function UpdateCheckin() {
   const handleSave = useCallback(async () => {
     setCheckInSaving(true);
     try {
-      await postCheckIn({
+      // Save check-in (battery, mood, thought, visibility)
+      const checkInPromise = postCheckIn({
         social_battery: battery,
         mood,
         description: thought,
-        track_id: trackId,
+        track_id: '',
         battery_visibility: batteryVis,
         mood_visibility: moodVis,
         song_visibility: songVis,
         thought_visibility: thoughtVis,
       });
+
+      // Save song separately (Song is a separate backend model)
+      const songPromise = trackId ? postSong(trackId) : Promise.resolve();
+
+      await Promise.all([checkInPromise, songPromise]);
+
       if (window.ReactNativeWebView) {
         sendMessage('WIDGET_DATA_UPDATED', {});
       }

--- a/src/routes/update/UpdateCheckin.tsx
+++ b/src/routes/update/UpdateCheckin.tsx
@@ -1,0 +1,15 @@
+import MainContainer from '@components/_common/main-container/MainContainer';
+import { Layout, Typo } from '@design-system';
+
+export default function UpdateCheckin() {
+  return (
+    <MainContainer>
+      <Layout.FlexCol w="100%" alignItems="center" justifyContent="center" pv={40}>
+        <Typo type="title-large">Update</Typo>
+        <Typo type="body-medium" color="MEDIUM_GRAY" mt={8}>
+          Check-in grid coming soon
+        </Typo>
+      </Layout.FlexCol>
+    </MainContainer>
+  );
+}

--- a/src/routes/update/UpdateCheckin.tsx
+++ b/src/routes/update/UpdateCheckin.tsx
@@ -199,7 +199,7 @@ export default function UpdateCheckin() {
             </Layout.FlexCol>
           ) : (
             <>
-              <SvgIcon name="edit_outline" size={32} />
+              <SvgIcon name="edit" size={32} />
               <QuadrantLabel>Thought Snippet</QuadrantLabel>
             </>
           )}

--- a/src/routes/update/UpdateCheckin.tsx
+++ b/src/routes/update/UpdateCheckin.tsx
@@ -1,29 +1,23 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import EmojiItem from '@components/_common/emoji-item/EmojiItem';
-import MainContainer from '@components/_common/main-container/MainContainer';
 import BatteryEditor from '@components/check-in/update-quadrant/BatteryEditor';
 import MoodEditor from '@components/check-in/update-quadrant/MoodEditor';
 import SongEditor from '@components/check-in/update-quadrant/SongEditor';
 import ThoughtEditor from '@components/check-in/update-quadrant/ThoughtEditor';
 import SpotifyMusic from '@components/music/spotify-music/SpotifyMusic';
 import { SocialBatteryChipAssets } from '@components/profile/social-batter-chip/SocialBatteryChip.contants';
-import { Button, Layout, SvgIcon, Typo } from '@design-system';
+import { Layout, SvgIcon, Typo } from '@design-system';
 import { usePostAppMessage } from '@hooks/useAppMessage';
 import useAsyncEffect from '@hooks/useAsyncEffect';
 import { ComponentVisibility, DEFAULT_VISIBILITY, SocialBattery } from '@models/checkIn';
 import { useBoundStore } from '@stores/useBoundStore';
 import { postCheckIn } from '@utils/apis/checkIn';
-import {
-  ArchivedBadge,
-  GridContainer,
-  QuadrantCard,
-  QuadrantLabel,
-  SaveButtonWrapper,
-} from './UpdateCheckin.styled';
+import { MainScrollContainer } from '../Root';
+import { ArchivedBadge, GridContainer, QuadrantCard, QuadrantLabel } from './UpdateCheckin.styled';
 
 type EditorTarget = 'battery' | 'mood' | 'song' | 'thought' | null;
 
-const ARCHIVE_THRESHOLD_MS = 12 * 60 * 60 * 1000; // 12 hours
+const ARCHIVE_THRESHOLD_MS = 12 * 60 * 60 * 1000;
 
 function isArchived(updatedAt?: string): boolean {
   if (!updatedAt) return false;
@@ -31,29 +25,29 @@ function isArchived(updatedAt?: string): boolean {
 }
 
 export default function UpdateCheckin() {
-  const { checkIn, fetchCheckIn } = useBoundStore((state) => ({
-    checkIn: state.checkIn,
-    fetchCheckIn: state.fetchCheckIn,
-  }));
+  const { checkIn, fetchCheckIn, setCheckInSaveHandler, setCheckInSaving } = useBoundStore(
+    (state) => ({
+      checkIn: state.checkIn,
+      fetchCheckIn: state.fetchCheckIn,
+      setCheckInSaveHandler: state.setCheckInSaveHandler,
+      setCheckInSaving: state.setCheckInSaving,
+    }),
+  );
 
   const sendMessage = usePostAppMessage();
 
   const [activeEditor, setActiveEditor] = useState<EditorTarget>(null);
-  const [saving, setSaving] = useState(false);
 
-  // Draft state for all 4 components
   const [battery, setBattery] = useState<SocialBattery | null>(null);
   const [mood, setMood] = useState('');
   const [trackId, setTrackId] = useState('');
   const [thought, setThought] = useState('');
 
-  // Per-component visibility
   const [batteryVis, setBatteryVis] = useState<ComponentVisibility>(DEFAULT_VISIBILITY.battery);
   const [moodVis, setMoodVis] = useState<ComponentVisibility>(DEFAULT_VISIBILITY.mood);
   const [songVis, setSongVis] = useState<ComponentVisibility>(DEFAULT_VISIBILITY.song);
   const [thoughtVis, setThoughtVis] = useState<ComponentVisibility>(DEFAULT_VISIBILITY.thought);
 
-  // Load existing check-in data
   useAsyncEffect(async () => {
     const ci = await fetchCheckIn();
     if (!ci) return;
@@ -67,7 +61,6 @@ export default function UpdateCheckin() {
     if (ci.thought_visibility) setThoughtVis(ci.thought_visibility);
   }, []);
 
-  // Detect archived state per component
   const batteryArchived = useMemo(
     () => !!battery && isArchived(checkIn?.battery_updated_at),
     [battery, checkIn?.battery_updated_at],
@@ -86,7 +79,7 @@ export default function UpdateCheckin() {
   );
 
   const handleSave = useCallback(async () => {
-    setSaving(true);
+    setCheckInSaving(true);
     try {
       await postCheckIn({
         social_battery: battery,
@@ -103,7 +96,7 @@ export default function UpdateCheckin() {
       }
       await fetchCheckIn();
     } finally {
-      setSaving(false);
+      setCheckInSaving(false);
     }
   }, [
     battery,
@@ -116,10 +109,17 @@ export default function UpdateCheckin() {
     thoughtVis,
     fetchCheckIn,
     sendMessage,
+    setCheckInSaving,
   ]);
 
+  // Register save handler for the header Save button
+  useEffect(() => {
+    setCheckInSaveHandler(handleSave);
+    return () => setCheckInSaveHandler(null);
+  }, [handleSave, setCheckInSaveHandler]);
+
   return (
-    <MainContainer>
+    <MainScrollContainer>
       <GridContainer>
         {/* Top-Left: Social Battery */}
         <QuadrantCard
@@ -206,14 +206,6 @@ export default function UpdateCheckin() {
         </QuadrantCard>
       </GridContainer>
 
-      <SaveButtonWrapper>
-        <Button.Primary
-          text={saving ? 'Saving...' : 'Save'}
-          status={saving ? 'disabled' : 'normal'}
-          onClick={handleSave}
-        />
-      </SaveButtonWrapper>
-
       {/* Editor Popups */}
       <BatteryEditor
         isOpen={activeEditor === 'battery'}
@@ -247,6 +239,6 @@ export default function UpdateCheckin() {
         visibility={thoughtVis}
         onVisibilityChange={setThoughtVis}
       />
-    </MainContainer>
+    </MainScrollContainer>
   );
 }

--- a/src/stores/checkIn.ts
+++ b/src/stores/checkIn.ts
@@ -6,10 +6,14 @@ import { SliceStateCreator } from './useBoundStore';
 interface CheckInState {
   checkIn: MyCheckIn | null;
   checkInForm: CheckInForm;
+  checkInSaveHandler: (() => Promise<void>) | null;
+  checkInSaving: boolean;
 }
 interface CheckInAction {
   fetchCheckIn: () => Promise<MyCheckIn | null>;
   setCheckInForm: (checkInForm: Partial<CheckInForm>) => void;
+  setCheckInSaveHandler: (handler: (() => Promise<void>) | null) => void;
+  setCheckInSaving: (saving: boolean) => void;
 }
 
 const initialState = {
@@ -21,6 +25,8 @@ const initialState = {
     mood: '',
     track_id: '',
   },
+  checkInSaveHandler: null as (() => Promise<void>) | null,
+  checkInSaving: false,
 };
 
 export type CheckInSlice = CheckInState & CheckInAction;
@@ -40,5 +46,7 @@ export const createCheckInSlice: SliceStateCreator<CheckInSlice> = (set) => {
     },
     setCheckInForm: (checkInForm) =>
       set((state) => ({ checkInForm: { ...state.checkInForm, ...checkInForm } })),
+    setCheckInSaveHandler: (handler) => set({ checkInSaveHandler: handler }),
+    setCheckInSaving: (saving) => set({ checkInSaving: saving }),
   };
 };

--- a/src/utils/apis/checkIn.ts
+++ b/src/utils/apis/checkIn.ts
@@ -40,6 +40,25 @@ export const toggleCheckInReaction = async (checkInId: number, emoji: string) =>
   return data;
 };
 
+// GET active song
+export const getActiveSong = async () => {
+  const { data } = await axios.get<{ results: { id: number; track_id: string }[] }>(
+    `/check_in/song/`,
+  );
+  return data.results?.[0] || null;
+};
+
+// POST song (create or update active song)
+export const postSong = async (trackId: string) => {
+  const { data } = await axios.post(`/check_in/song/`, { track_id: trackId });
+  return data;
+};
+
+// DELETE song (deactivate)
+export const deactivateSong = async (songId: number) => {
+  await axios.patch(`/check_in/song/${songId}/`);
+};
+
 // GET reactions for a check-in
 export const getCheckInReactions = async (checkInId: number) => {
   const { data } = await axios.get<


### PR DESCRIPTION
## Summary
- Restructure bottom nav: Friends → Check-In → Share → Discover → Chats
- Remove My tab (profile accessed via Friends tab username tap)
- New Check-In tab with 2x2 grid (Social Battery, Mood, Song, Thought Snippet)
- Centered popup editors with per-component visibility toggles
- Save button in header, inline Spotify search
- Song quadrant shows large album art with title/artist

## Test plan
- [ ] Navigate all 5 tabs
- [ ] Tap own username on Friends tab → profile loads
- [ ] Edit all 4 check-in components, save, navigate away and back — data persists
- [ ] Spotify search works with checkmark toggle