### PR TITLE
feat(pinned-checkin): always render Pinned Check-ins (N) chip

### DIFF
--- a/src/components/check-in/CheckIn.tsx
+++ b/src/components/check-in/CheckIn.tsx
@@ -80,8 +80,7 @@ function CheckIn({ user }: CheckInProps) {
           {isMyPage ? (
             <CheckInArchiveChip />
           ) : (
-            friendUsername &&
-            friendPinnedCount > 0 && (
+            friendUsername && (
               <FriendPinnedChip
                 pinnedCount={friendPinnedCount}
                 to={`/users/${friendUsername}/check-in/pinned`}

--- a/src/components/check-in/my-check-in-card/MyCheckInCard.tsx
+++ b/src/components/check-in/my-check-in-card/MyCheckInCard.tsx
@@ -173,11 +173,11 @@ function MyCheckInCard() {
  * Friends feed. Mirrors the friend card layout so the row matches visually.
  * Navigates to `/check-in/archive?tab=pinned` (own archive with pin
  * controls) rather than the read-only `/users/<u>/check-in/pinned` path
- * that FriendPinnedChip uses on friend cards.
+ * that FriendPinnedChip uses on friend cards. Always renders (including
+ * N=0) so the affordance stays at a predictable position on the card.
  */
 function MyPinnedLink() {
   const { pinnedCount } = useArchiveCounts();
-  if (pinnedCount <= 0) return null;
   return (
     <Layout.FlexRow alignSelf="flex-start">
       <FriendPinnedChip pinnedCount={pinnedCount} to="/check-in/archive?tab=pinned" />

--- a/src/components/friends/friend-item-with-updates/FriendItemWithUpdates.tsx
+++ b/src/components/friends/friend-item-with-updates/FriendItemWithUpdates.tsx
@@ -344,13 +344,11 @@ function FriendItemWithUpdates({
         </>
       )}
 
-      {/* Pinned Check-ins chip — hidden when count is 0 (per the spec: the
-          chip only surfaces friends who have pins visible to this viewer). */}
-      {pinnedCount > 0 && (
-        <Layout.FlexRow w="100%" alignSelf="flex-start">
-          <FriendPinnedChip pinnedCount={pinnedCount} to={`/users/${username}/check-in/pinned`} />
-        </Layout.FlexRow>
-      )}
+      {/* Pinned Check-ins chip — always renders (including N=0) so the
+          affordance sits at a predictable position on every friend card. */}
+      <Layout.FlexRow w="100%" alignSelf="flex-start">
+        <FriendPinnedChip pinnedCount={pinnedCount} to={`/users/${username}/check-in/pinned`} />
+      </Layout.FlexRow>
 
       {/* Check-in detail popup */}
       <CheckInDetailBottomSheet

--- a/src/components/friends/friend-pinned-chip/FriendPinnedChip.tsx
+++ b/src/components/friends/friend-pinned-chip/FriendPinnedChip.tsx
@@ -4,7 +4,10 @@ import { useNavigate } from 'react-router-dom';
 import { SvgIcon, Typo } from '@design-system';
 
 interface Props {
-  /** Viewer-visible pinned count — hides the chip entirely when 0. */
+  /** Viewer-visible pinned count. The chip renders even when 0 so the
+   *  affordance stays at a predictable position on every card, matching
+   *  the owner's `[ All Archived (N) | Pinned (N) ]` segmented control
+   *  which also surfaces 0-counts. */
   pinnedCount: number;
   /** Navigation target on tap. Callers route to `/users/<u>/check-in/pinned`
    *  for a friend, and `/check-in/archive?tab=pinned` for the viewer's own
@@ -22,14 +25,13 @@ interface Props {
  * around it (battery, mood, thought, song, new-post badge, etc). The
  * pin icon prefix keeps it recognizable at a glance.
  *
- * Visible only when `pinnedCount > 0`. Click stops propagation so it
- * doesn't fire the outer card click handler.
+ * Always visible. Click stops propagation so it doesn't fire the outer
+ * card click handler; tapping when N=0 still opens the destination
+ * (empty feed) so users learn where pins would surface.
  */
 function FriendPinnedChip({ pinnedCount, to }: Props) {
   const [t] = useTranslation('translation', { keyPrefix: 'archive.friend_card' });
   const navigate = useNavigate();
-
-  if (pinnedCount <= 0) return null;
 
   const handleClick = (e: MouseEvent) => {
     e.stopPropagation();

--- a/src/components/friends/updated-friend-item/UpdatedFriendItemDefault.tsx
+++ b/src/components/friends/updated-friend-item/UpdatedFriendItemDefault.tsx
@@ -50,14 +50,12 @@ function UpdatedFriendItemDefault({ user, isMyPage }: Props) {
                   {description}
                 </Typo>
               )}
-              {pinnedCount > 0 && (
-                <Layout.FlexRow mt={4}>
-                  <FriendPinnedChip
-                    pinnedCount={pinnedCount}
-                    to={`/users/${username}/check-in/pinned`}
-                  />
-                </Layout.FlexRow>
-              )}
+              <Layout.FlexRow mt={4}>
+                <FriendPinnedChip
+                  pinnedCount={pinnedCount}
+                  to={`/users/${username}/check-in/pinned`}
+                />
+              </Layout.FlexRow>
             </Layout.FlexCol>
           </Layout.FlexRow>
         </StyledProfileArea>


### PR DESCRIPTION
## Summary
- Remove the `pinnedCount > 0` early-return / guard from every chip callsite (friend cards, friend profile Most Recent Check-in row, self-card on the Friends feed) so the affordance sits at a predictable position regardless of count.
- `FriendPinnedChip` now always renders; callers no longer wrap it in `pinnedCount > 0 && (...)`.
- `MyPinnedLink` on the self-card drops its early return so viewers with zero pins still see `📌 Pinned Check-ins (0)`.

## Test plan
- [ ] Viewer with zero visible pins on a friend profile still sees `📌 Pinned Check-ins (0)` on the friend card + Most Recent Check-in row.
- [ ] Self-card on Friends feed shows `📌 Pinned Check-ins (0)` when you have no pins.
- [ ] Tap when count is 0 still opens the empty pinned archive (friend route / own archive tab) without errors.
- [ ] Positive-count path unchanged.