### PR TITLE
feat: #1247 add chat error handling

### DIFF
--- a/src/components/chat/chat-message-input/ChatMessageInput.tsx
+++ b/src/components/chat/chat-message-input/ChatMessageInput.tsx
@@ -1,6 +1,8 @@
+import { AxiosError } from 'axios';
 import EmojiPicker, { EmojiClickData } from 'emoji-picker-react';
 import { ChangeEvent, KeyboardEvent, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
+import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 import Icon from '@components/_common/icon/Icon';
 import { BOTTOM_TABBAR_HEIGHT, Z_INDEX } from '@constants/layout';
@@ -12,6 +14,7 @@ import {
   InputChatMessage,
   PostChatMessageRes,
 } from '@models/chat';
+import { useBoundStore } from '@stores/useBoundStore';
 import { postChatMessage, postGroupMessage } from '@utils/apis/chat';
 
 const StyledTextarea = styled.textarea`
@@ -110,9 +113,12 @@ function ChatMessageInput({
   const [showEmojiPicker, setShowEmojiPicker] = useState(false);
   const [selectedImage, setSelectedImage] = useState<File | null>(null);
   const [imagePreview, setImagePreview] = useState<string | null>(null);
+  const [isSending, setIsSending] = useState(false);
   const lastTypingSent = useRef(0);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const { openToast } = useBoundStore((state) => ({ openToast: state.openToast }));
+  const [t] = useTranslation('translation', { keyPrefix: 'chat' });
 
   // Auto-expand textarea
   useEffect(() => {
@@ -142,6 +148,7 @@ function ChatMessageInput({
   };
 
   const sendMessage = async () => {
+    if (isSending) return;
     if (!inputValue.trim() && !selectedImage) return;
 
     const msg: InputChatMessage = {
@@ -153,6 +160,7 @@ function ChatMessageInput({
       msg.parent = replyTarget.id;
     }
 
+    setIsSending(true);
     try {
       const { data } = isGroup
         ? await postGroupMessage(userId, msg, selectedImage || undefined)
@@ -164,7 +172,15 @@ function ChatMessageInput({
       onClearReply();
       setShowEmojiPicker(false);
     } catch (err) {
-      console.error('[ChatMessageInput] send failed:', err);
+      const axiosErr = err as AxiosError<{ detail?: string }>;
+      const status = axiosErr?.response?.status;
+      if (status === 403) {
+        openToast({ message: t('send_blocked') });
+      } else {
+        openToast({ message: t('send_failed') });
+      }
+    } finally {
+      setIsSending(false);
     }
   };
 

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -423,6 +423,8 @@
         "refresh": "Refresh",
         "list_title": "Chats",
         "no_rooms": "No conversations yet.",
+        "send_blocked": "This message could not be sent.",
+        "send_failed": "Failed to send message. Please try again.",
         "request": {
             "send": "Send chat request",
             "sent": "Requested",

--- a/src/i18n/locales/ko/translation.json
+++ b/src/i18n/locales/ko/translation.json
@@ -420,6 +420,8 @@
     "refresh": "새로고침",
     "list_title": "Chats",
     "no_rooms": "아직 대화가 없습니다.",
+    "send_blocked": "메시지를 보낼 수 없습니다.",
+    "send_failed": "메시지 전송에 실패했습니다. 다시 시도해주세요.",
     "request": {
       "send": "채팅 요청 보내기",
       "sent": "요청됨",

--- a/src/routes/chat/Chat.tsx
+++ b/src/routes/chat/Chat.tsx
@@ -1,3 +1,4 @@
+import { AxiosError } from 'axios';
 import { isSameDay } from 'date-fns';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -51,6 +52,7 @@ function Chat() {
   const [receivedChatRequestId, setReceivedChatRequestId] = useState<number | null>(null);
 
   const currentUser = useBoundStore((state) => state.myProfile);
+  const openToast = useBoundStore((state) => state.openToast);
 
   const loadRelationship = useCallback(async (profileUsername: string) => {
     if (!profileUsername) return;
@@ -66,21 +68,30 @@ function Chat() {
 
   const fetchMessages = useCallback(
     async (_userId: number) => {
-      const { next, results, username: _username } = await getChatMessages(_userId);
-      const resolvedUsername = _username ?? '';
-      setUsername(resolvedUsername);
-      if (resolvedUsername) loadRelationship(resolvedUsername);
-      if (!results) {
+      try {
+        const { next, results, username: _username } = await getChatMessages(_userId);
+        const resolvedUsername = _username ?? '';
+        setUsername(resolvedUsername);
+        if (resolvedUsername) loadRelationship(resolvedUsername);
+        if (!results) {
+          setNextUrl(next);
+          setMessages([]);
+          setFirstLoad(false);
+          return;
+        }
+        setMessages([...results].reverse());
         setNextUrl(next);
-        setMessages([]);
         setFirstLoad(false);
-        return;
+      } catch (err) {
+        const axiosErr = err as AxiosError;
+        if (axiosErr?.response?.status === 403) {
+          openToast({ message: t('send_blocked') });
+          navigate(-1);
+        }
+        setFirstLoad(false);
       }
-      setMessages([...results].reverse());
-      setNextUrl(next);
-      setFirstLoad(false);
     },
-    [loadRelationship],
+    [loadRelationship, navigate, openToast, t],
   );
 
   useEffect(() => {


### PR DESCRIPTION
# Chat Message Send Failure: Silent Error Fix

## Problem

When two users are actively chatting (sending text, photos, etc.), one user's send button (paper airplane icon) suddenly stops working — pressing it does nothing. No error message, no toast, no visual feedback at all.

This bug existed before the recent block filter changes and occurs regardless of whether users have blocked each other.

## Root Cause

Two issues combine to produce the "nothing happens" symptom:

### 1. Backend: Unhandled WebSocket Broadcast Exception

In `MessageList.create()`, after the message is successfully saved to the database, the method broadcasts the new message via the channel layer (Redis in production). This broadcast had **no error handling**:

```python
# Before — no try/except
async_to_sync(channel_layer.group_send)(
    group_name,
    {"type": "chat.message", "data": response.data},
)
```

In production, if Redis is temporarily unavailable (connection timeout, memory pressure, brief restart), this line throws an unhandled exception. Because `super().create()` already committed the message to the database, the message **is saved** but the HTTP response becomes a **500 Internal Server Error**.

Note: This could not be reproduced locally because the development environment uses `InMemoryChannelLayer`, which never fails.

### 2. Frontend: Silent Error Swallowing

`ChatMessageInput.sendMessage()` caught all API errors with only `console.error`:

```typescript
// Before — silent catch
} catch (err) {
  console.error('[ChatMessageInput] send failed:', err);
}
```

Any error (403 Forbidden, 500 Internal Server Error, network failure) was logged to the browser console but **never shown to the user**. The input text remained, the send button stayed enabled, and from the user's perspective, pressing the button did absolutely nothing.

## Changes

### Backend

| File | What changed |
|------|-------------|
| `chat/views.py` | Wrapped the chat room WebSocket broadcast in `try/except`; on failure, logs the error and sends a Slack alert via `send_msg_to_slack()` |

The message is still saved and the 201 response is still returned to the client. Only the real-time WebSocket delivery to the chat room fails gracefully — the recipient will see the message on their next page load or scroll.

### Frontend

| File | What changed |
|------|-------------|
| `ChatMessageInput.tsx` | Replaced silent `console.error` with toast notifications: 403 → "send_blocked" message, other errors → "send_failed" message. Added `isSending` guard to prevent duplicate sends while a request is in flight. |
| `Chat.tsx` | Wrapped `fetchMessages` in `try/catch`; on 403 (e.g. blocked user), shows toast and navigates back instead of rendering an empty/broken chat page. |
| `i18n/locales/ko/translation.json` | Added `send_blocked` ("메시지를 보낼 수 없습니다.") and `send_failed` ("메시지 전송에 실패했습니다. 다시 시도해주세요.") |
| `i18n/locales/en/translation.json` | Added `send_blocked` ("This message could not be sent.") and `send_failed` ("Failed to send message. Please try again.") |

## Error Monitoring

The backend broadcast failure now triggers a Slack alert containing:
- Chat room identifier
- Sender and receiver usernames + IDs
- The exception message

Other chat errors (validation, authentication, CSRF) are already handled by the existing `adoor_exception_handler` which sends Slack alerts for server-level exceptions.

## Notes

- The `send_blocked` toast message is intentionally vague ("This message could not be sent.") rather than saying "You are blocked" — this follows the common UX pattern of not revealing block status to the blocked user.
- The `isSending` state prevents rapid double-taps from queuing duplicate API calls.
- The `fetchMessages` error handling in `Chat.tsx` also covers the case where a blocked user navigates directly to a chat URL — they see a toast and get redirected back instead of seeing a blank page.
