### PR TITLE
fix: rename nudge to ping + remove chat list back arrow

### DIFF
--- a/src/components/friends/friend-item-with-updates/FriendItemWithUpdates.tsx
+++ b/src/components/friends/friend-item-with-updates/FriendItemWithUpdates.tsx
@@ -163,7 +163,7 @@ function FriendItemWithUpdates({ user, recentPost, onConnectionChanged }: Props)
         </Layout.FlexRow>
       </Layout.FlexRow>
 
-      {/* Nudge row for battery + mood if both empty */}
+      {/* Ping row for battery + mood if both empty */}
       {(!hasBattery || !hasMood) && (
         <Layout.FlexRow gap={4} style={{ flexWrap: 'wrap' }}>
           {!hasBattery && <PokeButton receiverId={id} componentType="battery" />}

--- a/src/components/friends/poke-button/PokeButton.tsx
+++ b/src/components/friends/poke-button/PokeButton.tsx
@@ -12,17 +12,17 @@ interface Props {
 }
 
 const POKE_LABELS: Record<PokeComponentType, { text: string; emoji: string }> = {
-  battery: { text: 'Nudge for social battery', emoji: '🔋' },
-  mood: { text: 'Nudge for mood', emoji: '😊' },
-  thought: { text: 'Nudge for random thoughts', emoji: '💭' },
-  song: { text: 'Nudge for a song', emoji: '🎵' },
+  battery: { text: 'Ping for social battery', emoji: '🔋' },
+  mood: { text: 'Ping for mood', emoji: '😊' },
+  thought: { text: 'Ping for random thoughts', emoji: '💭' },
+  song: { text: 'Ping for a song', emoji: '🎵' },
 };
 
 const POKED_LABELS: Record<PokeComponentType, { text: string; emoji: string }> = {
-  battery: { text: 'Nudged: battery', emoji: '✔️' },
-  mood: { text: 'Nudged: mood', emoji: '✔️' },
-  thought: { text: 'Nudged: thoughts', emoji: '✔️' },
-  song: { text: 'Nudged: song', emoji: '✔️' },
+  battery: { text: 'Pinged: battery', emoji: '✔️' },
+  mood: { text: 'Pinged: mood', emoji: '✔️' },
+  thought: { text: 'Pinged: thoughts', emoji: '✔️' },
+  song: { text: 'Pinged: song', emoji: '✔️' },
 };
 
 function PokeButton({ receiverId, componentType }: Props) {
@@ -92,8 +92,8 @@ function PokeButton({ receiverId, componentType }: Props) {
       </PokeContainer>
       <CommonDialog
         visible={showConfirm}
-        title="Un-nudge?"
-        content="This will remove your nudge."
+        title="Un-ping?"
+        content="This will remove your ping."
         cancelText="Cancel"
         confirmText="Remove"
         confirmTextColor="WARNING"

--- a/src/routes/chat/ChatList.tsx
+++ b/src/routes/chat/ChatList.tsx
@@ -86,6 +86,7 @@ function ChatList() {
     <MainScrollContainer>
       <SubHeader
         title="Chats"
+        LeftComponent={<Layout.LayoutBase w={36} h={36} />}
         RightComponent={
           <Layout.FlexRow gap={4} alignItems="center">
             <Icon name="search_black" size={38} onClick={() => navigate('/chats/search')} />


### PR DESCRIPTION
## Summary
- Rename all user-facing 'Nudge' text to 'Ping'
- Remove back arrow from Chats tab header (top-level page)

## Test plan
- [ ] Ping buttons show 'Ping for...' text
- [ ] Pinged state shows 'Pinged: ...'
- [ ] Un-ping dialog says 'Un-ping?'
- [ ] Chats tab has no back arrow