### PR TITLE
feat: Friends tab — multi-emoji mood, per-component nudges, auto-save

### DIFF
--- a/src/components/check-in/CheckIn.tsx
+++ b/src/components/check-in/CheckIn.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
-import EmojiItem from '@components/_common/emoji-item/EmojiItem';
 import UpdatedLabel from '@components/friends/updated-label/UpdatedLabel';
 import SpotifyMusic from '@components/music/spotify-music/SpotifyMusic';
 import MoodPlaceholder from '@components/profile/placeholders/MoodPlaceholder';
@@ -35,8 +34,8 @@ function CheckIn({ user }: CheckInProps) {
   const [checkIn, setCheckIn] = useState<CheckInBase | null | undefined>(
     isMyPage ? initialCheckIn : user.check_in,
   );
-  const { social_battery, track_id, mood, description, current_user_read } = checkIn || {};
-  const hasCheckIn = checkIn && (mood || description || social_battery || track_id);
+  const { social_battery, track_id, mood, thought, current_user_read } = checkIn || {};
+  const hasCheckIn = checkIn && (mood || thought || social_battery || track_id);
 
   const [currentDate] = useState(() => new Date());
   const navigate = useNavigate();
@@ -101,7 +100,7 @@ function CheckIn({ user }: CheckInProps) {
           </Layout.FlexRow>
         </Layout.FlexRow>
         <Layout.FlexRow w="100%" alignItems="center" gap={8}>
-          {!!mood || !!description ? (
+          {!!mood || !!thought ? (
             <Layout.FlexRow
               gap={4}
               bgColor="WHITE"
@@ -117,18 +116,16 @@ function CheckIn({ user }: CheckInProps) {
               }}
             >
               {/* emoji */}
-              {mood && (
-                <EmojiItem
-                  emojiString={mood}
-                  size={16}
-                  bgColor="TRANSPARENT"
-                  outline="TRANSPARENT"
-                />
-              )}
-              {/* description */}
-              {description && (
+              {mood &&
+                (Array.isArray(mood) ? mood : [mood]).filter(Boolean).map((emoji) => (
+                  <span key={emoji} style={{ fontSize: 16, lineHeight: 1 }}>
+                    {emoji}
+                  </span>
+                ))}
+              {/* thought */}
+              {thought && (
                 <Typo type="label-large" numberOfLines={2}>
-                  {description}
+                  {thought}
                 </Typo>
               )}
             </Layout.FlexRow>

--- a/src/components/check-in/check-in-detail-bottom-sheet/CheckInDetailBottomSheet.tsx
+++ b/src/components/check-in/check-in-detail-bottom-sheet/CheckInDetailBottomSheet.tsx
@@ -24,13 +24,13 @@ const REACTION_SHORTCUTS = [
 interface Props {
   visible: boolean;
   closeBottomSheet: () => void;
-  focusComponent?: 'battery' | 'status' | 'song' | null;
+  focusComponent?: 'battery' | 'mood' | 'thought' | 'song' | null;
   checkInId?: number | null;
   username?: string;
   profileImage?: string | null;
   socialBattery?: SocialBattery | null;
   trackId?: string;
-  mood?: string;
+  mood?: string[];
   description?: string;
 }
 
@@ -161,22 +161,23 @@ function CheckInDetailBottomSheet({
               </Layout.FlexCol>
             )}
 
-          {/* Mood + Description */}
-          {focusComponent === 'status' && (mood || description) && (
+          {/* Mood (emojis) */}
+          {focusComponent === 'mood' && mood && mood.length > 0 && (
+            <Layout.FlexRow gap={8} alignItems="center" justifyContent="center" w="100%">
+              {mood.map((emoji) => (
+                <span key={emoji} style={{ fontSize: 32, lineHeight: 1 }}>
+                  {emoji}
+                </span>
+              ))}
+            </Layout.FlexRow>
+          )}
+
+          {/* Thought (text) */}
+          {focusComponent === 'thought' && description && (
             <Layout.FlexCol gap={8} alignItems="center" w="100%">
-              {mood && (
-                <EmojiItem
-                  emojiString={mood}
-                  size={32}
-                  bgColor="TRANSPARENT"
-                  outline="TRANSPARENT"
-                />
-              )}
-              {description && (
-                <Typo type="body-large" textAlign="center" numberOfLines={5}>
-                  {description}
-                </Typo>
-              )}
+              <Typo type="body-large" textAlign="center" numberOfLines={5}>
+                {description}
+              </Typo>
             </Layout.FlexCol>
           )}
 

--- a/src/components/check-in/my-check-in-card/MyCheckInCard.tsx
+++ b/src/components/check-in/my-check-in-card/MyCheckInCard.tsx
@@ -1,7 +1,7 @@
 import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
 import ProfileImage from '@components/_common/profile-image/ProfileImage';
 import SpotifyMusic from '@components/music/spotify-music/SpotifyMusic';
-import MoodPlaceholder from '@components/profile/placeholders/MoodPlaceholder';
 import MusicPlaceholder from '@components/profile/placeholders/MusicPlaceholder';
 import SocialBatteryPlaceholder from '@components/profile/placeholders/SocialBatteryPlaceholder';
 import SocialBatteryChip from '@components/profile/social-batter-chip/SocialBatteryChip';
@@ -27,12 +27,13 @@ function MyCheckInCard() {
   const { social_battery, track_id, mood, thought } = checkIn || {};
   const moodArray: string[] = Array.isArray(mood) ? mood : mood ? [mood] : [];
   const hasMood = moodArray.length > 0;
+  const hasBattery = !!social_battery && Object.values(SocialBattery).includes(social_battery);
 
   const goToCheckIn = () => navigate('/update');
 
   return (
     <Container>
-      {/* Row 1: Profile + username + social battery */}
+      {/* Row 1: Profile + username + battery | mood emojis */}
       <Layout.FlexRow w="100%" gap={7} alignItems="center">
         <Layout.FlexRow
           gap={7}
@@ -49,40 +50,32 @@ function MyCheckInCard() {
             {myProfile?.username || ''}
           </Typo>
         </Layout.FlexRow>
-        {social_battery && Object.values(SocialBattery).includes(social_battery) ? (
-          <SocialBatteryChip
-            socialBattery={social_battery}
-            compact
-            borderless
-            onClick={goToCheckIn}
-          />
-        ) : (
-          <SocialBatteryPlaceholder />
-        )}
-      </Layout.FlexRow>
-
-      {/* Mood pill */}
-      {hasMood ? (
-        <Layout.FlexRow
-          bgColor="WHITE"
-          gap={2}
-          pv={4}
-          ph={8}
-          outline="LIGHT_GRAY"
-          alignItems="center"
-          rounded={8}
-          style={{ flexShrink: 0, cursor: 'pointer', alignSelf: 'flex-start' }}
-          onClick={goToCheckIn}
-        >
-          {moodArray.map((emoji) => (
-            <span key={emoji} style={{ fontSize: 16, lineHeight: 1 }}>
-              {emoji}
-            </span>
-          ))}
+        <Layout.FlexRow alignItems="center" gap={2}>
+          {hasBattery ? (
+            <SocialBatteryChip
+              socialBattery={social_battery}
+              compact
+              borderless
+              onClick={goToCheckIn}
+            />
+          ) : (
+            <SocialBatteryPlaceholder />
+          )}
+          {hasBattery && hasMood && <InlineDivider />}
+          {hasMood && (
+            <StackedEmojis onClick={goToCheckIn}>
+              {moodArray.map((emoji, idx) => {
+                const dupeCount = moodArray.slice(0, idx).filter((e) => e === emoji).length;
+                return (
+                  <StackedEmoji key={`${emoji}${dupeCount}`} $offset={idx}>
+                    {emoji}
+                  </StackedEmoji>
+                );
+              })}
+            </StackedEmojis>
+          )}
         </Layout.FlexRow>
-      ) : (
-        <MoodPlaceholder />
-      )}
+      </Layout.FlexRow>
 
       {/* Thought pill */}
       {thought ? (
@@ -113,5 +106,28 @@ function MyCheckInCard() {
     </Container>
   );
 }
+
+const StackedEmojis = styled.div`
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  padding: 2px 0;
+`;
+
+const StackedEmoji = styled.span<{ $offset: number }>`
+  font-size: 16px;
+  line-height: 1;
+  margin-left: ${({ $offset }) => ($offset > 0 ? '-4px' : '0')};
+  z-index: ${({ $offset }) => 5 - $offset};
+  position: relative;
+`;
+
+const InlineDivider = styled.span`
+  width: 1px;
+  height: 14px;
+  background-color: #d9d9d9;
+  margin: 0 2px;
+  flex-shrink: 0;
+`;
 
 export default MyCheckInCard;

--- a/src/components/check-in/my-check-in-card/MyCheckInCard.tsx
+++ b/src/components/check-in/my-check-in-card/MyCheckInCard.tsx
@@ -1,5 +1,4 @@
 import { useNavigate } from 'react-router-dom';
-import EmojiItem from '@components/_common/emoji-item/EmojiItem';
 import ProfileImage from '@components/_common/profile-image/ProfileImage';
 import SpotifyMusic from '@components/music/spotify-music/SpotifyMusic';
 import MoodPlaceholder from '@components/profile/placeholders/MoodPlaceholder';
@@ -25,7 +24,11 @@ function MyCheckInCard() {
     await fetchCheckIn();
   }, []);
 
-  const { social_battery, track_id, mood, description } = checkIn || {};
+  const { social_battery, track_id, mood, thought } = checkIn || {};
+  const moodArray: string[] = Array.isArray(mood) ? mood : mood ? [mood] : [];
+  const hasMood = moodArray.length > 0;
+
+  const goToCheckIn = () => navigate('/update');
 
   return (
     <Container>
@@ -51,48 +54,58 @@ function MyCheckInCard() {
             socialBattery={social_battery}
             compact
             borderless
-            onClick={() => navigate('/check-in/edit?focus=battery')}
+            onClick={goToCheckIn}
           />
         ) : (
           <SocialBatteryPlaceholder />
         )}
       </Layout.FlexRow>
 
-      {/* Row 2: Status (mood + description) or empty state */}
-      {mood || description ? (
+      {/* Mood pill */}
+      {hasMood ? (
         <Layout.FlexRow
           bgColor="WHITE"
-          gap={4}
+          gap={2}
           pv={4}
           ph={8}
           outline="LIGHT_GRAY"
           alignItems="center"
           rounded={8}
-          style={{ flexShrink: 0, cursor: 'pointer' }}
-          onClick={() => navigate('/check-in/edit?focus=status')}
+          style={{ flexShrink: 0, cursor: 'pointer', alignSelf: 'flex-start' }}
+          onClick={goToCheckIn}
         >
-          {mood && (
-            <EmojiItem emojiString={mood} size={16} bgColor="TRANSPARENT" outline="TRANSPARENT" />
-          )}
-          {description && (
-            <Typo type="label-large" numberOfLines={1}>
-              {description}
-            </Typo>
-          )}
+          {moodArray.map((emoji) => (
+            <span key={emoji} style={{ fontSize: 16, lineHeight: 1 }}>
+              {emoji}
+            </span>
+          ))}
         </Layout.FlexRow>
       ) : (
         <MoodPlaceholder />
       )}
 
-      {/* Row 3: Song (full width) or empty state */}
+      {/* Thought pill */}
+      {thought ? (
+        <Layout.FlexRow
+          bgColor="WHITE"
+          pv={4}
+          ph={8}
+          outline="LIGHT_GRAY"
+          alignItems="center"
+          rounded={8}
+          style={{ flexShrink: 0, cursor: 'pointer', alignSelf: 'flex-start' }}
+          onClick={goToCheckIn}
+        >
+          <Typo type="label-large" numberOfLines={1}>
+            {thought}
+          </Typo>
+        </Layout.FlexRow>
+      ) : null}
+
+      {/* Song */}
       {track_id ? (
         <Layout.FlexRow w="100%" style={{ minWidth: 0, cursor: 'pointer' }}>
-          <SpotifyMusic
-            track={track_id}
-            useAlbumImg
-            fontType="label-large"
-            onClick={() => navigate('/check-in/edit?focus=song')}
-          />
+          <SpotifyMusic track={track_id} useAlbumImg fontType="label-large" onClick={goToCheckIn} />
         </Layout.FlexRow>
       ) : (
         <MusicPlaceholder />

--- a/src/components/check-in/update-quadrant/MoodEditor.tsx
+++ b/src/components/check-in/update-quadrant/MoodEditor.tsx
@@ -1,16 +1,18 @@
 import EmojiPicker, { EmojiClickData } from 'emoji-picker-react';
 import { useCallback } from 'react';
-import EmojiItem from '@components/_common/emoji-item/EmojiItem';
+import styled from 'styled-components';
 import VisibilityToggle from '@components/check-in/visibility-toggle/VisibilityToggle';
-import { Layout, SvgIcon, Typo } from '@design-system';
+import { Colors, Layout, Typo } from '@design-system';
 import { ComponentVisibility } from '@models/checkIn';
 import EditorPopup from './EditorPopup';
+
+const MAX_MOOD_EMOJIS = 5;
 
 interface Props {
   isOpen: boolean;
   onClose: () => void;
-  value: string;
-  onChange: (value: string) => void;
+  value: string[];
+  onChange: (value: string[]) => void;
   visibility: ComponentVisibility;
   onVisibilityChange: (v: ComponentVisibility) => void;
 }
@@ -25,38 +27,51 @@ export default function MoodEditor({
 }: Props) {
   const handleEmojiClick = useCallback(
     (emojiData: EmojiClickData) => {
-      onChange(emojiData.emoji);
+      if (value.length >= MAX_MOOD_EMOJIS) return;
+      onChange([...value, emojiData.emoji]);
     },
-    [onChange],
+    [onChange, value],
+  );
+
+  const handleRemoveEmoji = useCallback(
+    (index: number) => {
+      onChange(value.filter((_, i) => i !== index));
+    },
+    [onChange, value],
   );
 
   return (
     <EditorPopup isOpen={isOpen} onClose={onClose} title="Mood">
       <Layout.FlexCol w="100%" alignItems="center" gap={12} mb={16}>
-        {value ? (
-          <Layout.FlexRow gap={12} alignItems="center">
-            <EmojiItem emojiString={value} size={48} bgColor="TRANSPARENT" outline="TRANSPARENT" />
-            <Layout.FlexRow
-              style={{ cursor: 'pointer' }}
-              onClick={() => onChange('')}
-              alignItems="center"
-              gap={4}
-            >
-              <SvgIcon name="delete_button" size={20} />
-              <Typo type="label-medium" color="MEDIUM_GRAY">
-                Clear
-              </Typo>
+        {value.length > 0 ? (
+          <Layout.FlexCol w="100%" gap={8} alignItems="center">
+            <Layout.FlexRow gap={8} alignItems="center" justifyContent="center">
+              {value.map((emoji, idx) => {
+                const handleRemove = () => handleRemoveEmoji(idx);
+                return (
+                  <EmojiChip
+                    key={`${emoji}${value.slice(0, idx).filter((e) => e === emoji).length}`}
+                    onClick={handleRemove}
+                  >
+                    <span style={{ fontSize: 28, lineHeight: 1 }}>{emoji}</span>
+                    <RemoveX>x</RemoveX>
+                  </EmojiChip>
+                );
+              })}
             </Layout.FlexRow>
-          </Layout.FlexRow>
+            <Typo type="label-small" color="MEDIUM_GRAY">
+              {value.length}/{MAX_MOOD_EMOJIS} selected. Tap emoji to remove.
+            </Typo>
+          </Layout.FlexCol>
         ) : (
           <Typo type="body-medium" color="MEDIUM_GRAY">
-            Pick an emoji
+            Pick up to {MAX_MOOD_EMOJIS} emojis
           </Typo>
         )}
         <EmojiPicker
           onEmojiClick={handleEmojiClick}
           width="100%"
-          height={280}
+          height={250}
           searchDisabled
           skinTonesDisabled
           previewConfig={{ showPreview: false }}
@@ -66,3 +81,35 @@ export default function MoodEditor({
     </EditorPopup>
   );
 }
+
+const EmojiChip = styled.div`
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px;
+  cursor: pointer;
+  border-radius: 8px;
+  transition: background-color 0.15s ease;
+
+  &:hover {
+    background-color: ${Colors.LIGHT_GRAY};
+  }
+`;
+
+const RemoveX = styled.span`
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background-color: ${Colors.MEDIUM_GRAY};
+  color: white;
+  font-size: 10px;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+`;

--- a/src/components/friends/friend-item-with-updates/FriendItemWithUpdates.tsx
+++ b/src/components/friends/friend-item-with-updates/FriendItemWithUpdates.tsx
@@ -1,5 +1,6 @@
 import { MouseEvent, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
 import Icon from '@components/_common/icon/Icon';
 import ProfileImage from '@components/_common/profile-image/ProfileImage';
 import CheckInDetailBottomSheet from '@components/check-in/check-in-detail-bottom-sheet/CheckInDetailBottomSheet';
@@ -69,7 +70,6 @@ function FriendItemWithUpdates({ user, recentPost, onConnectionChanged }: Props)
 
   const hasNewPost = (!!recentPost && !recentPost.is_read) || (user as any).unread_post_cnt > 0;
 
-  // Normalize mood to array
   const moodArray: string[] = Array.isArray(mood) ? mood : mood ? [mood] : [];
   const hasMood = moodArray.length > 0;
   const hasThought = !!thought;
@@ -77,8 +77,8 @@ function FriendItemWithUpdates({ user, recentPost, onConnectionChanged }: Props)
   const hasSong = !!track_id;
 
   return (
-    <Container mh={16} ph={16} pv={12} gap={12} rounded={12}>
-      {/* Row 1: Profile + username + badge + battery(emoji or nudge) + new post + ping */}
+    <Container mh={16} ph={16} pv={12} gap={8} rounded={12}>
+      {/* Row 1: Profile + username + badge + battery | mood emojis + new post + ping */}
       <Layout.FlexRow w="100%" gap={4} alignItems="center" justifyContent="space-between">
         <Layout.FlexRow alignItems="center" gap={6} style={{ flex: 1, minWidth: 0 }}>
           <Layout.FlexRow
@@ -99,16 +99,32 @@ function FriendItemWithUpdates({ user, recentPost, onConnectionChanged }: Props)
               onClick={handleClickFriendBadge}
             />
           </Layout.FlexRow>
-          {hasBattery ? (
-            <SocialBatteryChip
-              socialBattery={social_battery}
-              compact
-              borderless
-              onClick={() => setCheckInDetailFocus('battery')}
-            />
-          ) : (
-            <PokeButton receiverId={id} componentType="battery" />
-          )}
+
+          {/* Battery + Mood emojis inline */}
+          <Layout.FlexRow alignItems="center" gap={2}>
+            {hasBattery && (
+              <SocialBatteryChip
+                socialBattery={social_battery}
+                compact
+                borderless
+                onClick={() => setCheckInDetailFocus('battery')}
+              />
+            )}
+            {hasBattery && hasMood && <Divider />}
+            {hasMood && (
+              <StackedEmojis onClick={() => setCheckInDetailFocus('mood')}>
+                {moodArray.map((emoji, idx) => {
+                  const dupeCount = moodArray.slice(0, idx).filter((e) => e === emoji).length;
+                  return (
+                    <StackedEmoji key={`${emoji}${dupeCount}`} $offset={idx}>
+                      {emoji}
+                    </StackedEmoji>
+                  );
+                })}
+              </StackedEmojis>
+            )}
+          </Layout.FlexRow>
+
           {hasNewPost && (
             <Layout.FlexRow
               pv={4}
@@ -146,30 +162,15 @@ function FriendItemWithUpdates({ user, recentPost, onConnectionChanged }: Props)
         </Layout.FlexRow>
       </Layout.FlexRow>
 
-      {/* Mood pill (separate from thought) */}
-      {hasMood ? (
-        <Layout.FlexRow
-          bgColor="WHITE"
-          gap={2}
-          pv={4}
-          ph={8}
-          outline="LIGHT_GRAY"
-          alignItems="center"
-          rounded={8}
-          style={{ flexShrink: 0, cursor: 'pointer', alignSelf: 'flex-start' }}
-          onClick={() => setCheckInDetailFocus('mood')}
-        >
-          {moodArray.map((emoji) => (
-            <span key={emoji} style={{ fontSize: 16, lineHeight: 1 }}>
-              {emoji}
-            </span>
-          ))}
+      {/* Nudge row for battery + mood if both empty */}
+      {(!hasBattery || !hasMood) && (
+        <Layout.FlexRow gap={4} style={{ flexWrap: 'wrap' }}>
+          {!hasBattery && <PokeButton receiverId={id} componentType="battery" />}
+          {!hasMood && <PokeButton receiverId={id} componentType="mood" />}
         </Layout.FlexRow>
-      ) : (
-        <PokeButton receiverId={id} componentType="mood" />
       )}
 
-      {/* Thought pill (separate from mood) */}
+      {/* Thought pill */}
       {hasThought ? (
         <Layout.FlexRow
           bgColor="WHITE"
@@ -228,5 +229,28 @@ function FriendItemWithUpdates({ user, recentPost, onConnectionChanged }: Props)
     </Container>
   );
 }
+
+const StackedEmojis = styled.div`
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  padding: 2px 0;
+`;
+
+const StackedEmoji = styled.span<{ $offset: number }>`
+  font-size: 16px;
+  line-height: 1;
+  margin-left: ${({ $offset }) => ($offset > 0 ? '-4px' : '0')};
+  z-index: ${({ $offset }) => 5 - $offset};
+  position: relative;
+`;
+
+const Divider = styled.span`
+  width: 1px;
+  height: 14px;
+  background-color: #d9d9d9;
+  margin: 0 2px;
+  flex-shrink: 0;
+`;
 
 export default FriendItemWithUpdates;

--- a/src/components/friends/friend-item-with-updates/FriendItemWithUpdates.tsx
+++ b/src/components/friends/friend-item-with-updates/FriendItemWithUpdates.tsx
@@ -101,6 +101,7 @@ function FriendItemWithUpdates({ user, recentPost, onConnectionChanged }: Props)
           </Layout.FlexRow>
 
           {/* Battery + Mood emojis inline */}
+          {(hasBattery || hasMood) && <Divider />}
           <Layout.FlexRow alignItems="center" gap={2}>
             {hasBattery && (
               <SocialBatteryChip

--- a/src/components/friends/friend-item-with-updates/FriendItemWithUpdates.tsx
+++ b/src/components/friends/friend-item-with-updates/FriendItemWithUpdates.tsx
@@ -1,6 +1,5 @@
 import { MouseEvent, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import EmojiItem from '@components/_common/emoji-item/EmojiItem';
 import Icon from '@components/_common/icon/Icon';
 import ProfileImage from '@components/_common/profile-image/ProfileImage';
 import CheckInDetailBottomSheet from '@components/check-in/check-in-detail-bottom-sheet/CheckInDetailBottomSheet';
@@ -31,11 +30,11 @@ function FriendItemWithUpdates({ user, recentPost, onConnectionChanged }: Props)
     username,
     unread_ping_count,
     track_id,
-    description,
     mood,
     social_battery,
     connection_status,
   } = user;
+  const thought = (user as any).thought ?? (user as any).description ?? '';
 
   const navigate = useNavigate();
   const { featureFlags } = useBoundStore(UserSelector);
@@ -43,7 +42,7 @@ function FriendItemWithUpdates({ user, recentPost, onConnectionChanged }: Props)
   const [isEditConnectionsBottomSheetVisible, setIsEditConnectionsBottomSheetVisible] =
     useState(false);
   const [checkInDetailFocus, setCheckInDetailFocus] = useState<
-    'battery' | 'status' | 'song' | null
+    'battery' | 'mood' | 'thought' | 'song' | null
   >(null);
 
   const handleClickProfile = (e: MouseEvent) => {
@@ -63,16 +62,6 @@ function FriendItemWithUpdates({ user, recentPost, onConnectionChanged }: Props)
     }
   };
 
-  const handleClickBattery = (e?: MouseEvent) => {
-    e?.stopPropagation();
-    setCheckInDetailFocus('battery');
-  };
-
-  const handleClickStatus = (e?: MouseEvent) => {
-    e?.stopPropagation();
-    setCheckInDetailFocus('status');
-  };
-
   const handleClickNewPost = (e: MouseEvent) => {
     e.stopPropagation();
     navigate(`/friends/${username}/new-posts`);
@@ -80,9 +69,16 @@ function FriendItemWithUpdates({ user, recentPost, onConnectionChanged }: Props)
 
   const hasNewPost = (!!recentPost && !recentPost.is_read) || (user as any).unread_post_cnt > 0;
 
+  // Normalize mood to array
+  const moodArray: string[] = Array.isArray(mood) ? mood : mood ? [mood] : [];
+  const hasMood = moodArray.length > 0;
+  const hasThought = !!thought;
+  const hasBattery = !!social_battery && Object.values(SocialBattery).includes(social_battery);
+  const hasSong = !!track_id;
+
   return (
     <Container mh={16} ph={16} pv={12} gap={12} rounded={12}>
-      {/* Row 1: Profile + username + badge + battery(emoji) + new post + ping */}
+      {/* Row 1: Profile + username + badge + battery(emoji or nudge) + new post + ping */}
       <Layout.FlexRow w="100%" gap={4} alignItems="center" justifyContent="space-between">
         <Layout.FlexRow alignItems="center" gap={6} style={{ flex: 1, minWidth: 0 }}>
           <Layout.FlexRow
@@ -103,13 +99,15 @@ function FriendItemWithUpdates({ user, recentPost, onConnectionChanged }: Props)
               onClick={handleClickFriendBadge}
             />
           </Layout.FlexRow>
-          {social_battery && Object.values(SocialBattery).includes(social_battery) && (
+          {hasBattery ? (
             <SocialBatteryChip
               socialBattery={social_battery}
               compact
               borderless
-              onClick={handleClickBattery}
+              onClick={() => setCheckInDetailFocus('battery')}
             />
+          ) : (
+            <PokeButton receiverId={id} componentType="battery" />
           )}
           {hasNewPost && (
             <Layout.FlexRow
@@ -148,37 +146,51 @@ function FriendItemWithUpdates({ user, recentPost, onConnectionChanged }: Props)
         </Layout.FlexRow>
       </Layout.FlexRow>
 
-      {/* Poke buttons for empty components */}
-      {!social_battery && !mood && !description && !track_id && (
-        <Layout.FlexRow gap={4} style={{ flexWrap: 'wrap' }}>
-          <PokeButton receiverId={id} componentType="battery" />
-          <PokeButton receiverId={id} componentType="status" />
-          <PokeButton receiverId={id} componentType="song" />
-        </Layout.FlexRow>
-      )}
-
-      {/* Row 2: Status (mood + description) */}
-      {(mood || description) && (
+      {/* Mood pill (separate from thought) */}
+      {hasMood ? (
         <Layout.FlexRow
           bgColor="WHITE"
-          gap={4}
+          gap={2}
           pv={4}
           ph={8}
           outline="LIGHT_GRAY"
           alignItems="center"
           rounded={8}
-          style={{ flexShrink: 0, cursor: 'pointer' }}
-          onClick={() => handleClickStatus()}
+          style={{ flexShrink: 0, cursor: 'pointer', alignSelf: 'flex-start' }}
+          onClick={() => setCheckInDetailFocus('mood')}
         >
-          {mood && (
-            <EmojiItem emojiString={mood} size={16} bgColor="TRANSPARENT" outline="TRANSPARENT" />
-          )}
-          {description && <Typo type="label-large">{description}</Typo>}
+          {moodArray.map((emoji) => (
+            <span key={emoji} style={{ fontSize: 16, lineHeight: 1 }}>
+              {emoji}
+            </span>
+          ))}
         </Layout.FlexRow>
+      ) : (
+        <PokeButton receiverId={id} componentType="mood" />
       )}
 
-      {/* Row 3: Song (full width) */}
-      {track_id && (
+      {/* Thought pill (separate from mood) */}
+      {hasThought ? (
+        <Layout.FlexRow
+          bgColor="WHITE"
+          pv={4}
+          ph={8}
+          outline="LIGHT_GRAY"
+          alignItems="center"
+          rounded={8}
+          style={{ flexShrink: 0, cursor: 'pointer', alignSelf: 'flex-start' }}
+          onClick={() => setCheckInDetailFocus('thought')}
+        >
+          <Typo type="label-large" numberOfLines={1}>
+            {thought}
+          </Typo>
+        </Layout.FlexRow>
+      ) : (
+        <PokeButton receiverId={id} componentType="thought" />
+      )}
+
+      {/* Song */}
+      {hasSong ? (
         <Layout.FlexRow w="100%" style={{ minWidth: 0, overflow: 'hidden' }}>
           <SpotifyMusic
             track={track_id}
@@ -188,9 +200,11 @@ function FriendItemWithUpdates({ user, recentPost, onConnectionChanged }: Props)
             useDetailBottomSheet
           />
         </Layout.FlexRow>
+      ) : (
+        <PokeButton receiverId={id} componentType="song" />
       )}
 
-      {/* Check-in detail bottom sheet */}
+      {/* Check-in detail popup */}
       <CheckInDetailBottomSheet
         visible={!!checkInDetailFocus}
         closeBottomSheet={() => setCheckInDetailFocus(null)}
@@ -199,8 +213,8 @@ function FriendItemWithUpdates({ user, recentPost, onConnectionChanged }: Props)
         username={username}
         profileImage={profile_image}
         socialBattery={social_battery}
-        mood={mood}
-        description={description}
+        mood={moodArray}
+        description={thought}
       />
 
       <EditConnectionsBottomSheet

--- a/src/components/friends/poke-button/PokeButton.tsx
+++ b/src/components/friends/poke-button/PokeButton.tsx
@@ -12,15 +12,17 @@ interface Props {
 }
 
 const POKE_LABELS: Record<PokeComponentType, { text: string; emoji: string }> = {
-  song: { text: 'Nudge for a song', emoji: '\u{1F3B5}' },
-  status: { text: 'Nudge for a vibe check', emoji: '\u{270C}\u{FE0F}' },
-  battery: { text: 'Nudge to share how they feel', emoji: '\u{1F4AB}' },
+  battery: { text: 'Nudge for social battery', emoji: '🔋' },
+  mood: { text: 'Nudge for mood', emoji: '😊' },
+  thought: { text: 'Nudge for random thoughts', emoji: '💭' },
+  song: { text: 'Nudge for a song', emoji: '🎵' },
 };
 
 const POKED_LABELS: Record<PokeComponentType, { text: string; emoji: string }> = {
-  song: { text: 'Nudged: song', emoji: '\u{2714}\u{FE0F}' },
-  status: { text: 'Nudged: vibe', emoji: '\u{2714}\u{FE0F}' },
-  battery: { text: 'Nudged: battery', emoji: '\u{2714}\u{FE0F}' },
+  battery: { text: 'Nudged: battery', emoji: '✔️' },
+  mood: { text: 'Nudged: mood', emoji: '✔️' },
+  thought: { text: 'Nudged: thoughts', emoji: '✔️' },
+  song: { text: 'Nudged: song', emoji: '✔️' },
 };
 
 function PokeButton({ receiverId, componentType }: Props) {

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 import SubHeader from '@components/sub-header/SubHeader';
 import ChatsHeader from './chats-header/ChatsHeader';
-import CheckInHeader from './check-in-header/CheckInHeader';
 import CommonHeader from './common-header/CommonHeader';
 import FriendHeader from './friends-header/FriendsHeader';
 
@@ -23,7 +22,7 @@ function Header() {
     case '/my':
       return <CommonHeader title={t('header.my')} />;
     case '/update':
-      return <CheckInHeader />;
+      return <CommonHeader title="Check-In" />;
     case '/share':
       return <CommonHeader title={t('header.share')} />;
     case '/questions':

--- a/src/mock/users.ts
+++ b/src/mock/users.ts
@@ -10,9 +10,9 @@ export const checkIn: CheckInBase = {
   id: 4,
   created_at: '2023-11-17T22:13:27.155202-08:00',
   is_active: true,
-  mood: '🎀',
+  mood: ['🎀'],
   social_battery: SocialBattery.completely_drained,
-  description: 'I am available',
+  thought: 'I am available',
   track_id: '11dFghVXANMlKmJXsNCbNl',
   current_user_read: true,
 };

--- a/src/models/checkIn.ts
+++ b/src/models/checkIn.ts
@@ -25,9 +25,9 @@ export type CheckInBase = {
   id: number;
   is_active: boolean;
   created_at: string;
-  mood: string;
+  mood: string[];
   social_battery: SocialBattery | null;
-  description: string;
+  thought: string;
   track_id: string;
   current_user_read: boolean;
   song_visibility?: ComponentVisibility;

--- a/src/routes/check-in/CheckInEdit.tsx
+++ b/src/routes/check-in/CheckInEdit.tsx
@@ -76,7 +76,7 @@ function CheckInEdit() {
   const handleConfirmSave = async () => {
     await postCheckIn({
       social_battery: checkInForm.social_battery,
-      description: checkInForm.description,
+      thought: checkInForm.thought,
       mood: checkInForm.mood,
       track_id: '',
       song_visibility: songVisibility,
@@ -221,16 +221,20 @@ function CheckInEdit() {
         <div ref={statusRef} style={{ width: '100%' }}>
           <SectionContainer title={t('mood.title')} description={t('mood.description')}>
             <CheckInEmoji
-              mood={checkInForm?.mood || ''}
+              mood={
+                Array.isArray(checkInForm?.mood)
+                  ? checkInForm.mood[0] || ''
+                  : checkInForm?.mood || ''
+              }
               onDelete={() => handleDelete('mood')}
               onSelectEmoji={(e: EmojiClickData) => {
-                handleChange('mood', e.emoji);
+                handleChange('mood', [e.emoji] as any);
               }}
             />
             <CheckInDescription
-              description={checkInForm?.description || ''}
-              onDelete={() => handleDelete('description')}
-              onChange={(e) => handleChange('description', e.target.value)}
+              description={checkInForm?.thought || ''}
+              onDelete={() => handleDelete('thought')}
+              onChange={(e) => handleChange('thought', e.target.value)}
             />
             <Layout.FlexRow mt={8}>
               <VisibilityToggle value={statusVisibility} onChange={setStatusVisibility} />

--- a/src/routes/update/UpdateCheckin.tsx
+++ b/src/routes/update/UpdateCheckin.tsx
@@ -28,16 +28,13 @@ function isArchived(updatedAt?: string): boolean {
 export default function UpdateCheckin() {
   const [t] = useTranslation('translation', { keyPrefix: 'social_battery' });
 
-  const { checkIn, fetchCheckIn, setCheckInSaveHandler, setCheckInSaving } = useBoundStore(
-    (state) => ({
-      checkIn: state.checkIn,
-      fetchCheckIn: state.fetchCheckIn,
-      setCheckInSaveHandler: state.setCheckInSaveHandler,
-      setCheckInSaving: state.setCheckInSaving,
-    }),
-  );
+  const { checkIn, fetchCheckIn } = useBoundStore((state) => ({
+    checkIn: state.checkIn,
+    fetchCheckIn: state.fetchCheckIn,
+  }));
 
   const sendMessage = usePostAppMessage();
+  const openToast = useBoundStore((state) => state.openToast);
 
   const [activeEditor, setActiveEditor] = useState<EditorTarget>(null);
 
@@ -99,10 +96,9 @@ export default function UpdateCheckin() {
     [thought, checkIn?.thought_updated_at],
   );
 
-  const handleSave = useCallback(async () => {
-    setCheckInSaving(true);
+  // Save all check-in fields + song to backend
+  const saveAll = useCallback(async () => {
     try {
-      // Save check-in (battery, mood, thought, visibility)
       const checkInPromise = postCheckIn({
         social_battery: battery,
         mood,
@@ -113,10 +109,7 @@ export default function UpdateCheckin() {
         song_visibility: songVis,
         thought_visibility: thoughtVis,
       });
-
-      // Save song separately (Song is a separate backend model)
       const songPromise = trackId ? postSong(trackId) : Promise.resolve();
-
       await Promise.all([checkInPromise, songPromise]);
 
       if (window.ReactNativeWebView) {
@@ -134,8 +127,9 @@ export default function UpdateCheckin() {
         });
       }
       await fetchCheckIn();
-    } finally {
-      setCheckInSaving(false);
+      openToast({ message: 'Shared!' });
+    } catch {
+      openToast({ message: 'Failed to save' });
     }
   }, [
     battery,
@@ -151,14 +145,15 @@ export default function UpdateCheckin() {
     trackData?.album?.images,
     fetchCheckIn,
     sendMessage,
-    setCheckInSaving,
+    openToast,
   ]);
 
-  // Register save handler for the header Save button
-  useEffect(() => {
-    setCheckInSaveHandler(handleSave);
-    return () => setCheckInSaveHandler(null);
-  }, [handleSave, setCheckInSaveHandler]);
+  // When an editor popup closes via "Share", auto-save
+  const handleEditorClose = useCallback(() => {
+    setActiveEditor(null);
+    // Save after state update settles
+    setTimeout(() => saveAll(), 0);
+  }, [saveAll]);
 
   return (
     <MainScrollContainer>
@@ -273,10 +268,10 @@ export default function UpdateCheckin() {
         </QuadrantCard>
       </GridContainer>
 
-      {/* Editor Popups */}
+      {/* Editor Popups — "Share" auto-saves */}
       <BatteryEditor
         isOpen={activeEditor === 'battery'}
-        onClose={() => setActiveEditor(null)}
+        onClose={() => handleEditorClose()}
         value={battery}
         onChange={setBattery}
         visibility={batteryVis}
@@ -284,7 +279,7 @@ export default function UpdateCheckin() {
       />
       <MoodEditor
         isOpen={activeEditor === 'mood'}
-        onClose={() => setActiveEditor(null)}
+        onClose={() => handleEditorClose()}
         value={mood}
         onChange={setMood}
         visibility={moodVis}
@@ -292,7 +287,7 @@ export default function UpdateCheckin() {
       />
       <SongEditor
         isOpen={activeEditor === 'song'}
-        onClose={() => setActiveEditor(null)}
+        onClose={() => handleEditorClose()}
         trackId={trackId}
         onChange={setTrackId}
         visibility={songVis}
@@ -300,7 +295,7 @@ export default function UpdateCheckin() {
       />
       <ThoughtEditor
         isOpen={activeEditor === 'thought'}
-        onClose={() => setActiveEditor(null)}
+        onClose={() => handleEditorClose()}
         value={thought}
         onChange={setThought}
         visibility={thoughtVis}

--- a/src/routes/update/UpdateCheckin.tsx
+++ b/src/routes/update/UpdateCheckin.tsx
@@ -1,5 +1,5 @@
 import { Track } from '@spotify/web-api-ts-sdk';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import BatteryEditor from '@components/check-in/update-quadrant/BatteryEditor';
 import MoodEditor from '@components/check-in/update-quadrant/MoodEditor';
@@ -96,20 +96,33 @@ export default function UpdateCheckin() {
     [thought, checkIn?.thought_updated_at],
   );
 
-  // Save all check-in fields + song to backend
-  const saveAll = useCallback(async () => {
+  // Refs to always have latest values for saving (avoids stale closure issues)
+  const stateRef = useRef({
+    battery,
+    mood,
+    thought,
+    trackId,
+    batteryVis,
+    moodVis,
+    songVis,
+    thoughtVis,
+  });
+  stateRef.current = { battery, mood, thought, trackId, batteryVis, moodVis, songVis, thoughtVis };
+
+  const doSave = useCallback(async () => {
+    const s = stateRef.current;
     try {
       const checkInPromise = postCheckIn({
-        social_battery: battery,
-        mood,
-        thought,
+        social_battery: s.battery,
+        mood: s.mood,
+        thought: s.thought,
         track_id: '',
-        battery_visibility: batteryVis,
-        mood_visibility: moodVis,
-        song_visibility: songVis,
-        thought_visibility: thoughtVis,
+        battery_visibility: s.batteryVis,
+        mood_visibility: s.moodVis,
+        song_visibility: s.songVis,
+        thought_visibility: s.thoughtVis,
       });
-      const songPromise = trackId ? postSong(trackId) : Promise.resolve();
+      const songPromise = s.trackId ? postSong(s.trackId) : Promise.resolve();
       await Promise.all([checkInPromise, songPromise]);
 
       if (window.ReactNativeWebView) {
@@ -131,29 +144,13 @@ export default function UpdateCheckin() {
     } catch {
       openToast({ message: 'Failed to save' });
     }
-  }, [
-    battery,
-    mood,
-    thought,
-    trackId,
-    batteryVis,
-    moodVis,
-    songVis,
-    thoughtVis,
-    checkIn?.id,
-    checkIn?.created_at,
-    trackData?.album?.images,
-    fetchCheckIn,
-    sendMessage,
-    openToast,
-  ]);
+  }, [fetchCheckIn, sendMessage, openToast]);
 
-  // When an editor popup closes via "Share", auto-save
   const handleEditorClose = useCallback(() => {
     setActiveEditor(null);
-    // Save after state update settles
-    setTimeout(() => saveAll(), 0);
-  }, [saveAll]);
+    // Use rAF to ensure React has committed the state update from the editor
+    requestAnimationFrame(() => doSave());
+  }, [doSave]);
 
   return (
     <MainScrollContainer>

--- a/src/routes/update/UpdateCheckin.tsx
+++ b/src/routes/update/UpdateCheckin.tsx
@@ -1,7 +1,6 @@
 import { Track } from '@spotify/web-api-ts-sdk';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import EmojiItem from '@components/_common/emoji-item/EmojiItem';
 import BatteryEditor from '@components/check-in/update-quadrant/BatteryEditor';
 import MoodEditor from '@components/check-in/update-quadrant/MoodEditor';
 import SongEditor from '@components/check-in/update-quadrant/SongEditor';
@@ -43,7 +42,7 @@ export default function UpdateCheckin() {
   const [activeEditor, setActiveEditor] = useState<EditorTarget>(null);
 
   const [battery, setBattery] = useState<SocialBattery | null>(null);
-  const [mood, setMood] = useState('');
+  const [mood, setMood] = useState<string[]>([]);
   const [trackId, setTrackId] = useState('');
   const [thought, setThought] = useState('');
 
@@ -71,8 +70,8 @@ export default function UpdateCheckin() {
     const [ci, activeSong] = await Promise.all([fetchCheckIn(), getActiveSong()]);
     if (ci) {
       setBattery(ci.social_battery || null);
-      setMood(ci.mood || '');
-      setThought(ci.description || '');
+      setMood(Array.isArray(ci.mood) ? ci.mood : ci.mood ? [ci.mood] : []);
+      setThought(ci.thought || '');
       if (ci.battery_visibility) setBatteryVis(ci.battery_visibility);
       if (ci.mood_visibility) setMoodVis(ci.mood_visibility);
       if (ci.song_visibility) setSongVis(ci.song_visibility);
@@ -88,7 +87,7 @@ export default function UpdateCheckin() {
     [battery, checkIn?.battery_updated_at],
   );
   const moodArchived = useMemo(
-    () => !!mood && isArchived(checkIn?.mood_updated_at),
+    () => mood.length > 0 && isArchived(checkIn?.mood_updated_at),
     [mood, checkIn?.mood_updated_at],
   );
   const songArchived = useMemo(
@@ -107,7 +106,7 @@ export default function UpdateCheckin() {
       const checkInPromise = postCheckIn({
         social_battery: battery,
         mood,
-        description: thought,
+        thought,
         track_id: '',
         battery_visibility: batteryVis,
         mood_visibility: moodVis,
@@ -196,14 +195,20 @@ export default function UpdateCheckin() {
 
         {/* Top-Right: Mood */}
         <QuadrantCard
-          $isEmpty={!mood}
+          $isEmpty={mood.length === 0}
           $isArchived={moodArchived}
           onClick={() => setActiveEditor('mood')}
         >
           {moodArchived && <ArchivedBadge>Only Me</ArchivedBadge>}
-          {mood ? (
+          {mood.length > 0 ? (
             <>
-              <EmojiItem emojiString={mood} size={40} bgColor="TRANSPARENT" outline="TRANSPARENT" />
+              <Layout.FlexRow gap={4} alignItems="center">
+                {mood.map((emoji) => (
+                  <span key={emoji} style={{ fontSize: 32, lineHeight: 1 }}>
+                    {emoji}
+                  </span>
+                ))}
+              </Layout.FlexRow>
               <QuadrantLabel>Mood</QuadrantLabel>
             </>
           ) : (

--- a/src/stores/checkIn.ts
+++ b/src/stores/checkIn.ts
@@ -21,8 +21,8 @@ const initialState = {
   checkInForm: {
     social_battery: null,
     bio: '',
-    description: '',
-    mood: '',
+    thought: '',
+    mood: [] as string[],
     track_id: '',
   },
   checkInSaveHandler: null as (() => Promise<void>) | null,

--- a/src/utils/apis/checkIn.ts
+++ b/src/utils/apis/checkIn.ts
@@ -60,9 +60,11 @@ export const deactivateSong = async (songId: number) => {
 };
 
 // GET reactions for a check-in
-export const getCheckInReactions = async (checkInId: number) => {
-  const { data } = await axios.get<
-    { id: number; emoji: string; user: { id: number; username: string } }[]
-  >(`/check_in/${checkInId}/reactions/`);
-  return data;
+type ReactionItem = { id: number; emoji: string; user: { id: number; username: string } };
+export const getCheckInReactions = async (checkInId: number): Promise<ReactionItem[]> => {
+  const { data } = await axios.get(`/check_in/${checkInId}/reactions/`);
+  // Handle both paginated ({ results: [...] }) and flat array responses
+  if (Array.isArray(data)) return data;
+  if (data.results && Array.isArray(data.results)) return data.results;
+  return [];
 };

--- a/src/utils/apis/poke.ts
+++ b/src/utils/apis/poke.ts
@@ -1,6 +1,6 @@
 import axiosInstance from '@utils/apis/axios';
 
-export type PokeComponentType = 'song' | 'status' | 'battery';
+export type PokeComponentType = 'song' | 'mood' | 'thought' | 'battery';
 
 export interface Poke {
   id: number;


### PR DESCRIPTION
## Summary
- mood field changed from string to string[] (up to 5 emojis)
- description renamed to thought across all components
- Mood emojis display inline with battery (stacked, overlapping)
- Separate thought pill below
- Per-component nudge buttons (battery, mood, thought, song)
- Auto-save on Share click (no global Save button)
- Reactions persist on popup reopen (paginated response fix)
- Divider between close friend badge and battery/mood
- Check-in clicks navigate to Check-In tab

## Test plan
- [ ] Multi-emoji mood displays correctly (1-5 emojis stacked)
- [ ] Each empty component shows its own nudge button
- [ ] Auto-save works on Share click for all 4 quadrants
- [ ] Reactions show as selected when reopening popup