### PR TITLE
fix: UI polish — borderless battery, larger fonts, Chats header, reactions

### DIFF
--- a/src/components/check-in/check-in-detail-bottom-sheet/CheckInDetailBottomSheet.tsx
+++ b/src/components/check-in/check-in-detail-bottom-sheet/CheckInDetailBottomSheet.tsx
@@ -51,8 +51,9 @@ function CheckInDetailBottomSheet({
   const [trackData, setTrackData] = useState<Track | null>(null);
   const [selectedReactions, setSelectedReactions] = useState<Set<string>>(new Set());
   const [isToggling, setIsToggling] = useState(false);
+  const myProfile = useBoundStore((state) => state.myProfile);
 
-  // Fetch existing reactions when the bottom sheet opens
+  // Fetch existing reactions when the popup opens — filter to current user's only
   useEffect(() => {
     if (!visible || !checkInId) {
       setSelectedReactions(new Set());
@@ -62,17 +63,14 @@ function CheckInDetailBottomSheet({
       .then((reactions) => {
         const myEmojis = new Set<string>();
         reactions.forEach((r) => {
-          // The ReactionSerializer returns user object with id
-          // We check if the reaction belongs to the current user by checking is_mine or
-          // matching. Since the list endpoint returns all reactions, we mark ones that
-          // are ours. The backend currently returns reactions for the current user only
-          // (when not the author), so all returned reactions are ours.
-          myEmojis.add(r.emoji);
+          if (r.user?.id === myProfile?.id) {
+            myEmojis.add(r.emoji);
+          }
         });
         setSelectedReactions(myEmojis);
       })
       .catch(() => setSelectedReactions(new Set()));
-  }, [visible, checkInId]);
+  }, [visible, checkInId, myProfile?.id]);
 
   useEffect(() => {
     if (!visible || !trackId) {

--- a/src/components/check-in/my-check-in-card/MyCheckInCard.tsx
+++ b/src/components/check-in/my-check-in-card/MyCheckInCard.tsx
@@ -50,6 +50,7 @@ function MyCheckInCard() {
           <SocialBatteryChip
             socialBattery={social_battery}
             compact
+            borderless
             onClick={() => navigate('/check-in/edit?focus=battery')}
           />
         ) : (

--- a/src/components/check-in/visibility-toggle/VisibilityToggle.tsx
+++ b/src/components/check-in/visibility-toggle/VisibilityToggle.tsx
@@ -24,7 +24,7 @@ function VisibilityToggle({ value, onChange }: Props) {
           onClick={() => onChange(opt.value)}
         >
           <Typo
-            type="label-small"
+            type="label-large"
             color={value === opt.value ? 'PRIMARY' : 'MEDIUM_GRAY'}
             fontWeight={value === opt.value ? 600 : 400}
           >
@@ -47,8 +47,8 @@ const ToggleContainer = styled.div`
 const ToggleOption = styled.div<{ $isSelected: boolean }>`
   display: flex;
   align-items: center;
-  padding: 4px 8px;
-  border-radius: 6px;
+  padding: 6px 10px;
+  border-radius: 8px;
   cursor: pointer;
   background-color: ${({ $isSelected, theme }) => ($isSelected ? theme.WHITE : 'transparent')};
   border: 1px solid ${({ $isSelected, theme }) => ($isSelected ? theme.PRIMARY : 'transparent')};

--- a/src/components/friends/friend-item-with-updates/FriendItemWithUpdates.tsx
+++ b/src/components/friends/friend-item-with-updates/FriendItemWithUpdates.tsx
@@ -107,6 +107,7 @@ function FriendItemWithUpdates({ user, recentPost, onConnectionChanged }: Props)
             <SocialBatteryChip
               socialBattery={social_battery}
               compact
+              borderless
               onClick={handleClickBattery}
             />
           )}

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -30,6 +30,8 @@ function Header() {
       return <SubHeader title={t('header.questions')} />;
     case '/chats':
       return <ChatsHeader />;
+    case '/my/pings':
+      return <CommonHeader title={t('nav_tab.chats')} />;
     default:
       return null;
   }

--- a/src/components/note/new-note-header/NewNoteHeader.tsx
+++ b/src/components/note/new-note-header/NewNoteHeader.tsx
@@ -49,7 +49,7 @@ function NewNoteHeader({ status, noteId, title, noteInfo }: NewNoteHeaderProps) 
         markMissionCompleted();
       }
 
-      navigate(`/notes/${newNoteId}`, { state: 'new' });
+      navigate(`/notes/${newNoteId}`, { state: { new: true, fromShare } });
       openToast({
         message: t(status === 'edit' ? 'updated' : 'posted'),
         actionText: t('view'),

--- a/src/components/note/note-item/NoteItem.tsx
+++ b/src/components/note/note-item/NoteItem.tsx
@@ -155,6 +155,9 @@ function NoteItem({ note, isMyPage, displayType = 'LIST', refresh }: NoteItemPro
                 <Typo type="title-medium" ellipsis={{ enabled: true, maxWidth: 140 }}>
                   {username}
                 </Typo>
+                {(author_detail as any)?.connection_status === 'close_friend' && (
+                  <SvgIcon name="close_friend" size={16} />
+                )}
                 {!current_user_read && !isMyPage && <UpdatedLabel />}
               </Layout.FlexRow>
               <Layout.FlexRow alignItems="center" gap={4} style={{ flexWrap: 'wrap' }}>

--- a/src/components/profile/social-batter-chip/SocialBatteryChip.tsx
+++ b/src/components/profile/social-batter-chip/SocialBatteryChip.tsx
@@ -1,5 +1,4 @@
 import { useTranslation } from 'react-i18next';
-import EmojiItem from '@components/_common/emoji-item/EmojiItem';
 import { Layout, Typo } from '@design-system';
 import { SocialBattery } from '@models/checkIn';
 import { SocialBatteryChipAssets } from './SocialBatteryChip.contants';
@@ -9,6 +8,7 @@ interface SocialBatteryChipProps {
   onSelect?: (socialBattery: SocialBattery) => void;
   isSelected?: boolean;
   compact?: boolean;
+  borderless?: boolean;
   onClick?: () => void;
 }
 
@@ -17,6 +17,7 @@ function SocialBatteryChip({
   onSelect,
   isSelected,
   compact = false,
+  borderless = false,
   onClick,
 }: SocialBatteryChipProps) {
   const [t] = useTranslation('translation', { keyPrefix: 'social_battery' });
@@ -29,6 +30,21 @@ function SocialBatteryChip({
     return null;
   }
   const { emoji } = SocialBatteryChipAssets[socialBattery];
+
+  if (borderless) {
+    return (
+      // eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
+      <span
+        role="button"
+        tabIndex={0}
+        style={{ cursor: onClick ? 'pointer' : undefined, fontSize: 18, lineHeight: 1 }}
+        onClick={handleOnClick}
+      >
+        {emoji}
+      </span>
+    );
+  }
+
   return (
     <Layout.FlexRow
       bgColor="WHITE"
@@ -41,9 +57,7 @@ function SocialBatteryChip({
       style={{ flexShrink: 0 }}
       onClick={handleOnClick}
     >
-      {emoji && (
-        <EmojiItem emojiString={emoji} size={16} bgColor="TRANSPARENT" outline="TRANSPARENT" />
-      )}
+      {emoji && <span style={{ fontSize: 16, lineHeight: 1 }}>{emoji}</span>}
       {!compact && <Typo type="label-large">{t(socialBattery)}</Typo>}
     </Layout.FlexRow>
   );

--- a/src/components/response/response-item/ResponseItem.tsx
+++ b/src/components/response/response-item/ResponseItem.tsx
@@ -156,10 +156,13 @@ function ResponseItem({
               />
               {/* author, created_at information */}
               <Layout.FlexCol>
-                <Layout.FlexRow onClick={navigateToProfile}>
+                <Layout.FlexRow onClick={navigateToProfile} gap={4} alignItems="center">
                   <Typo type="title-medium" ellipsis={{ enabled: true, maxWidth: 90 }}>
                     {username}
                   </Typo>
+                  {(author_detail as any)?.connection_status === 'close_friend' && (
+                    <SvgIcon name="close_friend" size={16} />
+                  )}
                 </Layout.FlexRow>
                 {!current_user_read && !isMyPage && <UpdatedLabel />}
                 <Layout.FlexRow alignItems="center" gap={4} style={{ flexWrap: 'wrap' }}>

--- a/src/components/share/MissionOfTheDay.tsx
+++ b/src/components/share/MissionOfTheDay.tsx
@@ -93,10 +93,11 @@ function MissionOfTheDay({ onDoMission }: Props) {
     setAttempts(currentAttempts);
   }
 
+  const remaining = MAX_ATTEMPTS - attempts;
   const buttonLabel = allUsed
-    ? `All ${MAX_ATTEMPTS} attempts used`
+    ? 'No attempts left today'
     : attempts > 0
-    ? `Do it (${attempts}/${MAX_ATTEMPTS} shared)`
+    ? `Try again (${remaining} left)`
     : 'Do it';
 
   return (

--- a/src/routes/notes/NoteDetail.tsx
+++ b/src/routes/notes/NoteDetail.tsx
@@ -50,8 +50,15 @@ export function NoteDetail() {
     }
   }, [noteId, reload]);
 
+  const isNew = location.state === 'new' || location.state?.new;
+  const fromShare = location.state?.fromShare;
+
   const handleGoBack = () => {
-    navigate('/my');
+    if (fromShare) {
+      navigate('/share');
+    } else {
+      navigate('/my');
+    }
   };
 
   return (
@@ -62,7 +69,7 @@ export function NoteDetail() {
             ? t('note_detail.title', { username: noteDetail.data.author_detail?.username })
             : ''
         }
-        onGoBack={location.state === 'new' ? handleGoBack : undefined}
+        onGoBack={isNew ? handleGoBack : undefined}
       />
       <Layout.FlexCol w="100%" alignItems="center" mt={12} ph={12}>
         {noteDetail.state === 'loading' && <NoteLoader />}

--- a/src/routes/ping/PingList.tsx
+++ b/src/routes/ping/PingList.tsx
@@ -2,15 +2,14 @@ import { Fragment, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import Divider from '@components/_common/divider/Divider';
 import Loader from '@components/_common/loader/Loader';
-import MainContainer from '@components/_common/main-container/MainContainer';
 import NoContents from '@components/_common/no-contents/NoContents';
-import SubHeader from '@components/sub-header/SubHeader';
-import { DEFAULT_MARGIN, TITLE_HEADER_HEIGHT } from '@constants/layout';
+import { DEFAULT_MARGIN } from '@constants/layout';
 import { Layout } from '@design-system';
 import useAsyncEffect from '@hooks/useAsyncEffect';
 import useInfiniteScroll from '@hooks/useInfiniteScroll';
 import { PingRoom } from '@models/ping';
 import { getPingRooms } from '@utils/apis/ping';
+import { MainScrollContainer } from '../Root';
 import { PingRoomItem } from './PingRoomItem';
 
 function PingList() {
@@ -50,9 +49,8 @@ function PingList() {
     useInfiniteScroll<HTMLDivElement>(infiniteCallback);
 
   return (
-    <MainContainer>
-      <SubHeader title={t('list_title')} LeftComponent={<Layout.LayoutBase w={36} h={36} />} />
-      <Layout.FlexCol w="100%" mt={TITLE_HEADER_HEIGHT} ph={DEFAULT_MARGIN} pb={14} gap={0}>
+    <MainScrollContainer>
+      <Layout.FlexCol w="100%" ph={DEFAULT_MARGIN} pb={14} gap={0}>
         {loading && rooms.length < 1 && (
           <Layout.FlexRow w="100%" h={40} justifyContent="center">
             <Loader />
@@ -76,7 +74,7 @@ function PingList() {
           </>
         )}
       </Layout.FlexCol>
-    </MainContainer>
+    </MainScrollContainer>
   );
 }
 

--- a/src/routes/settings/EditProfile.tsx
+++ b/src/routes/settings/EditProfile.tsx
@@ -342,13 +342,15 @@ function EditProfile() {
 
         {/* pronouns */}
         <Layout.FlexCol gap={4} w="100%">
-          <ValidatedInput
-            label={t('pronouns')}
-            name="pronouns"
-            type="text"
-            value={draft.pronouns}
-            onChange={handleChangeInput}
-          />
+          <Layout.FlexCol w="100%" mb={4}>
+            <ValidatedInput
+              label={t('pronouns')}
+              name="pronouns"
+              type="text"
+              value={draft.pronouns}
+              onChange={handleChangeInput}
+            />
+          </Layout.FlexCol>
           <CheckBox
             name={String(t('friends_only.pronouns'))}
             checked={draft.pronouns_friends_only}

--- a/src/routes/update/UpdateCheckin.styled.ts
+++ b/src/routes/update/UpdateCheckin.styled.ts
@@ -62,7 +62,7 @@ export const ArchivedBadge = styled.div`
 `;
 
 export const QuadrantLabel = styled.span`
-  font-size: 12px;
+  font-size: 14px;
   color: ${Colors.MEDIUM_GRAY};
   font-weight: 500;
 `;

--- a/src/routes/update/UpdateCheckin.tsx
+++ b/src/routes/update/UpdateCheckin.tsx
@@ -162,10 +162,10 @@ export default function UpdateCheckin() {
               <span style={{ fontSize: 40, lineHeight: 1 }}>
                 {SocialBatteryChipAssets[battery]?.emoji || ''}
               </span>
-              <Typo type="label-medium" numberOfLines={1} textAlign="center">
+              <Typo type="body-medium" numberOfLines={1} textAlign="center">
                 {t(battery)}
               </Typo>
-              <Typo type="label-medium" color="MEDIUM_GRAY" numberOfLines={1} textAlign="center">
+              <Typo type="body-medium" color="MEDIUM_GRAY" numberOfLines={1} textAlign="center">
                 Social Battery
               </Typo>
             </Layout.FlexCol>
@@ -213,10 +213,10 @@ export default function UpdateCheckin() {
                   style={{ width: 56, height: 56, borderRadius: 8, objectFit: 'cover' }}
                 />
               )}
-              <Typo type="label-medium" numberOfLines={1} textAlign="center">
+              <Typo type="body-medium" numberOfLines={1} textAlign="center">
                 {trackData.name}
               </Typo>
-              <Typo type="label-medium" color="MEDIUM_GRAY" numberOfLines={1} textAlign="center">
+              <Typo type="body-medium" color="MEDIUM_GRAY" numberOfLines={1} textAlign="center">
                 {trackData.artists?.[0]?.name || ''}
               </Typo>
             </Layout.FlexCol>


### PR DESCRIPTION
## Summary
- Social Battery renders as bare emoji on friend cards (no border/bg), keeps border on profile
- Check-In page: larger quadrant labels, body-medium content text, label-large visibility toggle
- Chats tab header renamed from "Ping" to "Chats" with notification bell and hamburger
- Post-submission from Share navigates to post detail, back returns to Share
- Pronoun input spacing fix
- Check-in reactions filter by current user on popup reopen
- Close friend icon on Posts tab feed items (uses connection_status from API)

## Test plan
- [ ] Battery emoji borderless on friend cards, bordered on profile page
- [ ] Check-In page text clearly readable
- [ ] Chats tab shows "Chats" header with standard buttons
- [ ] Close friend icon visible on posts from close friends