### PR TITLE
(#1242) fix mission of the day button error

### DIFF
--- a/src/components/_common/prompt/PromptCard.tsx
+++ b/src/components/_common/prompt/PromptCard.tsx
@@ -13,13 +13,20 @@ interface PromptCardProps {
   id: number;
   content: string;
   authorDetail?: User | AdminAuthor;
+  missionMode?: boolean;
 }
-function PromptCard({ id, content, widthMode = 'normal', authorDetail }: PromptCardProps) {
+function PromptCard({
+  id,
+  content,
+  widthMode = 'normal',
+  authorDetail,
+  missionMode,
+}: PromptCardProps) {
   const navigate = useNavigate();
 
   const [sendPromptModalVisible, setSendPromptBottomModalVisible] = useState(false);
   const handleClickRespond = () => {
-    navigate(`/questions/${id}/new`);
+    navigate(`/questions/${id}/new`, missionMode ? { state: { missionMode: true } } : undefined);
   };
 
   const handleClickSend = (e: MouseEvent) => {

--- a/src/components/discover/MissionPromptCard/MissionPromptCard.tsx
+++ b/src/components/discover/MissionPromptCard/MissionPromptCard.tsx
@@ -1,21 +1,8 @@
-import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { getDayOfYear } from '@components/share/MissionOfTheDay';
+import { getAttemptsToday } from '@components/share/MissionOfTheDay';
 import { Layout, Typo } from '@design-system';
 import { MissionPromptCardBody } from '@models/discover';
 import * as S from './MissionPromptCard.styled';
-
-const MISSION_STORAGE_KEY = 'whoami_mission_completed';
-
-function isMissionCompletedToday(): boolean {
-  const stored = localStorage.getItem(MISSION_STORAGE_KEY);
-  if (!stored) return false;
-  return stored === String(getDayOfYear());
-}
-
-function markMissionCompleted(): void {
-  localStorage.setItem(MISSION_STORAGE_KEY, String(getDayOfYear()));
-}
 
 interface MissionPromptCardProps {
   mission: MissionPromptCardBody;
@@ -23,18 +10,16 @@ interface MissionPromptCardProps {
 
 function MissionPromptCard({ mission }: MissionPromptCardProps) {
   const navigate = useNavigate();
-  const [isCompleted, setIsCompleted] = useState(isMissionCompletedToday());
+  const isCompleted = getAttemptsToday() > 0;
 
   const handleDoIt = () => {
     if (isCompleted) return;
-    markMissionCompleted();
-    setIsCompleted(true);
 
-    // Navigate based on mission type
+    // Navigate to creation page — completion is marked after successful post
     if (mission.missionType === 'question') {
-      navigate('/questions');
+      navigate('/questions', { state: { missionMode: true } });
     } else {
-      navigate('/notes/new');
+      navigate('/notes/new', { state: { missionMode: true } });
     }
   };
 

--- a/src/components/share/MissionOfTheDay.tsx
+++ b/src/components/share/MissionOfTheDay.tsx
@@ -52,7 +52,7 @@ export function getDayOfYear(): number {
 const MISSION_STORAGE_KEY = 'whoami_mission_attempts';
 const MAX_ATTEMPTS = 5;
 
-function getAttemptsToday(): number {
+export function getAttemptsToday(): number {
   const stored = localStorage.getItem(MISSION_STORAGE_KEY);
   if (!stored) return 0;
   try {

--- a/src/routes/AllQuestions.tsx
+++ b/src/routes/AllQuestions.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useLocation } from 'react-router-dom';
 import NoContents from '@components/_common/no-contents/NoContents';
 import PromptCard from '@components/_common/prompt/PromptCard';
 import PullToRefresh from '@components/_common/pull-to-refresh/PullToRefresh';
@@ -17,6 +18,8 @@ import { MainScrollContainer } from './Root';
 
 function AllQuestions() {
   const [t] = useTranslation('translation');
+  const location = useLocation();
+  const missionMode = location.state?.missionMode;
 
   const {
     targetRef,
@@ -62,6 +65,7 @@ function AllQuestions() {
                           id={question.id}
                           content={question.content}
                           widthMode="full"
+                          missionMode={missionMode}
                         />
                       ))}
                     </Layout.FlexCol>

--- a/src/routes/responses/NewResponse.tsx
+++ b/src/routes/responses/NewResponse.tsx
@@ -6,6 +6,7 @@ import NoContents from '@components/_common/no-contents/NoContents';
 import ProfileImage from '@components/_common/profile-image/ProfileImage';
 import { StyledNewResponsePrompt } from '@components/_common/prompt/PromptCard.styled';
 import VisibilityMultiSelect from '@components/note/visibility-multi-select/VisibilityMultiSelect';
+import { markMissionCompleted } from '@components/share/MissionOfTheDay';
 import SubHeader from '@components/sub-header/SubHeader';
 import { Layout, TextArea, Typo } from '@design-system';
 import useAsyncEffect from '@hooks/useAsyncEffect';
@@ -24,6 +25,7 @@ function NewResponse() {
   const location = useLocation();
   const { questionId, responseId } = useParams();
   const isEdit = location.pathname.includes('/edit');
+  const missionMode = location.state?.missionMode;
 
   const currentUser = useBoundStore.getState().myProfile;
 
@@ -37,7 +39,7 @@ function NewResponse() {
   const [visibilityList, setVisibilityList] = useState<PostVisibility[]>([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const title = !location.state
+  const title = !isEdit
     ? t('question.response.new_response')
     : t('question.response.edit_response');
 
@@ -118,6 +120,10 @@ function NewResponse() {
             content: newResponse || '',
             visibility: visibilityList,
           });
+
+      if (missionMode) {
+        markMissionCompleted();
+      }
 
       openToast({
         message: t(isEdit ? 'question.response.edited' : 'question.response.posted'),


### PR DESCRIPTION
# Fix: Mission of the Day "Done" State Shown Without Completing Mission

## Problem
- Pressing "Do it" on the Mission card, entering the post creation page, then going back **without writing anything** caused the button to display "Done" — the mission was marked complete on navigation, not on actual post submission.
- Two separate localStorage keys (`whoami_mission_completed` and `whoami_mission_attempts`) tracked mission state independently, causing inconsistency.
- The question-type mission flow (`/questions` → pick question → `/questions/:id/new`) did not propagate `missionMode` at all, so completing a question response never marked the mission as done.

## Changes

### MissionPromptCard (`MissionPromptCard.tsx`)
- Removed self-contained localStorage logic (`whoami_mission_completed` key, `isMissionCompletedToday`, `markMissionCompleted`)
- Completion status now reads from the shared key via `getAttemptsToday()` from `MissionOfTheDay.tsx`
- `handleDoIt` no longer marks completion — only navigates with `{ state: { missionMode: true } }`

### MissionOfTheDay (`MissionOfTheDay.tsx`)
- Exported `getAttemptsToday` so `MissionPromptCard` can read from the shared storage

### AllQuestions (`AllQuestions.tsx`)
- Extracts `missionMode` from `location.state` and passes it to `PromptCard`

### PromptCard (`PromptCard.tsx`)
- Accepts optional `missionMode` prop
- Forwards `{ state: { missionMode: true } }` when navigating to `/questions/:id/new`

### NewResponse (`NewResponse.tsx`)
- Reads `missionMode` from `location.state`
- Calls `markMissionCompleted()` after successful response submission
- Fixed title logic: was using `!location.state` (broke when state carried `missionMode`), now uses `isEdit`

## missionMode Propagation Chain

```
MissionPromptCard → /questions (missionMode)
  → AllQuestions → PromptCard (prop)
    → /questions/:id/new (missionMode)
      → NewResponse → markMissionCompleted() on success

MissionPromptCard → /notes/new (missionMode)
  → NewNoteHeader → markMissionCompleted() on success  (already worked)
```

## Impact
- Mission card only shows "Done" after the user actually submits a post or response
- Going back without writing keeps the button as "Do it"
- Single localStorage key (`whoami_mission_attempts`) for all mission tracking
