### PR TITLE
feat(check-in): Archive button in each component editor popup

### DIFF
--- a/src/components/check-in/update-quadrant/BatteryEditor.tsx
+++ b/src/components/check-in/update-quadrant/BatteryEditor.tsx
@@ -9,6 +9,7 @@ interface Props {
   isOpen: boolean;
   onClose: () => void;
   onShare: (value: SocialBattery | null, visibility: ComponentVisibility) => void;
+  onArchive?: () => void;
   value: SocialBattery | null;
   onChange: (value: SocialBattery | null) => void;
   visibility: ComponentVisibility;
@@ -21,6 +22,7 @@ export default function BatteryEditor({
   isOpen,
   onClose,
   onShare,
+  onArchive,
   value,
   onChange,
   visibility,
@@ -44,7 +46,13 @@ export default function BatteryEditor({
   }, [draftValue, draftVisibility, onChange, onVisibilityChange, onShare]);
 
   return (
-    <EditorPopup isOpen={isOpen} onClose={onClose} onShare={handleShare} title="Social Battery">
+    <EditorPopup
+      isOpen={isOpen}
+      onClose={onClose}
+      onShare={handleShare}
+      onArchive={onArchive}
+      title="Social Battery"
+    >
       <Layout.FlexRow w="100%" gap={8} mb={16} style={{ flexWrap: 'wrap' }}>
         {BATTERY_OPTIONS.map((battery) => (
           <SocialBatteryChip

--- a/src/components/check-in/update-quadrant/EditorPopup.tsx
+++ b/src/components/check-in/update-quadrant/EditorPopup.tsx
@@ -7,6 +7,10 @@ interface EditorPopupProps {
   isOpen: boolean;
   onClose: () => void;
   onShare: () => void;
+  /** Optional archive action — when provided, renders an "Archive" link
+   *  next to the Share button. Hidden when the editor has no current
+   *  live value to archive (i.e. the component is empty). */
+  onArchive?: () => void;
   title: string;
 }
 
@@ -14,6 +18,7 @@ function EditorPopup({
   isOpen,
   onClose,
   onShare,
+  onArchive,
   title,
   children,
 }: PropsWithChildren<EditorPopupProps>) {
@@ -95,21 +100,39 @@ function EditorPopup({
       >
         <Layout.FlexRow w="100%" justifyContent="space-between" alignItems="center" mb={12}>
           <Typo type="title-medium">{title}</Typo>
-          <CloseButton
-            type="button"
-            onTouchEnd={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              triggerShare();
-            }}
-            onClick={(e) => {
-              e.stopPropagation();
-              console.log('[EditorPopup] Share clicked', { title });
-              triggerShare();
-            }}
-          >
-            Share
-          </CloseButton>
+          <Layout.FlexRow alignItems="center" gap={8}>
+            {onArchive && (
+              <ArchiveButton
+                type="button"
+                onTouchEnd={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  onArchive();
+                }}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onArchive();
+                }}
+              >
+                Archive
+              </ArchiveButton>
+            )}
+            <CloseButton
+              type="button"
+              onTouchEnd={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                triggerShare();
+              }}
+              onClick={(e) => {
+                e.stopPropagation();
+                console.log('[EditorPopup] Share clicked', { title });
+                triggerShare();
+              }}
+            >
+              Share
+            </CloseButton>
+          </Layout.FlexRow>
         </Layout.FlexRow>
         {children}
       </Content>
@@ -148,6 +171,18 @@ const CloseButton = styled.button`
   font-weight: 600;
   cursor: pointer;
   padding: 4px 8px;
+`;
+
+const ArchiveButton = styled.button`
+  background: none;
+  border: none;
+  color: ${Colors.DARK_GRAY};
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  padding: 4px 8px;
+  text-decoration: underline;
+  text-underline-offset: 2px;
 `;
 
 export default EditorPopup;

--- a/src/components/check-in/update-quadrant/MoodEditor.tsx
+++ b/src/components/check-in/update-quadrant/MoodEditor.tsx
@@ -12,6 +12,7 @@ interface Props {
   isOpen: boolean;
   onClose: () => void;
   onShare: (value: string[], visibility: ComponentVisibility) => void;
+  onArchive?: () => void;
   value: string[];
   onChange: (value: string[]) => void;
   visibility: ComponentVisibility;
@@ -22,6 +23,7 @@ export default function MoodEditor({
   isOpen,
   onClose,
   onShare,
+  onArchive,
   value,
   onChange,
   visibility,
@@ -60,7 +62,13 @@ export default function MoodEditor({
   }, [draftValue, draftVisibility, onChange, onVisibilityChange, onShare]);
 
   return (
-    <EditorPopup isOpen={isOpen} onClose={onClose} onShare={handleShare} title="Mood">
+    <EditorPopup
+      isOpen={isOpen}
+      onClose={onClose}
+      onShare={handleShare}
+      onArchive={onArchive}
+      title="Mood"
+    >
       <Layout.FlexCol w="100%" alignItems="center" gap={12} mb={16}>
         {draftValue.length > 0 ? (
           <Layout.FlexCol w="100%" gap={8} alignItems="center">

--- a/src/components/check-in/update-quadrant/SongEditor.tsx
+++ b/src/components/check-in/update-quadrant/SongEditor.tsx
@@ -13,6 +13,7 @@ interface Props {
   isOpen: boolean;
   onClose: () => void;
   onShare: (trackId: string, visibility: ComponentVisibility) => void;
+  onArchive?: () => void;
   trackId: string;
   onChange: (trackId: string) => void;
   visibility: ComponentVisibility;
@@ -23,6 +24,7 @@ export default function SongEditor({
   isOpen,
   onClose,
   onShare,
+  onArchive,
   trackId,
   onChange,
   visibility,
@@ -85,7 +87,13 @@ export default function SongEditor({
   }, [draftTrackId, draftVisibility, onChange, onVisibilityChange, onShare]);
 
   return (
-    <EditorPopup isOpen={isOpen} onClose={onClose} onShare={handleShare} title="Song">
+    <EditorPopup
+      isOpen={isOpen}
+      onClose={onClose}
+      onShare={handleShare}
+      onArchive={onArchive}
+      title="Song"
+    >
       <Layout.FlexCol w="100%" gap={12} mb={16}>
         {currentTrack && !query && (
           <Layout.FlexCol w="100%" gap={8}>

--- a/src/components/check-in/update-quadrant/ThoughtEditor.tsx
+++ b/src/components/check-in/update-quadrant/ThoughtEditor.tsx
@@ -11,6 +11,7 @@ interface Props {
   isOpen: boolean;
   onClose: () => void;
   onShare: (value: string, visibility: ComponentVisibility) => void;
+  onArchive?: () => void;
   value: string;
   onChange: (value: string) => void;
   visibility: ComponentVisibility;
@@ -21,6 +22,7 @@ export default function ThoughtEditor({
   isOpen,
   onClose,
   onShare,
+  onArchive,
   value,
   onChange,
   visibility,
@@ -50,7 +52,13 @@ export default function ThoughtEditor({
   }, [draftValue, draftVisibility, onChange, onVisibilityChange, onShare]);
 
   return (
-    <EditorPopup isOpen={isOpen} onClose={onClose} onShare={handleShare} title="Thought Snippet">
+    <EditorPopup
+      isOpen={isOpen}
+      onClose={onClose}
+      onShare={handleShare}
+      onArchive={onArchive}
+      title="Thought Snippet"
+    >
       <Layout.FlexCol w="100%" gap={8} mb={16}>
         <StyledTextArea
           value={draftValue}

--- a/src/routes/update/UpdateCheckin.tsx
+++ b/src/routes/update/UpdateCheckin.tsx
@@ -16,7 +16,13 @@ import useAsyncEffect from '@hooks/useAsyncEffect';
 import SpotifyManager from '@libs/SpotifyManager';
 import { ComponentVisibility, DEFAULT_VISIBILITY, SocialBattery } from '@models/checkIn';
 import { useBoundStore } from '@stores/useBoundStore';
-import { getActiveSong, postCheckIn, postSong } from '@utils/apis/checkIn';
+import {
+  ArchivableCheckInComponent,
+  archiveLiveComponent,
+  getActiveSong,
+  postCheckIn,
+  postSong,
+} from '@utils/apis/checkIn';
 import { MainScrollContainer } from '../Root';
 import {
   ArchivedBadge,
@@ -284,6 +290,33 @@ export default function UpdateCheckin() {
     [doSave],
   );
 
+  /**
+   * Archive a currently-live component (without replacing it). Closes the
+   * editor, hits the new PATCH /check_in/components/<c>/archive/, refetches
+   * the active check-in to reset local state to "no value," and surfaces
+   * a toast. The archived row drops into the user's archive feed under
+   * "Today" and is eligible for pinning.
+   */
+  const handleArchive = useCallback(
+    async (component: ArchivableCheckInComponent) => {
+      setActiveEditor(null);
+      try {
+        await archiveLiveComponent(component);
+        const ci = await fetchCheckIn();
+        if (component === 'battery') setBattery(ci?.social_battery ?? null);
+        if (component === 'mood') {
+          setMood(Array.isArray(ci?.mood) ? ci?.mood ?? [] : ci?.mood ? [ci.mood] : []);
+        }
+        if (component === 'thought') setThought(ci?.thought ?? '');
+        if (component === 'song') setTrackId('');
+        openToast({ message: `Archived ${component}` });
+      } catch {
+        openToast({ message: `Couldn't archive ${component}. Please try again.` });
+      }
+    },
+    [fetchCheckIn, openToast],
+  );
+
   return (
     <MainScrollContainer>
       <GridContainer>
@@ -424,6 +457,7 @@ export default function UpdateCheckin() {
         isOpen={activeEditor === 'battery'}
         onClose={handleEditorDismiss}
         onShare={handleBatteryShare}
+        onArchive={battery ? () => handleArchive('battery') : undefined}
         value={battery}
         onChange={setBattery}
         visibility={effectiveBatteryVis}
@@ -433,6 +467,7 @@ export default function UpdateCheckin() {
         isOpen={activeEditor === 'mood'}
         onClose={handleEditorDismiss}
         onShare={handleMoodShare}
+        onArchive={mood.length > 0 ? () => handleArchive('mood') : undefined}
         value={mood}
         onChange={setMood}
         visibility={effectiveMoodVis}
@@ -442,6 +477,7 @@ export default function UpdateCheckin() {
         isOpen={activeEditor === 'song'}
         onClose={handleEditorDismiss}
         onShare={handleSongShare}
+        onArchive={trackId ? () => handleArchive('song') : undefined}
         trackId={trackId}
         onChange={setTrackId}
         visibility={effectiveSongVis}
@@ -451,6 +487,7 @@ export default function UpdateCheckin() {
         isOpen={activeEditor === 'thought'}
         onClose={handleEditorDismiss}
         onShare={handleThoughtShare}
+        onArchive={thought ? () => handleArchive('thought') : undefined}
         value={thought}
         onChange={setThought}
         visibility={effectiveThoughtVis}

--- a/src/utils/apis/checkIn.ts
+++ b/src/utils/apis/checkIn.ts
@@ -59,6 +59,21 @@ export const deactivateSong = async (songId: number) => {
   await axios.patch(`/check_in/song/${songId}/`);
 };
 
+export type ArchivableCheckInComponent = 'battery' | 'mood' | 'thought' | 'song';
+
+/**
+ * Archive a single currently-live check-in component without replacing it.
+ * Backend stamps superseded_at on the live entry, clears the matching
+ * CheckIn field (or deactivates the active Song), and the row drops into
+ * the archive feed under "Today" — eligible for pinning afterwards.
+ */
+export const archiveLiveComponent = async (component: ArchivableCheckInComponent) => {
+  const { data } = await axios.patch<{ archived: ArchivableCheckInComponent }>(
+    `/check_in/components/${component}/archive/`,
+  );
+  return data;
+};
+
 // GET reactions for a check-in
 type ReactionItem = { id: number; emoji: string; user: { id: number; username: string } };
 export const getCheckInReactions = async (checkInId: number): Promise<ReactionItem[]> => {


### PR DESCRIPTION
## Summary
- Adds an "Archive" link to the top-right of each editor popup (Battery / Mood / Song / Thought), beside the existing "Share" button
- Hidden when the component has no current value to archive
- Calls the new backend PATCH /components/<c>/archive/ endpoint, refetches the active check-in to clear local state, toasts "Archived <component>"
- The just-archived entry drops into the owner's archive feed under "Today" and is eligible for pinning

## Test plan
- [x] Cache-clean `npx craco build` passes
- [x] Dev server restarts clean (no compile errors after import schema change)
- [x] Screenshot verification: Archive link renders next to Share in the Battery editor
- [x] Click flow ready to QA against the matching backend PR