### PR TITLE
hotfix: fetch chip definitions from backend instead of hardcoding

### DIFF
--- a/src/components/discover/SelectInterestSection/SelectInterestSection.tsx
+++ b/src/components/discover/SelectInterestSection/SelectInterestSection.tsx
@@ -11,12 +11,16 @@ import * as S from './SelectInterestSection.styled';
 const COLLAPSED_COUNT = 10;
 
 interface SelectInterestSectionProps {
+  category?: string;
+  categoryLabel?: string;
   interestList?: InterestItem[];
   isSaved?: boolean;
   onSave?: () => void;
 }
 
 function SelectInterestSection({
+  category,
+  categoryLabel,
   interestList = [],
   isSaved = false,
   onSave,
@@ -51,6 +55,7 @@ function SelectInterestSection({
       profile: {
         user_interests: selectedInterests,
       },
+      interestCategory: category,
       onSuccess: (data: MyProfile) => {
         updateMyProfile({ ...data });
       },
@@ -65,7 +70,7 @@ function SelectInterestSection({
   return (
     <S.SelectInterestSectionWrapper>
       <Typo type="title-medium" color="WHITE" ml={16}>
-        Select your interests
+        {categoryLabel || 'Select your interests'}
       </Typo>
 
       <S.InterestGrid>

--- a/src/components/profile/Profile.tsx
+++ b/src/components/profile/Profile.tsx
@@ -10,7 +10,8 @@ import { Layout, SvgIcon, Typo } from '@design-system';
 import useAsyncEffect from '@hooks/useAsyncEffect';
 import { Connection } from '@models/api/friends';
 import { MyProfile } from '@models/api/user';
-import { ALL_CATEGORIES, normalizeChipText } from '@models/chips';
+import { normalizeChipText } from '@models/chips';
+import { useChipCategories } from '@hooks/useChipCategories';
 import { areFriends, isMyProfile, UserProfile } from '@models/user';
 import { useBoundStore } from '@stores/useBoundStore';
 import { UserSelector } from '@stores/user';
@@ -29,6 +30,7 @@ interface ProfileProps {
 
 function Profile({ user }: ProfileProps) {
   const [t] = useTranslation('translation', { keyPrefix: 'user_page' });
+  const { categories } = useChipCategories();
 
   const { featureFlags, myProfile } = useBoundStore(useShallow(UserSelector));
   const isMyPage = user?.id === myProfile?.id;
@@ -245,7 +247,7 @@ function Profile({ user }: ProfileProps) {
                     ...(friendData.mutual_interests ?? []),
                     ...(friendData.mutual_personas ?? []),
                   ].map((trait) => {
-                    const matchedCat = ALL_CATEGORIES.find((cat) =>
+                    const matchedCat = categories.find((cat) =>
                       cat.chips.some(
                         (c) => normalizeChipText(c) === normalizeChipText(trait.content),
                       ),
@@ -254,7 +256,7 @@ function Profile({ user }: ProfileProps) {
                       <CategoryChip
                         key={trait.id}
                         label={trait.content}
-                        category={matchedCat?.key ?? ALL_CATEGORIES[0].key}
+                        category={matchedCat?.key ?? categories[0].key}
                         isSelected
                       />
                     );

--- a/src/components/profile/chip/AddCustomChipInput.tsx
+++ b/src/components/profile/chip/AddCustomChipInput.tsx
@@ -1,6 +1,6 @@
 import { KeyboardEvent, useRef, useState } from 'react';
 import styled from 'styled-components';
-import { CHIP_CATEGORIES, ChipCategory, MAX_CUSTOM_CHIP_LENGTH } from '@models/chips';
+import { CHIP_CATEGORY_COLORS, ChipCategory, MAX_CUSTOM_CHIP_LENGTH } from '@models/chips';
 
 interface Props {
   category: ChipCategory;
@@ -12,7 +12,7 @@ function AddCustomChipInput({ category, onAdd, disabled = false }: Props) {
   const [isEditing, setIsEditing] = useState(false);
   const [value, setValue] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);
-  const { colors } = CHIP_CATEGORIES[category];
+  const colors = CHIP_CATEGORY_COLORS[category] ?? { bg: '#F3E8FF', text: '#8700FF', border: '#8700FF' };
 
   const handleStartEditing = () => {
     if (disabled) return;

--- a/src/components/profile/chip/CategoryChip.tsx
+++ b/src/components/profile/chip/CategoryChip.tsx
@@ -1,6 +1,6 @@
 import { MouseEvent } from 'react';
 import styled from 'styled-components';
-import { CHIP_CATEGORIES, ChipCategory } from '@models/chips';
+import { CHIP_CATEGORY_COLORS, ChipCategory } from '@models/chips';
 
 interface Props {
   label: string;
@@ -11,7 +11,7 @@ interface Props {
 }
 
 function CategoryChip({ label, category, isSelected = false, isCustom = false, onClick }: Props) {
-  const { colors } = CHIP_CATEGORIES[category];
+  const colors = CHIP_CATEGORY_COLORS[category] ?? { bg: '#F3E8FF', text: '#8700FF', border: '#8700FF' };
 
   return (
     <ChipContainer

--- a/src/components/profile/more-about-bottom-sheet/MoreAboutBottomSheet.tsx
+++ b/src/components/profile/more-about-bottom-sheet/MoreAboutBottomSheet.tsx
@@ -4,7 +4,8 @@ import BottomModal from '@components/_common/bottom-modal/BottomModal';
 import Icon from '@components/_common/icon/Icon';
 import { Layout, SvgIcon, Typo } from '@design-system';
 import { MyProfile } from '@models/api/user';
-import { ALL_CATEGORIES, normalizeChipText } from '@models/chips';
+import { normalizeChipText } from '@models/chips';
+import { useChipCategories } from '@hooks/useChipCategories';
 import { UserProfile } from '@models/user';
 import CategoryChip from '../chip/CategoryChip';
 
@@ -24,6 +25,7 @@ function MoreAboutBottomSheet({
   isMyPage,
 }: MoreAboutBottomSheetProps) {
   const [t] = useTranslation('translation', { keyPrefix: 'user_page' });
+  const { categories } = useChipCategories();
   const navigate = useNavigate();
 
   const handleClickEdit = () => {
@@ -40,7 +42,7 @@ function MoreAboutBottomSheet({
     : [];
 
   // Group chips by category
-  const groupedByCategory = ALL_CATEGORIES.map((cat) => ({
+  const groupedByCategory = categories.map((cat) => ({
     category: cat,
     chips: allUserChips.filter((chip) =>
       cat.chips.some((c) => normalizeChipText(c) === normalizeChipText(chip)),

--- a/src/hooks/useChipCategories.ts
+++ b/src/hooks/useChipCategories.ts
@@ -1,0 +1,14 @@
+import useSWR from 'swr';
+import { ChipCategoryInfo, toChipCategoryInfo } from '@models/chips';
+import { getChipCategories } from '@utils/apis/chips';
+
+export function useChipCategories() {
+  const { data, isLoading } = useSWR('/user/chip-categories/', getChipCategories, {
+    revalidateOnFocus: false,
+    dedupingInterval: 60_000,
+  });
+
+  const categories: ChipCategoryInfo[] = (data ?? []).map(toChipCategoryInfo);
+
+  return { categories, isLoading };
+}

--- a/src/models/chips.ts
+++ b/src/models/chips.ts
@@ -1,6 +1,6 @@
 /**
- * Expanded chip system with 7 distinct categories.
- * Each category has a unique color scheme (WCAG AA compliant).
+ * Chip category system — colors and types live here,
+ * chip names are fetched from the backend (single source of truth).
  */
 
 export enum ChipCategory {
@@ -13,6 +13,15 @@ export enum ChipCategory {
   LEAST_FAVORITE_PLATFORM = 'least_favorite_platform',
 }
 
+/** Shape returned by GET /user/chip-categories/ */
+export interface ChipCategoryData {
+  key: string;
+  label: string;
+  description: string;
+  chips: string[];
+}
+
+/** Full category info used by components (API data + local colors). */
 export interface ChipCategoryInfo {
   key: ChipCategory;
   label: string;
@@ -30,168 +39,27 @@ export interface CustomChip {
 export const MAX_CUSTOM_CHIPS_PER_CATEGORY = 5;
 export const MAX_CUSTOM_CHIP_LENGTH = 25;
 
-export const CHIP_CATEGORIES: Record<ChipCategory, ChipCategoryInfo> = {
-  [ChipCategory.MUSIC_ENTERTAINMENT]: {
-    key: ChipCategory.MUSIC_ENTERTAINMENT,
-    label: 'Music & Entertainment',
-    description: 'What you consume — genres, media, formats.',
-    chips: [
-      'Hip-Hop',
-      'R&B',
-      'Pop',
-      'Indie',
-      'K-Pop',
-      'Rock',
-      'EDM',
-      'Jazz',
-      'Lo-Fi',
-      'Anime',
-      'K-Drama',
-      'Reality TV',
-      'Horror',
-      'Sci-Fi',
-      'Documentaries',
-      'Comedy',
-      'Podcasts',
-      'Manga/Webtoons',
-    ],
-    colors: { bg: '#F3E8FF', text: '#8700FF', border: '#8700FF' },
-  },
-  [ChipCategory.HOBBIES_ACTIVITIES]: {
-    key: ChipCategory.HOBBIES_ACTIVITIES,
-    label: 'Hobbies & Activities',
-    description: 'What you do with your time — sports, creative work, lifestyle.',
-    chips: [
-      'Gaming',
-      'Basketball',
-      'Soccer',
-      'Volleyball',
-      'Tennis',
-      'Gym',
-      'Running',
-      'Skating',
-      'Climbing',
-      'Hiking',
-      'Surfing',
-      'Cycling',
-      'Drawing',
-      'Photography',
-      'Cooking',
-      'Baking',
-      'Thrifting',
-      'Journaling',
-      'Reading',
-      'Coding',
-      'Music Production',
-      'Video Editing',
-      'Fashion',
-      'DIY',
-    ],
-    colors: { bg: '#F3E8FF', text: '#8700FF', border: '#8700FF' },
-  },
-  [ChipCategory.ON_MY_MIND]: {
-    key: ChipCategory.ON_MY_MIND,
-    label: 'On My Mind',
-    description: 'Current rabbit holes, intellectual interests, life-phase topics.',
-    chips: [
-      'Astrology',
-      'Psychology',
-      'Philosophy',
-      'Sustainability',
-      'Mental Health',
-      'Skincare',
-      'Spirituality',
-      'Finance',
-      'Language Learning',
-      'AI & Tech',
-      'Design',
-      'Writing',
-      'College/Career',
-      'Fitness Journey',
-    ],
-    colors: { bg: '#F3E8FF', text: '#8700FF', border: '#8700FF' },
-  },
-  [ChipCategory.AS_A_FRIEND]: {
-    key: ChipCategory.AS_A_FRIEND,
-    label: 'As a Friend',
-    description: 'How you show up in relationships — personality and values.',
-    chips: [
-      'Good Listener',
-      'Brutally Honest',
-      'Hype Person',
-      'Low Maintenance',
-      'Planner',
-      'Spontaneous',
-      'Night Owl',
-      'Early Bird',
-      'Overthinker',
-      'Go With the Flow',
-      'Needs Alone Time',
-      'Always Down to Talk',
-      'Dry Humor',
-      'Keeps It Real',
-    ],
-    colors: { bg: '#F3E8FF', text: '#8700FF', border: '#8700FF' },
-  },
-  [ChipCategory.ONLINE_PERSONA]: {
-    key: ChipCategory.ONLINE_PERSONA,
-    label: 'Online Persona',
-    description: 'How you behave on the internet — distinct behavioral archetypes.',
-    chips: [
-      'Lurker',
-      'Content Creator',
-      'Meme Collector',
-      'Night Scroller',
-      'Occasional Poster',
-      'Story Watcher',
-      'Always in the Comments',
-      'Curated Feed',
-      'Posts and Deletes',
-      'Oversharer',
-      'Silent Supporter',
-      'Late Replier',
-    ],
-    colors: { bg: '#F3E8FF', text: '#8700FF', border: '#8700FF' },
-  },
-  [ChipCategory.FAVORITE_PLATFORM]: {
-    key: ChipCategory.FAVORITE_PLATFORM,
-    label: 'Favorite Platform',
-    description: 'The platforms you love most.',
-    chips: [
-      'Instagram',
-      'TikTok',
-      'YouTube',
-      'Snapchat',
-      'X / Twitter',
-      'Discord',
-      'Reddit',
-      'Pinterest',
-      'BeReal',
-      'Threads',
-    ],
-    colors: { bg: '#F3E8FF', text: '#8700FF', border: '#8700FF' },
-  },
-  [ChipCategory.LEAST_FAVORITE_PLATFORM]: {
-    key: ChipCategory.LEAST_FAVORITE_PLATFORM,
-    label: 'Least Favorite Platform',
-    description: 'The platforms you could do without.',
-    chips: [
-      'Instagram',
-      'TikTok',
-      'YouTube',
-      'Snapchat',
-      'X / Twitter',
-      'Discord',
-      'Reddit',
-      'Pinterest',
-      'BeReal',
-      'Threads',
-    ],
-    colors: { bg: '#F3E8FF', text: '#8700FF', border: '#8700FF' },
-  },
+/** Per-category color scheme (WCAG AA compliant). */
+export const CHIP_CATEGORY_COLORS: Record<string, { bg: string; text: string; border: string }> = {
+  [ChipCategory.MUSIC_ENTERTAINMENT]: { bg: '#F3E8FF', text: '#8700FF', border: '#8700FF' },
+  [ChipCategory.HOBBIES_ACTIVITIES]: { bg: '#F3E8FF', text: '#8700FF', border: '#8700FF' },
+  [ChipCategory.ON_MY_MIND]: { bg: '#F3E8FF', text: '#8700FF', border: '#8700FF' },
+  [ChipCategory.AS_A_FRIEND]: { bg: '#F3E8FF', text: '#8700FF', border: '#8700FF' },
+  [ChipCategory.ONLINE_PERSONA]: { bg: '#F3E8FF', text: '#8700FF', border: '#8700FF' },
+  [ChipCategory.FAVORITE_PLATFORM]: { bg: '#F3E8FF', text: '#8700FF', border: '#8700FF' },
+  [ChipCategory.LEAST_FAVORITE_PLATFORM]: { bg: '#F3E8FF', text: '#8700FF', border: '#8700FF' },
 };
 
-export const ALL_CATEGORIES = Object.values(CHIP_CATEGORIES);
+const DEFAULT_COLORS = { bg: '#F3E8FF', text: '#8700FF', border: '#8700FF' };
+
+/** Merge backend category data with local colors. */
+export function toChipCategoryInfo(data: ChipCategoryData): ChipCategoryInfo {
+  return {
+    ...data,
+    key: data.key as ChipCategory,
+    colors: CHIP_CATEGORY_COLORS[data.key] ?? DEFAULT_COLORS,
+  };
+}
 
 /**
  * Normalize chip text for comparison (case-insensitive matching for custom chips).

--- a/src/models/discover.ts
+++ b/src/models/discover.ts
@@ -37,6 +37,8 @@ export interface InterestItem {
 
 // Interest Card Body (type: "Interest")
 export interface InterestCardBody {
+  category: string;
+  category_label: string;
   list: InterestItem[];
 }
 

--- a/src/routes/discover/Discover.tsx
+++ b/src/routes/discover/Discover.tsx
@@ -212,6 +212,8 @@ function Discover() {
             <S.AnimatedCardWrapper key={`interest-${index}`} $isAnimating={isInterestAnimating}>
               <SelectInterestSection
                 key={`interest-${index}`}
+                category={item.body.category}
+                categoryLabel={item.body.category_label}
                 interestList={item.body.list}
                 isSaved={isInterestSaved}
                 onSave={handleInterestSave}

--- a/src/routes/settings/EditProfile.tsx
+++ b/src/routes/settings/EditProfile.tsx
@@ -12,7 +12,8 @@ import SubHeader from '@components/sub-header/SubHeader';
 import { TITLE_HEADER_HEIGHT } from '@constants/layout';
 import { CheckBox, Layout, Typo } from '@design-system';
 import { MyProfile } from '@models/api/user';
-import { ALL_CATEGORIES, ChipCategory, CustomChip, normalizeChipText } from '@models/chips';
+import { ChipCategory, CustomChip, normalizeChipText } from '@models/chips';
+import { useChipCategories } from '@hooks/useChipCategories';
 import { useBoundStore } from '@stores/useBoundStore';
 import { createCustomChip, deleteCustomChip } from '@utils/apis/chips';
 import { editProfile, updateChipsByCategory } from '@utils/apis/my';
@@ -32,6 +33,8 @@ function EditProfile() {
     featureFlags: state.featureFlags,
   }));
 
+  const { categories } = useChipCategories();
+
   // Parse existing user chips into per-category selections
   const parseExistingChips = () => {
     const existing = [
@@ -41,7 +44,7 @@ function EditProfile() {
     const result: Record<string, string[]> = {};
     const customResult: CustomChip[] = [];
 
-    ALL_CATEGORIES.forEach((cat) => {
+    categories.forEach((cat) => {
       const matched = existing.filter((chip) =>
         cat.chips.some((c) => normalizeChipText(c) === normalizeChipText(chip)),
       );
@@ -375,7 +378,7 @@ function EditProfile() {
         </Layout.FlexCol>
 
         {/* Chip Categories (7 categories) — each with its own visibility */}
-        {ALL_CATEGORIES.map((categoryInfo) => (
+        {categories.map((categoryInfo) => (
           <Layout.FlexCol key={categoryInfo.key} gap={4} w="100%">
             <ChipCategorySection
               categoryInfo={categoryInfo}

--- a/src/utils/apis/chips.ts
+++ b/src/utils/apis/chips.ts
@@ -1,5 +1,10 @@
-import { CustomChip } from '@models/chips';
+import { ChipCategoryData, CustomChip } from '@models/chips';
 import axiosInstance from '@utils/apis/axios';
+
+export async function getChipCategories(): Promise<ChipCategoryData[]> {
+  const { data } = await axiosInstance.get<ChipCategoryData[]>('/user/chip-categories/');
+  return Array.isArray(data) ? data : (data as any).results ?? [];
+}
 
 export async function getCustomChips(): Promise<CustomChip[]> {
   const { data } = await axiosInstance.get<CustomChip[]>('/user/me/custom-chips/');

--- a/src/utils/apis/my.ts
+++ b/src/utils/apis/my.ts
@@ -26,6 +26,7 @@ export const getMyProfile = async () => {
 // update my profile
 export const editProfile = ({
   profile,
+  interestCategory,
   onSuccess,
   onError,
 }: {
@@ -43,6 +44,7 @@ export const editProfile = ({
   > & {
     profile_image?: File;
   };
+  interestCategory?: string;
   onSuccess: (data: MyProfile) => void;
   onError?: (error: any) => void;
 }) => {
@@ -59,10 +61,15 @@ export const editProfile = ({
       return;
     }
 
-    // user_interests, user_personas를 공백으로 구분된 문자열로 전송 (# 접두사 없이)
+    // When interestCategory is set, send as JSON array (chip names can contain spaces)
     if (key === 'user_interests' && Array.isArray(value)) {
       const cleanValues = value.map((v: string) => v.replace(/^#+/, ''));
-      formData.append('user_interests', cleanValues.join(' '));
+      if (interestCategory) {
+        formData.append('user_interests', JSON.stringify(cleanValues));
+        formData.append('interest_category', interestCategory);
+      } else {
+        formData.append('user_interests', cleanValues.join(' '));
+      }
       return;
     }
 


### PR DESCRIPTION
# Frontend Changes: Category-based Chip System

## Summary

Remove hardcoded chip lists from the frontend. Fetch chip definitions from the backend API so there is a single source of truth. Update discover card to send category context when saving.

## Changed Files

### `models/chips.ts`
- Remove all hardcoded chip name arrays and `CHIP_CATEGORIES` / `ALL_CATEGORIES`
- Keep: `ChipCategory` enum, `CHIP_CATEGORY_COLORS`, types, `normalizeChipText()`
- Add: `ChipCategoryData` (API response type), `toChipCategoryInfo()` (merges API data with local colors)

### `models/discover.ts`
- Add `category` and `category_label` fields to `InterestCardBody`

### `hooks/useChipCategories.ts` (new)
- SWR hook that fetches `GET /user/chip-categories/` and returns `ChipCategoryInfo[]` with colors merged

### `utils/apis/chips.ts`
- Add `getChipCategories()` API function

### `utils/apis/my.ts`
- `editProfile()` accepts optional `interestCategory` param
- When set, sends `user_interests` as JSON array + `interest_category` field (supports chip names with spaces)

### `components/discover/SelectInterestSection/SelectInterestSection.tsx`
- Accept `category` and `categoryLabel` props
- Show category label as card title
- Pass `interestCategory` to `editProfile` on save

### `routes/discover/Discover.tsx`
- Pass `item.body.category` and `item.body.category_label` to `SelectInterestSection`

### `routes/settings/EditProfile.tsx`
- Use `useChipCategories()` hook instead of static `ALL_CATEGORIES`

### `components/profile/Profile.tsx`
- Use `useChipCategories()` hook instead of static `ALL_CATEGORIES`

### `components/profile/more-about-bottom-sheet/MoreAboutBottomSheet.tsx`
- Use `useChipCategories()` hook instead of static `ALL_CATEGORIES`

### `components/profile/chip/CategoryChip.tsx` & `AddCustomChipInput.tsx`
- Use `CHIP_CATEGORY_COLORS` directly instead of `CHIP_CATEGORIES[category].colors`
