### PR TITLE
feat(chat): re-apply WIT Admin Announcements UX (verified)

### DIFF
--- a/src/components/chat/chat-message-input/ChatMessageInput.tsx
+++ b/src/components/chat/chat-message-input/ChatMessageInput.tsx
@@ -4,6 +4,7 @@ import { ChangeEvent, KeyboardEvent, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
+import CommonDialog from '@components/_common/alert-dialog/common-dialog/CommonDialog';
 import Icon from '@components/_common/icon/Icon';
 import { BOTTOM_TABBAR_HEIGHT, Z_INDEX } from '@constants/layout';
 import { Colors, Layout, Typo } from '@design-system';
@@ -96,9 +97,12 @@ interface Props {
   onTyping?: () => void;
   isGroup?: boolean;
   typingText?: string | null;
+  isAnnouncement?: boolean;
 }
 
 const TYPING_DEBOUNCE_MS = 2000;
+const MAX_HEIGHT_DEFAULT = 120;
+const MAX_HEIGHT_ANNOUNCEMENT = 360;
 
 function ChatMessageInput({
   userId,
@@ -108,11 +112,13 @@ function ChatMessageInput({
   onTyping,
   isGroup,
   typingText,
+  isAnnouncement,
 }: Props) {
   const [inputValue, setInputValue] = useState('');
   const [showEmojiPicker, setShowEmojiPicker] = useState(false);
   const [selectedImage, setSelectedImage] = useState<File | null>(null);
   const [imagePreview, setImagePreview] = useState<string | null>(null);
+  const [showAnnouncementConfirm, setShowAnnouncementConfirm] = useState(false);
   const [isSending, setIsSending] = useState(false);
   const lastTypingSent = useRef(0);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -120,14 +126,16 @@ function ChatMessageInput({
   const { openToast } = useBoundStore((state) => ({ openToast: state.openToast }));
   const [t] = useTranslation('translation', { keyPrefix: 'chat' });
 
+  const maxHeight = isAnnouncement ? MAX_HEIGHT_ANNOUNCEMENT : MAX_HEIGHT_DEFAULT;
+
   // Auto-expand textarea
   useEffect(() => {
     const textarea = textareaRef.current;
     if (textarea) {
       textarea.style.height = 'auto';
-      textarea.style.height = `${Math.min(textarea.scrollHeight, 120)}px`;
+      textarea.style.height = `${Math.min(textarea.scrollHeight, maxHeight)}px`;
     }
-  }, [inputValue]);
+  }, [inputValue, maxHeight]);
 
   const handleChangeInput = (e: ChangeEvent<HTMLTextAreaElement>) => {
     setInputValue(e.target.value);
@@ -143,7 +151,18 @@ function ChatMessageInput({
   const handleKeyDownInput = (e: KeyboardEvent) => {
     if (e.nativeEvent.isComposing || e.key !== 'Enter') return;
     if (e.shiftKey) return;
+    if (isAnnouncement) return; // Announcements require an explicit Post button — Enter inserts newline.
     e.preventDefault();
+    sendMessage();
+  };
+
+  const handleAnnouncementPostClick = () => {
+    if (!inputValue.trim() && !selectedImage) return;
+    setShowAnnouncementConfirm(true);
+  };
+
+  const handleAnnouncementConfirm = () => {
+    setShowAnnouncementConfirm(false);
     sendMessage();
   };
 
@@ -306,10 +325,13 @@ function ChatMessageInput({
           <StyledTextarea
             ref={textareaRef}
             value={inputValue}
-            placeholder="Send a message..."
+            placeholder={
+              isAnnouncement ? 'Compose announcement to all users...' : 'Send a message...'
+            }
             onChange={handleChangeInput}
             onKeyDown={handleKeyDownInput}
-            rows={1}
+            rows={isAnnouncement ? 4 : 1}
+            style={{ maxHeight: `${maxHeight}px` }}
           />
           <Icon
             name="emoji"
@@ -317,11 +339,44 @@ function ChatMessageInput({
             fill="DARK_GRAY"
             onClick={() => setShowEmojiPicker(!showEmojiPicker)}
           />
-          {(inputValue.trim() || selectedImage) && (
+          {!isAnnouncement && (inputValue.trim() || selectedImage) && (
             <Icon name="question_send" size={24} onClick={() => sendMessage()} color="PRIMARY" />
           )}
         </Layout.FlexRow>
+        {isAnnouncement && (
+          <Layout.FlexRow w="100%" pt={10} justifyContent="flex-end">
+            <button
+              type="button"
+              onClick={handleAnnouncementPostClick}
+              disabled={!inputValue.trim() && !selectedImage}
+              style={{
+                padding: '8px 20px',
+                background: !inputValue.trim() && !selectedImage ? '#D9D9D9' : '#8700FF',
+                color: 'white',
+                border: 'none',
+                borderRadius: 8,
+                cursor: !inputValue.trim() && !selectedImage ? 'not-allowed' : 'pointer',
+                fontSize: 14,
+                fontWeight: 600,
+              }}
+            >
+              Post Announcement
+            </button>
+          </Layout.FlexRow>
+        )}
       </Layout.FlexCol>
+      {isAnnouncement && (
+        <CommonDialog
+          visible={showAnnouncementConfirm}
+          title="Send announcement?"
+          content="This will be delivered to every user as a message from WIT Admin and cannot be undone."
+          cancelText="Cancel"
+          confirmText="Send to all"
+          confirmTextColor="PRIMARY"
+          onClickConfirm={handleAnnouncementConfirm}
+          onClickClose={() => setShowAnnouncementConfirm(false)}
+        />
+      )}
     </Layout.Fixed>
   );
 }

--- a/src/routes/chat/Chat.tsx
+++ b/src/routes/chat/Chat.tsx
@@ -330,6 +330,7 @@ function Chat() {
           onMessageSent={handleMessageSent}
           onTyping={sendTyping}
           typingText={isOpponentTyping ? `${username} is typing...` : null}
+          isAnnouncement={username === 'Announcements'}
         />
       )}
     </MainScrollContainer>

--- a/src/routes/chat/ChatList.tsx
+++ b/src/routes/chat/ChatList.tsx
@@ -1,8 +1,10 @@
 import { useCallback, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
 import Icon from '@components/_common/icon/Icon';
 import { Loader } from '@components/_common/loader/Loader.styled';
 import ProfileImage from '@components/_common/profile-image/ProfileImage';
+import { ToggleSwitch } from '@components/_common/toggle-switch/ToggleSwitch';
 import SubHeader from '@components/sub-header/SubHeader';
 import { Layout, Typo } from '@design-system';
 import useAsyncEffect from '@hooks/useAsyncEffect';
@@ -11,11 +13,19 @@ import { getChatRooms } from '@utils/apis/chat';
 import { MainScrollContainer } from '../Root';
 import { useChatListSocket } from './_hooks/useChatListSocket';
 
+// Override the shared ToggleSwitch's checked colour for the unread filter.
+const PurpleToggleWrapper = styled.div`
+  & input:checked + .slider {
+    background-color: #8700ff;
+  }
+`;
+
 function ChatList() {
   const navigate = useNavigate();
   const [rooms, setRooms] = useState<ChatRoom[]>([]);
   const [loading, setLoading] = useState(true);
   const [typingUsers, setTypingUsers] = useState<Record<number, string>>({});
+  const [unreadOnly, setUnreadOnly] = useState(false);
   const typingTimers = useRef<Record<number, ReturnType<typeof setTimeout>>>({});
 
   useAsyncEffect(async () => {
@@ -94,6 +104,31 @@ function ChatList() {
           </Layout.FlexRow>
         }
       />
+      {!loading && (
+        <Layout.FlexRow
+          w="100%"
+          ph={16}
+          pv={8}
+          gap={10}
+          bgColor="WHITE"
+          alignItems="center"
+          justifyContent="flex-start"
+        >
+          <PurpleToggleWrapper>
+            <ToggleSwitch
+              type="small"
+              checked={unreadOnly}
+              onChange={() => setUnreadOnly((v) => !v)}
+            />
+          </PurpleToggleWrapper>
+          <Typo type="body-medium" color="DARK_GRAY">
+            {(() => {
+              const unreadCount = rooms.filter((r) => (r.unread_count || 0) > 0).length;
+              return `Unread Only${unreadCount ? ` (${unreadCount})` : ''}`;
+            })()}
+          </Typo>
+        </Layout.FlexRow>
+      )}
       {loading && (
         <Layout.FlexCol w="100%" alignItems="center" mt={30}>
           <Loader />
@@ -107,116 +142,127 @@ function ChatList() {
         </Layout.FlexCol>
       )}
       {!loading &&
-        rooms.map((room) => {
-          const opponentId = room.is_group ? null : room.opponent?.id;
-          const isTyping = opponentId ? !!typingUsers[opponentId] : false;
-          const roomName = room.is_group
-            ? room.name || 'Group Chat'
-            : room.opponent?.username || 'Chat';
-          const chatUrl = room.is_group ? `/chats/group/${room.id}` : `/users/${opponentId}/chat`;
-          return (
-            <Layout.FlexRow
-              key={room.id}
-              w="100%"
-              ph={16}
-              pv={12}
-              gap={12}
-              alignItems="center"
-              cursor="pointer"
-              onClick={() => navigate(chatUrl)}
-              style={{ borderBottom: '1px solid #F0F0F0' }}
-            >
-              {room.is_group ? (
-                <div
-                  style={{
-                    width: 44,
-                    height: 44,
-                    borderRadius: 8,
-                    background: '#F0F0F0',
-                    display: 'grid',
-                    gridTemplateColumns: '1fr 1fr',
-                    gridTemplateRows: '1fr 1fr',
-                    overflow: 'hidden',
-                    flexShrink: 0,
-                  }}
-                >
-                  {(room.members_detail || []).slice(0, 4).map((m) => (
-                    <div
-                      key={m.id}
-                      style={{
-                        width: '100%',
-                        height: '100%',
-                        overflow: 'hidden',
-                      }}
-                    >
-                      {m.profile_image ? (
-                        <img
-                          src={m.profile_image}
-                          alt={m.username}
-                          style={{ width: '100%', height: '100%', objectFit: 'cover' }}
-                        />
-                      ) : (
-                        <div
-                          style={{
-                            width: '100%',
-                            height: '100%',
-                            background: '#D9D9D9',
-                            display: 'flex',
-                            alignItems: 'center',
-                            justifyContent: 'center',
-                            fontSize: 10,
-                          }}
-                        >
-                          {m.username[0]?.toUpperCase()}
-                        </div>
-                      )}
-                    </div>
-                  ))}
-                </div>
-              ) : (
-                <ProfileImage imageUrl={room.opponent?.profile_image} size={44} />
-              )}
-              <Layout.FlexCol style={{ flex: 1, minWidth: 0 }}>
-                <Layout.FlexRow gap={6} alignItems="center">
-                  <Typo type="title-medium" color="BLACK">
-                    {roomName}
-                  </Typo>
-                  {room.is_group && room.members_detail && (
-                    <Typo type="label-small" color="MEDIUM_GRAY">
-                      ({room.members_detail.length})
-                    </Typo>
-                  )}
-                </Layout.FlexRow>
-                {isTyping ? (
-                  <Typo type="body-small" color="PRIMARY">
-                    typing...
-                  </Typo>
+        rooms.length > 0 &&
+        rooms.filter((r) => (unreadOnly ? (r.unread_count || 0) > 0 : true)).length === 0 && (
+          <Layout.FlexCol w="100%" alignItems="center" mt={50}>
+            <Typo type="body-medium" color="MEDIUM_GRAY">
+              No unread chats.
+            </Typo>
+          </Layout.FlexCol>
+        )}
+      {!loading &&
+        rooms
+          .filter((r) => (unreadOnly ? (r.unread_count || 0) > 0 : true))
+          .map((room) => {
+            const opponentId = room.is_group ? null : room.opponent?.id;
+            const isTyping = opponentId ? !!typingUsers[opponentId] : false;
+            const roomName = room.is_group
+              ? room.name || 'Group Chat'
+              : room.opponent?.username || 'Chat';
+            const chatUrl = room.is_group ? `/chats/group/${room.id}` : `/users/${opponentId}/chat`;
+            return (
+              <Layout.FlexRow
+                key={room.id}
+                w="100%"
+                ph={16}
+                pv={12}
+                gap={12}
+                alignItems="center"
+                cursor="pointer"
+                onClick={() => navigate(chatUrl)}
+                style={{ borderBottom: '1px solid #F0F0F0' }}
+              >
+                {room.is_group ? (
+                  <div
+                    style={{
+                      width: 44,
+                      height: 44,
+                      borderRadius: 8,
+                      background: '#F0F0F0',
+                      display: 'grid',
+                      gridTemplateColumns: '1fr 1fr',
+                      gridTemplateRows: '1fr 1fr',
+                      overflow: 'hidden',
+                      flexShrink: 0,
+                    }}
+                  >
+                    {(room.members_detail || []).slice(0, 4).map((m) => (
+                      <div
+                        key={m.id}
+                        style={{
+                          width: '100%',
+                          height: '100%',
+                          overflow: 'hidden',
+                        }}
+                      >
+                        {m.profile_image ? (
+                          <img
+                            src={m.profile_image}
+                            alt={m.username}
+                            style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+                          />
+                        ) : (
+                          <div
+                            style={{
+                              width: '100%',
+                              height: '100%',
+                              background: '#D9D9D9',
+                              display: 'flex',
+                              alignItems: 'center',
+                              justifyContent: 'center',
+                              fontSize: 10,
+                            }}
+                          >
+                            {m.username[0]?.toUpperCase()}
+                          </div>
+                        )}
+                      </div>
+                    ))}
+                  </div>
                 ) : (
-                  room.last_message && (
-                    <Typo type="body-small" color="MEDIUM_GRAY">
-                      {room.last_message}
-                    </Typo>
-                  )
+                  <ProfileImage imageUrl={room.opponent?.profile_image} size={44} />
                 )}
-              </Layout.FlexCol>
-              {room.unread_count > 0 && (
-                <Layout.FlexRow
-                  ph={8}
-                  pv={2}
-                  rounded={10}
-                  alignItems="center"
-                  justifyContent="center"
-                  bgColor="SECONDARY"
-                  style={{ minWidth: 24 }}
-                >
-                  <Typo type="label-small" color="BLACK">
-                    {room.unread_count > 99 ? '99+' : room.unread_count}
-                  </Typo>
-                </Layout.FlexRow>
-              )}
-            </Layout.FlexRow>
-          );
-        })}
+                <Layout.FlexCol style={{ flex: 1, minWidth: 0 }}>
+                  <Layout.FlexRow gap={6} alignItems="center">
+                    <Typo type="title-medium" color="BLACK">
+                      {roomName}
+                    </Typo>
+                    {room.is_group && room.members_detail && (
+                      <Typo type="label-small" color="MEDIUM_GRAY">
+                        ({room.members_detail.length})
+                      </Typo>
+                    )}
+                  </Layout.FlexRow>
+                  {isTyping ? (
+                    <Typo type="body-small" color="PRIMARY">
+                      typing...
+                    </Typo>
+                  ) : (
+                    room.last_message && (
+                      <Typo type="body-small" color="MEDIUM_GRAY">
+                        {room.last_message}
+                      </Typo>
+                    )
+                  )}
+                </Layout.FlexCol>
+                {room.unread_count > 0 && (
+                  <Layout.FlexRow
+                    ph={8}
+                    pv={2}
+                    rounded={10}
+                    alignItems="center"
+                    justifyContent="center"
+                    bgColor="SECONDARY"
+                    style={{ minWidth: 24 }}
+                  >
+                    <Typo type="label-small" color="BLACK">
+                      {room.unread_count > 99 ? '99+' : room.unread_count}
+                    </Typo>
+                  </Layout.FlexRow>
+                )}
+              </Layout.FlexRow>
+            );
+          })}
     </MainScrollContainer>
   );
 }


### PR DESCRIPTION
Re-applies the announcements posting UX + Unread Only filter that was reverted in 6123b8e. Verified locally with yarn install --frozen-lockfile + craco build + dev server preview.