### PR TITLE
Poke Daily Limit UX

### DIFF
--- a/src/components/friends/poke-button/PokeButton.tsx
+++ b/src/components/friends/poke-button/PokeButton.tsx
@@ -1,8 +1,10 @@
 import { Emoji } from 'emoji-picker-react';
 import { MouseEvent, useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 import CommonDialog from '@components/_common/alert-dialog/common-dialog/CommonDialog';
 import { Typo } from '@design-system';
+import { useBoundStore } from '@stores/useBoundStore';
 import { deletePoke, getPokeStatus, Poke, PokeComponentType, sendPoke } from '@utils/apis/poke';
 import { getUnifiedEmoji } from '@utils/emojiHelpers';
 
@@ -27,6 +29,8 @@ const POKED_LABELS: Record<PokeComponentType, { text: string; emoji: string }> =
 };
 
 function PokeButton({ receiverId, componentType, initialPokeId }: Props) {
+  const [t] = useTranslation('translation', { keyPrefix: 'friend' });
+  const { openToast } = useBoundStore((state) => ({ openToast: state.openToast }));
   const [pokeRecord, setPokeRecord] = useState<Poke | null>(
     initialPokeId
       ? ({ id: initialPokeId, component_type: componentType, receiver: receiverId } as Poke)
@@ -79,8 +83,13 @@ function PokeButton({ receiverId, componentType, initialPokeId }: Props) {
     try {
       const newPoke = await sendPoke(receiverId, componentType);
       setPokeRecord(newPoke);
-    } catch {
-      // Silently fail -- rate limit or network error
+    } catch (err: unknown) {
+      if (err && typeof err === 'object' && 'response' in err) {
+        const status = (err as { response: { status: number } }).response?.status;
+        if (status === 429) {
+          openToast({ message: t('ping_daily_limit') });
+        }
+      }
     } finally {
       setIsLoading(false);
     }

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -6,7 +6,8 @@
         "close_friend": "Close Friend",
         "are_you_sure_you_want_to_delete_this_friend": "Remove this friend?",
         "temporary_error": "A temporary error occurred. Please try again later.",
-        "view_all_updates_this_week": "View all updates this week"
+        "view_all_updates_this_week": "View all updates this week",
+        "ping_daily_limit": "Today's ping limit reached! Try again tomorrow."
     },
     "common": {
         "done": "Done",

--- a/src/i18n/locales/ko/translation.json
+++ b/src/i18n/locales/ko/translation.json
@@ -6,7 +6,8 @@
     "close_friend": "친한 친구",
     "are_you_sure_you_want_to_delete_this_friend": "이 친구를 삭제하시겠습니까?",
     "temporary_error": "일시적으로 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.",
-    "view_all_updates_this_week": "이번주 모든 업데이트 보기"
+    "view_all_updates_this_week": "이번주 모든 업데이트 보기",
+    "ping_daily_limit": "오늘의 핑 횟수를 모두 사용했어요! 내일 다시 시도해주세요."
   },
   "common": {
     "done": "완료",


### PR DESCRIPTION
# Fix: Poke Daily Limit UX & Error Alerting

## Problem
- Users received no feedback when hitting the daily poke limit (button silently did nothing)
- Backend sent Slack error alerts for `Throttled` exceptions, which are intentional rate limits — not real errors

## Changes

### Backend (`adoorback/utils/validators.py`)
- Added `Throttled` to the exception types skipped by Slack alerting in `adoor_exception_handler`
- DRF still returns a proper 429 response to the client

### Frontend (`PokeButton.tsx`)
- Catch 429 responses and display a toast: "Today's ping limit reached! Try again tomorrow."
- Non-429 errors remain silent (unchanged behavior)
- Added `useTranslation` with i18n support (EN/KO)

### i18n
- **EN**: `"Today's ping limit reached! Try again tomorrow."`
- **KO**: `"오늘의 핑 횟수를 모두 사용했어요! 내일 다시 시도해주세요."`

## Impact
- Valid pokes: no change
- Rate-limited pokes: user now sees a clear toast message
- Slack alerts: no longer fires for expected throttle responses
