### PR TITLE
bugfix: #1253 1-1 chat counter bugfix

### DIFF
--- a/src/routes/Root.tsx
+++ b/src/routes/Root.tsx
@@ -48,8 +48,8 @@ function Root() {
     getMyProfile().catch(() => {});
   }, []);
   const onChatListSocketUpdate = useCallback(
-    (data: { unread_count: number }) => {
-      if (data.unread_count > 0) {
+    (data: { unread_count?: number }) => {
+      if (typeof data.unread_count === 'number') {
         refreshUnreadCount();
       }
     },

--- a/src/routes/chat/Chat.tsx
+++ b/src/routes/chat/Chat.tsx
@@ -40,6 +40,7 @@ function Chat() {
   const [prevScrollHeight, setPrevScrollHeight] = useState<number | undefined>();
   const justSentIdsRef = useRef<Set<number>>(new Set());
   const shouldPinToBottomRef = useRef<Set<number>>(new Set());
+  const markReadTimerRef = useRef<ReturnType<typeof setTimeout>>();
 
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [username, setUsername] = useState<string>('');
@@ -97,6 +98,9 @@ function Chat() {
   useEffect(() => {
     if (!userId) return;
     fetchMessages(Number(userId));
+    return () => {
+      clearTimeout(markReadTimerRef.current);
+    };
   }, [fetchMessages, userId]);
 
   // Scroll to target message or bottom on first load
@@ -205,7 +209,10 @@ function Chat() {
           return [...prev, { ...msg, is_read: true }];
         });
         if (userId) {
-          markMessagesRead(Number(userId)).catch(() => {});
+          clearTimeout(markReadTimerRef.current);
+          markReadTimerRef.current = setTimeout(() => {
+            markMessagesRead(Number(userId)).catch(() => {});
+          }, 300);
         }
       }
     },


### PR DESCRIPTION
# Fix: 1:1 Chat Unread Counter Stuck at 1

## Problem

In 1:1 chats, the unread message badge on the chat list always displayed "1" regardless of how many unread messages existed. Group chats were unaffected.

## Root Cause

Two interacting issues:

1. **Race condition in `Chat.tsx`**: Every incoming WebSocket message triggered `markMessagesRead()` immediately, marking all previous messages as read. When the next message was created, the backend counted only 1 unread message (the newest one).

2. **Missing broadcast on mark-read**: `MarkMessagesRead` and `MessageList.list` both marked messages as read but never broadcast the updated count to the chat list WebSocket. The badge retained its last stale value (always 1).

Group chats were unaffected because they use a cursor-based approach (`GroupReadCursor`) instead of per-message `is_read` flags.

## Changes

### Backend: `chat/views.py`

**`MarkMessagesRead.post()`** — After marking messages as read, broadcast `unread_count: 0` to the user's chat list WebSocket.

**`MessageList.list()`** — After marking paginated messages as read on page load, compute the remaining unread count and broadcast it to the user's chat list WebSocket.

### Frontend: `routes/chat/Chat.tsx`

**Debounce `markMessagesRead`** — Replaced the per-message `markMessagesRead()` call with a 300ms debounced version. Rapid consecutive messages now trigger a single API call, reducing the race condition window. Timer is cleaned up on unmount.

### Frontend: `routes/Root.tsx`

**Handle `unread_count: 0`** — Changed the condition from `data.unread_count > 0` to `typeof data.unread_count === 'number'` so that mark-read broadcasts (with count 0) also refresh the tab bar badge.
