### PR TITLE
feat(version-q): polish post/feed UI and hide legacy social metadata

### DIFF
--- a/src/components/_common/friend-type-select-modal/FriendTypeSelectModal.tsx
+++ b/src/components/_common/friend-type-select-modal/FriendTypeSelectModal.tsx
@@ -3,6 +3,8 @@ import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { CheckBox, Layout, RadioButton, Typo } from '@design-system';
 import { Connection } from '@models/api/friends';
+import { useBoundStore } from '@stores/useBoundStore';
+import { UserSelector } from '@stores/user';
 import * as S from './FriendTypeSelectModal.styled';
 
 interface FriendTypeSelectModalProps {
@@ -29,6 +31,7 @@ function FriendTypeSelectModal({
   const [t] = useTranslation('translation', {
     keyPrefix: 'friends.explore_friends.friend_item.friend_type_select_dialog',
   });
+  const { featureFlags } = useBoundStore(UserSelector);
   // default 값은 friend
   const [friendType, setFriendType] = useState<Connection>(Connection.FRIEND);
   const [isUpdatePastPosts, setIsUpdatePastPosts] = useState(false);
@@ -46,7 +49,7 @@ function FriendTypeSelectModal({
   const handleClickConfirm = () => {
     onClickConfirm({
       friendType,
-      updatePastPosts: isUpdatePastPosts,
+      updatePastPosts: featureFlags?.postsVerQ ? true : isUpdatePastPosts,
       isDefault: false,
     });
     onClickClose();
@@ -97,14 +100,16 @@ function FriendTypeSelectModal({
               onChange={handleChangeConnection}
             />
           </Layout.FlexCol>
-          <Layout.FlexRow mt={10} ml={20}>
-            <CheckBox
-              name={t('update_past_posts') || ''}
-              onChange={handleChangeCheckBox}
-              checked={isUpdatePastPosts}
-              disabled={friendType === Connection.FRIEND}
-            />
-          </Layout.FlexRow>
+          {!featureFlags?.postsVerQ && (
+            <Layout.FlexRow mt={10} ml={20}>
+              <CheckBox
+                name={t('update_past_posts') || ''}
+                onChange={handleChangeCheckBox}
+                checked={isUpdatePastPosts}
+                disabled={friendType === Connection.FRIEND}
+              />
+            </Layout.FlexRow>
+          )}
         </Layout.FlexCol>
         <S.ButtonContainer w="100%" justifyContent="space-evenly">
           <S.Button onClick={onClickClose} pv={11}>

--- a/src/components/_common/like-button/LikeButton.tsx
+++ b/src/components/_common/like-button/LikeButton.tsx
@@ -6,7 +6,7 @@ import { deleteLike, postLike } from '@utils/apis/likes';
 import * as S from './LikeButton.styled';
 
 interface LikeButtonProps {
-  postType: 'Moment' | 'Response' | 'Comment' | 'Note' | 'PrivateComment';
+  postType: 'Moment' | 'Response' | 'Comment' | 'Note' | 'PrivateComment' | 'CheckInPost';
   postId: number;
   currentUserLikeId: number | null;
   m?: number;

--- a/src/components/_common/post-footer/PostFooterLikeOnly.tsx
+++ b/src/components/_common/post-footer/PostFooterLikeOnly.tsx
@@ -1,0 +1,82 @@
+import { MouseEvent } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Layout, Typo } from '@design-system';
+import { Note, POST_DP_TYPE, POST_TYPE, Response } from '@models/post';
+import Icon from '../icon/Icon';
+import LikeButton from '../like-button/LikeButton';
+
+type PostFooterLikeOnlyProps = {
+  isMyPage: boolean;
+  post: Response | Note;
+  displayType?: POST_DP_TYPE;
+  showComments: () => void;
+  setInputFocus: () => void;
+  refresh?: () => void;
+};
+
+function PostFooterLikeOnly({
+  isMyPage,
+  post,
+  displayType = 'LIST',
+  showComments,
+  setInputFocus,
+  refresh,
+}: PostFooterLikeOnlyProps) {
+  const { comment_count, current_user_like_id } = post;
+  const [t] = useTranslation('translation', {
+    keyPrefix: post.type === POST_TYPE.RESPONSE ? 'responses' : 'notes',
+  });
+
+  const handleClickCommentText = (e: MouseEvent) => {
+    e.stopPropagation();
+    showComments();
+  };
+
+  const handleClickCommentIcon = (e: MouseEvent) => {
+    e.stopPropagation();
+    showComments();
+    setInputFocus();
+  };
+
+  return (
+    <Layout.FlexRow
+      gap={8}
+      w="100%"
+      style={{
+        position: displayType === 'DETAIL' ? 'relative' : undefined,
+        flexShrink: 0,
+        marginTop: 'auto',
+      }}
+      alignItems="center"
+    >
+      {!isMyPage && (
+        <LikeButton
+          postType={post.type === POST_TYPE.RESPONSE ? 'Response' : 'Note'}
+          postId={post.id}
+          currentUserLikeId={current_user_like_id}
+          iconSize={23}
+          refresh={refresh}
+        />
+      )}
+      {displayType === 'LIST' && (
+        <Layout.FlexRow w={48} h={48} alignItems="center" justifyContent="center">
+          <Icon name="add_comment" size={23} onClick={handleClickCommentIcon} />
+        </Layout.FlexRow>
+      )}
+      {!!comment_count && (
+        <Layout.FlexRow>
+          <button
+            type="button"
+            onClick={displayType === 'LIST' ? handleClickCommentText : undefined}
+          >
+            <Typo type="label-large" color="BLACK" underline>
+              {comment_count ?? 0} {t('comments')}
+            </Typo>
+          </button>
+        </Layout.FlexRow>
+      )}
+    </Layout.FlexRow>
+  );
+}
+
+export default PostFooterLikeOnly;

--- a/src/components/check-in-posts/CheckInPostStories.tsx
+++ b/src/components/check-in-posts/CheckInPostStories.tsx
@@ -49,9 +49,11 @@ function CheckInPostStories({ authorUserId, showCompose = false }: CheckInPostSt
         {showCompose && (
           <ComposeBubble onClick={() => navigate('/check-in-posts/new')}>
             <Plus>+</Plus>
-            <Typo type="label-small" color="DARK_GRAY">
-              {t('compose')}
-            </Typo>
+            <ComposeLabel>
+              <Typo type="label-large" color="DARK_GRAY">
+                {t('compose')}
+              </Typo>
+            </ComposeLabel>
           </ComposeBubble>
         )}
         {stories.map((story, idx) => (
@@ -107,7 +109,11 @@ const Bubble = styled.button`
 `;
 
 const ComposeBubble = styled(Bubble)`
-  width: 64px;
+  width: auto;
+`;
+
+const ComposeLabel = styled.span`
+  white-space: nowrap;
 `;
 
 const Plus = styled.span`

--- a/src/components/check-in-posts/CheckInPostStories.tsx
+++ b/src/components/check-in-posts/CheckInPostStories.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
+import ProfileImage from '@components/_common/profile-image/ProfileImage';
+import { Colors, Layout, Typo } from '@design-system';
+import { CheckInPostStory } from '@models/checkInPost';
+import { getCheckInPostStories, getUserCheckInPosts } from '@utils/apis/checkInPost';
+import CheckInPostViewer from './CheckInPostViewer';
+
+interface CheckInPostStoriesProps {
+  /** When provided, the strip lists only this user's posts (for friend's UserPage). */
+  authorUserId?: number;
+  showCompose?: boolean;
+}
+
+function CheckInPostStories({ authorUserId, showCompose = false }: CheckInPostStoriesProps) {
+  const [t] = useTranslation('translation', { keyPrefix: 'check_in_post' });
+  const navigate = useNavigate();
+
+  const [stories, setStories] = useState<CheckInPostStory[]>([]);
+  const [activeIndex, setActiveIndex] = useState<number | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const fetcher = authorUserId ? getUserCheckInPosts(authorUserId) : getCheckInPostStories();
+    fetcher
+      .then((data) => {
+        if (cancelled) return;
+        setStories(data.results ?? []);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setStories([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [authorUserId]);
+
+  const handleClickStory = (index: number) => () => setActiveIndex(index);
+  const handleClose = () => setActiveIndex(null);
+
+  if (!showCompose && stories.length === 0) return null;
+
+  return (
+    <>
+      <Strip>
+        {showCompose && (
+          <ComposeBubble onClick={() => navigate('/check-in-posts/new')}>
+            <Plus>+</Plus>
+            <Typo type="label-small" color="DARK_GRAY">
+              {t('compose')}
+            </Typo>
+          </ComposeBubble>
+        )}
+        {stories.map((story, idx) => (
+          <Bubble key={story.id} onClick={handleClickStory(idx)}>
+            <ProfileImage
+              imageUrl={story.author_detail.profile_image}
+              username={story.author_detail.username}
+              size={56}
+            />
+            <Typo type="label-small" color="BLACK" numberOfLines={1}>
+              {story.author_detail.username}
+            </Typo>
+          </Bubble>
+        ))}
+      </Strip>
+      {activeIndex !== null && stories[activeIndex] && (
+        <CheckInPostViewer
+          story={stories[activeIndex]}
+          onClose={handleClose}
+          onPrev={activeIndex > 0 ? () => setActiveIndex(activeIndex - 1) : undefined}
+          onNext={
+            activeIndex < stories.length - 1 ? () => setActiveIndex(activeIndex + 1) : undefined
+          }
+        />
+      )}
+    </>
+  );
+}
+
+const Strip = styled(Layout.FlexRow)`
+  width: 100%;
+  gap: 12px;
+  padding: 12px 16px;
+  overflow-x: auto;
+  background-color: ${Colors.WHITE};
+  border-bottom: 1px solid ${Colors.LIGHT};
+  &::-webkit-scrollbar {
+    display: none;
+  }
+`;
+
+const Bubble = styled.button`
+  background: none;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+  width: 64px;
+  padding: 0;
+`;
+
+const ComposeBubble = styled(Bubble)`
+  width: 64px;
+`;
+
+const Plus = styled.span`
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  border: 2px dashed ${Colors.MEDIUM_GRAY};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 28px;
+  color: ${Colors.DARK_GRAY};
+`;
+
+export default CheckInPostStories;

--- a/src/components/check-in-posts/CheckInPostViewer.tsx
+++ b/src/components/check-in-posts/CheckInPostViewer.tsx
@@ -1,0 +1,181 @@
+import { MouseEvent, useEffect, useState } from 'react';
+import styled from 'styled-components';
+import LikeButton from '@components/_common/like-button/LikeButton';
+import ProfileImage from '@components/_common/profile-image/ProfileImage';
+import { Z_INDEX } from '@constants/layout';
+import { Colors, Layout, Typo } from '@design-system';
+import { CheckInPost, CheckInPostStory } from '@models/checkInPost';
+import { getCheckInPost } from '@utils/apis/checkInPost';
+import { convertTimeDiffByString } from '@utils/timeHelpers';
+
+interface CheckInPostViewerProps {
+  story: CheckInPostStory;
+  onClose: () => void;
+  onPrev?: () => void;
+  onNext?: () => void;
+}
+
+function CheckInPostViewer({ story, onClose, onPrev, onNext }: CheckInPostViewerProps) {
+  const [post, setPost] = useState<CheckInPost | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setPost(null);
+    getCheckInPost(story.id)
+      .then((data) => {
+        if (!cancelled) setPost(data);
+      })
+      .catch(() => {
+        if (!cancelled) setPost(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [story.id]);
+
+  const handleBackdropClick = (e: MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) onClose();
+  };
+
+  const handleLeft = (e: MouseEvent) => {
+    e.stopPropagation();
+    onPrev?.();
+  };
+
+  const handleRight = (e: MouseEvent) => {
+    e.stopPropagation();
+    onNext?.();
+  };
+
+  return (
+    <Backdrop onClick={handleBackdropClick}>
+      <Card onClick={(e) => e.stopPropagation()}>
+        <Header>
+          <Layout.FlexRow alignItems="center" gap={8}>
+            <ProfileImage
+              imageUrl={story.author_detail.profile_image}
+              username={story.author_detail.username}
+              size={32}
+            />
+            <Typo type="label-large" color="WHITE" bold>
+              {story.author_detail.username}
+            </Typo>
+            <Typo type="label-small" color="LIGHT_GRAY">
+              {convertTimeDiffByString({ day: new Date(story.created_at) })}
+            </Typo>
+          </Layout.FlexRow>
+          <CloseBtn type="button" onClick={onClose}>
+            ×
+          </CloseBtn>
+        </Header>
+
+        {story.image_url && <StoryImage src={story.image_url} alt="check-in" />}
+
+        {post?.caption && (
+          <Caption>
+            <Typo type="body-medium" color="WHITE">
+              {post.caption}
+            </Typo>
+          </Caption>
+        )}
+
+        <Footer>
+          {post && (
+            <LikeButton
+              postType="CheckInPost"
+              postId={post.id}
+              currentUserLikeId={post.current_user_like_id}
+              iconSize={28}
+            />
+          )}
+        </Footer>
+
+        {onPrev && <NavZone $side="left" onClick={handleLeft} />}
+        {onNext && <NavZone $side="right" onClick={handleRight} />}
+      </Card>
+    </Backdrop>
+  );
+}
+
+const Backdrop = styled.div`
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.92);
+  z-index: ${Z_INDEX.COMMENT_LIKES_POPUP};
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const Card = styled.div`
+  position: relative;
+  width: 100%;
+  max-width: 480px;
+  height: 100%;
+  max-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: black;
+`;
+
+const Header = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  padding: 16px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  z-index: 2;
+  background: linear-gradient(to bottom, rgba(0, 0, 0, 0.7), transparent);
+`;
+
+const CloseBtn = styled.button`
+  background: none;
+  border: none;
+  color: ${Colors.WHITE};
+  font-size: 28px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 8px;
+`;
+
+const StoryImage = styled.img`
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+`;
+
+const Caption = styled.div`
+  position: absolute;
+  bottom: 80px;
+  left: 16px;
+  right: 16px;
+  text-align: center;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.7);
+`;
+
+const Footer = styled.div`
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 16px;
+  display: flex;
+  justify-content: flex-start;
+  z-index: 2;
+  background: linear-gradient(to top, rgba(0, 0, 0, 0.7), transparent);
+`;
+
+const NavZone = styled.div<{ $side: 'left' | 'right' }>`
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 25%;
+  ${({ $side }) => ($side === 'left' ? 'left: 0;' : 'right: 0;')}
+  cursor: pointer;
+  z-index: 1;
+`;
+
+export default CheckInPostViewer;

--- a/src/components/comment-list/comment-input-box/CommentInputBox.tsx
+++ b/src/components/comment-list/comment-input-box/CommentInputBox.tsx
@@ -123,7 +123,7 @@ function CommentInputBox({
       target_id: post.id,
       target_type: postType,
       content: content.trim(),
-      is_private: isPrivate,
+      is_private: featureFlags?.postsVerQ ? false : isPrivate,
     })
       .then(() => {
         setContent('');
@@ -174,7 +174,7 @@ function CommentInputBox({
       }}
     >
       {/* isPrivate */}
-      {featureFlags?.friendList && (
+      {featureFlags?.friendList && !featureFlags?.postsVerQ && (
         <Layout.FlexRow gap={4} alignItems="center">
           <CheckBox
             name={t('private_comment') || ''}

--- a/src/components/friends/friend-item-with-updates/FriendItemWithUpdates.tsx
+++ b/src/components/friends/friend-item-with-updates/FriendItemWithUpdates.tsx
@@ -8,6 +8,7 @@ import ProfileImage from '@components/_common/profile-image/ProfileImage';
 import CheckInDetailBottomSheet from '@components/check-in/check-in-detail-bottom-sheet/CheckInDetailBottomSheet';
 import FriendPinnedChip from '@components/friends/friend-pinned-chip/FriendPinnedChip';
 import PokeButton from '@components/friends/poke-button/PokeButton';
+import SubscriptionPopup from '@components/friends/subscription-popup/SubscriptionPopup';
 import SpotifyMusic from '@components/music/spotify-music/SpotifyMusic';
 import NoteItem from '@components/note/note-item/NoteItem';
 import EditConnectionsBottomSheet from '@components/profile/edit-connections/EditConnectionsBottomSheet';
@@ -15,7 +16,6 @@ import SocialBatteryChip from '@components/profile/social-batter-chip/SocialBatt
 import ResponseItem from '@components/response/response-item/ResponseItem';
 import { FeatureFlagKey } from '@constants/featureFlag';
 import { Layout, SvgIcon, Typo } from '@design-system';
-import { useCheckInSubscription } from '@hooks/useCheckInSubscription';
 import { Connection, UpdatedProfile } from '@models/api/friends';
 import { SocialBattery } from '@models/checkIn';
 import { Note, POST_TYPE, Response } from '@models/post';
@@ -56,18 +56,15 @@ function FriendItemWithUpdates({
 
   const navigate = useNavigate();
   const [t] = useTranslation('translation');
-  const { featureFlags } = useBoundStore(UserSelector);
-  const checkInEnabled = !!featureFlags?.[FeatureFlagKey.CHECK_IN];
+  const { featureFlags, myProfile } = useBoundStore(UserSelector);
+  const subscriptionPopupEnabled = !!featureFlags?.[FeatureFlagKey.SUBSCRIPTION_POPUP];
 
-  const { isSubscribed, toggle: toggleCheckInSubscription } = useCheckInSubscription({
-    userId: id,
-    initialSubscribed: user.is_check_in_subscribed,
-  });
-
-  const handleToggleSubscription = (e: MouseEvent) => {
+  const [showSubscriptionPopup, setShowSubscriptionPopup] = useState(false);
+  const handleOpenSubscriptionPopup = (e: MouseEvent) => {
     e.stopPropagation();
-    toggleCheckInSubscription();
+    setShowSubscriptionPopup(true);
   };
+  const handleCloseSubscriptionPopup = () => setShowSubscriptionPopup(false);
 
   const [isEditConnectionsBottomSheetVisible, setIsEditConnectionsBottomSheetVisible] =
     useState(false);
@@ -137,33 +134,31 @@ function FriendItemWithUpdates({
           </Layout.FlexRow>
         </Layout.FlexRow>
         <Layout.FlexRow style={{ position: 'relative' }} alignItems="center" gap={12}>
-          {checkInEnabled && tabMode !== 'unified' && (
-            <button
-              type="button"
-              onClick={handleToggleSubscription}
-              aria-label={
-                t(
-                  isSubscribed
-                    ? 'check_in_subscription.aria.unsubscribe'
-                    : 'check_in_subscription.aria.subscribe',
-                ) ?? ''
-              }
-              style={{
-                background: 'none',
-                border: 'none',
-                padding: 2,
-                fontSize: 18,
-                lineHeight: 1,
-                cursor: 'pointer',
-              }}
-            >
-              <EmojiItem
-                emojiString={isSubscribed ? '🔔' : '🔕'}
-                size={18}
-                bgColor="TRANSPARENT"
-                outline="TRANSPARENT"
+          {subscriptionPopupEnabled && tabMode !== 'unified' && (
+            <>
+              <button
+                type="button"
+                onClick={handleOpenSubscriptionPopup}
+                aria-label={t('check_in_subscription.aria.subscribe') ?? ''}
+                style={{
+                  background: 'none',
+                  border: 'none',
+                  padding: 2,
+                  fontSize: 18,
+                  lineHeight: 1,
+                  cursor: 'pointer',
+                }}
+              >
+                <EmojiItem emojiString="🔔" size={18} bgColor="TRANSPARENT" outline="TRANSPARENT" />
+              </button>
+              <SubscriptionPopup
+                isOpen={showSubscriptionPopup}
+                onClose={handleCloseSubscriptionPopup}
+                friendId={id}
+                username={username}
+                currentVersion={myProfile?.current_ver}
               />
-            </button>
+            </>
           )}
           <Layout.LayoutBase pb={2}>
             <Icon name="friend_item_chat" color="BLACK" size={20} onClick={handleClickChat} />

--- a/src/components/friends/select-close-friends-bottom-sheet/SelectCloseFriendsBottomSheet.tsx
+++ b/src/components/friends/select-close-friends-bottom-sheet/SelectCloseFriendsBottomSheet.tsx
@@ -11,6 +11,7 @@ import { CheckBox, Layout, Typo } from '@design-system';
 import useInfiniteFetchFriends from '@hooks/useInfiniteFetchFriends';
 import { Connection } from '@models/api/friends';
 import { useBoundStore } from '@stores/useBoundStore';
+import { UserSelector } from '@stores/user';
 import { changeConnection } from '@utils/apis/friends';
 import * as S from './SelectCloseFriendsBottomSheet.styled';
 
@@ -31,6 +32,7 @@ function SelectCloseFriendsBottomSheet({ visible, closeBottomSheet, onFriendAdde
   const [isUpdatePastPosts, setIsUpdatePastPosts] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const { openToast } = useBoundStore((state) => ({ openToast: state.openToast }));
+  const { featureFlags } = useBoundStore(UserSelector);
 
   // Reset state when bottom sheet closes
   useEffect(() => {
@@ -69,7 +71,7 @@ function SelectCloseFriendsBottomSheet({ visible, closeBottomSheet, onFriendAdde
     setIsSubmitting(true);
     changeConnection(selectedFriendId, {
       choice: Connection.CLOSE_FRIEND,
-      update_past_posts: isUpdatePastPosts,
+      update_past_posts: featureFlags?.postsVerQ ? true : isUpdatePastPosts,
     })
       .then(() => {
         setShowConfirmDialog(false);
@@ -169,13 +171,15 @@ function SelectCloseFriendsBottomSheet({ visible, closeBottomSheet, onFriendAdde
               <Typo type="title-large" mb={5}>
                 {t('add_to_close_friends')}
               </Typo>
-              <Layout.FlexRow mt={10} ml={20}>
-                <CheckBox
-                  name={tDialog('update_past_posts') || ''}
-                  onChange={() => setIsUpdatePastPosts((prev) => !prev)}
-                  checked={isUpdatePastPosts}
-                />
-              </Layout.FlexRow>
+              {!featureFlags?.postsVerQ && (
+                <Layout.FlexRow mt={10} ml={20}>
+                  <CheckBox
+                    name={tDialog('update_past_posts') || ''}
+                    onChange={() => setIsUpdatePastPosts((prev) => !prev)}
+                    checked={isUpdatePastPosts}
+                  />
+                </Layout.FlexRow>
+              )}
             </Layout.FlexCol>
             <ModalS.ButtonContainer w="100%" justifyContent="space-evenly">
               <ModalS.Button onClick={handleCancelConfirm} pv={11}>

--- a/src/components/friends/subscription-popup/SubscriptionPopup.tsx
+++ b/src/components/friends/subscription-popup/SubscriptionPopup.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import EditorPopup from '@components/check-in/update-quadrant/EditorPopup';
+import { CheckBox, Layout, Typo } from '@design-system';
+import { useSubscriptions } from '@hooks/useSubscriptions';
+import { VersionType } from '@models/api/user';
+import {
+  SubscriptionType,
+  VER_Q_SUBSCRIPTION_TYPES,
+  VER_W_SUBSCRIPTION_TYPES,
+} from '@models/subscription';
+
+interface SubscriptionPopupProps {
+  isOpen: boolean;
+  onClose: () => void;
+  friendId: number;
+  username?: string;
+  currentVersion?: VersionType | null;
+}
+
+function SubscriptionPopup({
+  isOpen,
+  onClose,
+  friendId,
+  username,
+  currentVersion,
+}: SubscriptionPopupProps) {
+  const [t] = useTranslation('translation', { keyPrefix: 'subscription_popup' });
+
+  const availableTypes =
+    currentVersion === VersionType.VER_Q ? VER_Q_SUBSCRIPTION_TYPES : VER_W_SUBSCRIPTION_TYPES;
+
+  const { types, save, isSaving } = useSubscriptions({ friendId, enabled: isOpen });
+  const [draft, setDraft] = useState<SubscriptionType[]>([]);
+
+  useEffect(() => {
+    if (isOpen) setDraft(types);
+  }, [isOpen, types]);
+
+  const toggleType = (type: SubscriptionType) => {
+    setDraft((prev) => (prev.includes(type) ? prev.filter((p) => p !== type) : [...prev, type]));
+  };
+
+  const handleShare = async () => {
+    if (isSaving) return;
+    await save(draft);
+    onClose();
+  };
+
+  const title = username ? t('title_with_user', { username }) : t('title');
+
+  return (
+    <EditorPopup isOpen={isOpen} onClose={onClose} onShare={handleShare} title={title}>
+      <Layout.FlexCol w="100%" gap={4} mb={12}>
+        <Typo type="body-medium" color="DARK_GRAY">
+          {t('description')}
+        </Typo>
+      </Layout.FlexCol>
+      <Layout.FlexCol w="100%" gap={12}>
+        {availableTypes.map((type) => (
+          <CheckBox
+            key={type}
+            name={t(`type.${type}`) || type}
+            checked={draft.includes(type)}
+            onChange={() => toggleType(type)}
+          />
+        ))}
+      </Layout.FlexCol>
+    </EditorPopup>
+  );
+}
+
+export default SubscriptionPopup;

--- a/src/components/friends/updated-friend-item/UpdatedFriendItemDefault.tsx
+++ b/src/components/friends/updated-friend-item/UpdatedFriendItemDefault.tsx
@@ -1,20 +1,31 @@
-import { MouseEvent } from 'react';
+import { MouseEvent, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Icon from '@components/_common/icon/Icon';
 import ProfileImage from '@components/_common/profile-image/ProfileImage';
 import FriendPinnedChip from '@components/friends/friend-pinned-chip/FriendPinnedChip';
+import UserMoreModal from '@components/user-page/UserMoreModal';
 import { Layout, Typo } from '@design-system';
 import { UpdatedProfile } from '@models/api/friends';
+import { UserProfile } from '@models/user';
 import { StyledProfileArea, StyledUpdatedFriendItem } from './UpdatedFriendItem.styled';
 
 interface Props {
   user: UpdatedProfile;
   isMyPage: boolean;
+  showMoreButton?: boolean;
+  onAfterUserMoreAction?: () => Promise<void>;
 }
 
-function UpdatedFriendItemDefault({ user, isMyPage }: Props) {
+function UpdatedFriendItemDefault({
+  user,
+  isMyPage,
+  showMoreButton,
+  onAfterUserMoreAction,
+}: Props) {
   const { id, profile_image, username, unread_chat_count, description } = user;
   const pinnedCount = user.pinned_count ?? 0;
+
+  const [showMoreModal, setShowMoreModal] = useState(false);
 
   const navigate = useNavigate();
   const handleClickProfile = () => {
@@ -24,6 +35,11 @@ function UpdatedFriendItemDefault({ user, isMyPage }: Props) {
   const handleClickChat = (e: MouseEvent) => {
     e.stopPropagation();
     navigate(`/users/${id}/chat`);
+  };
+
+  const handleClickMore = (e: MouseEvent) => {
+    e.stopPropagation();
+    setShowMoreModal(true);
   };
 
   return (
@@ -63,7 +79,7 @@ function UpdatedFriendItemDefault({ user, isMyPage }: Props) {
             style={{ position: 'relative' }}
             justifyContent="flex-end"
             alignItems="center"
-            gap={2}
+            gap={8}
           >
             <Layout.LayoutBase pb={2}>
               <Icon name="chat_send" size={22} onClick={handleClickChat} />
@@ -84,9 +100,18 @@ function UpdatedFriendItemDefault({ user, isMyPage }: Props) {
                 </Typo>
               </Layout.Absolute>
             )}
+            {showMoreButton && <Icon name="dots_menu" size={22} onClick={handleClickMore} />}
           </Layout.FlexRow>
         )}
       </StyledUpdatedFriendItem>
+      {showMoreButton && (
+        <UserMoreModal
+          isVisible={showMoreModal}
+          setIsVisible={setShowMoreModal}
+          user={user as unknown as UserProfile}
+          callback={onAfterUserMoreAction}
+        />
+      )}
     </Layout.FlexRow>
   );
 }

--- a/src/components/friends/updated-friend-item/UpdatedFriendItemDefault.tsx
+++ b/src/components/friends/updated-friend-item/UpdatedFriendItemDefault.tsx
@@ -7,6 +7,8 @@ import UserMoreModal from '@components/user-page/UserMoreModal';
 import { Layout, Typo } from '@design-system';
 import { UpdatedProfile } from '@models/api/friends';
 import { UserProfile } from '@models/user';
+import { useBoundStore } from '@stores/useBoundStore';
+import { UserSelector } from '@stores/user';
 import { StyledProfileArea, StyledUpdatedFriendItem } from './UpdatedFriendItem.styled';
 
 interface Props {
@@ -24,6 +26,9 @@ function UpdatedFriendItemDefault({
 }: Props) {
   const { id, profile_image, username, unread_chat_count, description } = user;
   const pinnedCount = user.pinned_count ?? 0;
+
+  const { featureFlags } = useBoundStore(UserSelector);
+  const isVerQ = !!featureFlags?.postsVerQ;
 
   const [showMoreModal, setShowMoreModal] = useState(false);
 
@@ -64,12 +69,14 @@ function UpdatedFriendItemDefault({
                   {description}
                 </Typo>
               )}
-              <Layout.FlexRow mt={4}>
-                <FriendPinnedChip
-                  pinnedCount={pinnedCount}
-                  to={`/users/${username}/check-in/pinned`}
-                />
-              </Layout.FlexRow>
+              {!isVerQ && (
+                <Layout.FlexRow mt={4}>
+                  <FriendPinnedChip
+                    pinnedCount={pinnedCount}
+                    to={`/users/${username}/check-in/pinned`}
+                  />
+                </Layout.FlexRow>
+              )}
             </Layout.FlexCol>
           </Layout.FlexRow>
         </StyledProfileArea>
@@ -82,7 +89,11 @@ function UpdatedFriendItemDefault({
             gap={8}
           >
             <Layout.LayoutBase pb={2}>
-              <Icon name="chat_send" size={22} onClick={handleClickChat} />
+              <Icon
+                name={isVerQ ? 'friend_item_chat' : 'chat_send'}
+                size={22}
+                onClick={handleClickChat}
+              />
             </Layout.LayoutBase>
             {unread_chat_count > 0 && (
               <Layout.Absolute

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -14,8 +14,6 @@ function Header() {
       // TODO: ver R에서 어떤 헤더로 보여줘야하지?
       // return <CommonHeader title={t('nav_tab.friends')} />;
       return <FriendHeader />;
-    case '/friends-q':
-      return <FriendHeader />;
     case '/feed':
       return <CommonHeader title={t('nav_tab.feed')} />;
     case '/discover':

--- a/src/components/note/new-note-content/NewNoteContent.tsx
+++ b/src/components/note/new-note-content/NewNoteContent.tsx
@@ -3,12 +3,13 @@ import { useTranslation } from 'react-i18next';
 import ProfileImage from '@components/_common/profile-image/ProfileImage';
 import VisibilityToggle from '@components/check-in/visibility-toggle/VisibilityToggle';
 import { DEFAULT_MARGIN } from '@constants/layout';
-import { Layout, SvgIcon, Typo } from '@design-system';
+import { CheckBox, Layout, SvgIcon, Typo } from '@design-system';
 import { useGetAppMessage, usePostAppMessage } from '@hooks/useAppMessage';
 import { FileSelectedData } from '@models/app';
 import { ComponentVisibility } from '@models/checkIn';
 import { NewNoteForm, PostVisibility } from '@models/post';
 import { useBoundStore } from '@stores/useBoundStore';
+import { UserSelector } from '@stores/user';
 import { CroppedImg, readFile } from '@utils/getCroppedImg';
 import { getMobileDeviceInfo } from '@utils/getUserAgent';
 import { processImageFromApp } from '@utils/imageHelpers';
@@ -34,6 +35,7 @@ function NewNoteContent({
   const [t] = useTranslation('translation');
   const { openToast } = useBoundStore((state) => ({ openToast: state.openToast }));
   const { myProfile } = useBoundStore((state) => ({ myProfile: state.myProfile }));
+  const { featureFlags } = useBoundStore(UserSelector);
 
   const [isEditVisible, setIsEditVisible] = useState(false);
   const [showPhotoUploadBottomSheet, setShowPhotoUploadBottomSheet] = useState(false);
@@ -208,13 +210,32 @@ function NewNoteContent({
           {/* Media button and visibility options */}
           <Layout.FlexRow w="100%" justifyContent="space-between" alignItems="center" mt={20}>
             <SvgIcon name="chat_media_image" size={24} onClick={onClickAdd} fill="DARK_GRAY" />
-            <VisibilityToggle
-              value={
-                (noteInfo.visibility[0] as unknown as ComponentVisibility) ||
-                ComponentVisibility.FRIENDS
-              }
-              onChange={(v) => handleChangeVisibility([v as unknown as PostVisibility])}
-            />
+            {featureFlags?.postsVerQ ? (
+              <Layout.FlexRow gap={6} alignItems="center">
+                <CheckBox
+                  name={t('notes.close_friends_only') || 'Close friends only'}
+                  checked={noteInfo.visibility[0] === PostVisibility.CLOSE_FRIENDS}
+                  onChange={() =>
+                    handleChangeVisibility([
+                      noteInfo.visibility[0] === PostVisibility.CLOSE_FRIENDS
+                        ? PostVisibility.FRIENDS
+                        : PostVisibility.CLOSE_FRIENDS,
+                    ])
+                  }
+                />
+                <Typo type="label-medium" color="DARK_GRAY">
+                  {t('notes.close_friends_only')}
+                </Typo>
+              </Layout.FlexRow>
+            ) : (
+              <VisibilityToggle
+                value={
+                  (noteInfo.visibility[0] as unknown as ComponentVisibility) ||
+                  ComponentVisibility.FRIENDS
+                }
+                onChange={(v) => handleChangeVisibility([v as unknown as PostVisibility])}
+              />
+            )}
           </Layout.FlexRow>
 
           <input

--- a/src/components/note/note-item/NoteItem.tsx
+++ b/src/components/note/note-item/NoteItem.tsx
@@ -7,6 +7,7 @@ import Icon from '@components/_common/icon/Icon';
 import LinkifiedText from '@components/_common/linkified-text/LinkifiedText';
 import PostFooter from '@components/_common/post-footer/PostFooter';
 import PostFooterDefault from '@components/_common/post-footer/PostFooterDefault';
+import PostFooterLikeOnly from '@components/_common/post-footer/PostFooterLikeOnly';
 import PostMoreModal from '@components/_common/post-more-modal/PostMoreModal';
 import ProfileImage from '@components/_common/profile-image/ProfileImage';
 import CommentBottomSheet from '@components/comments/comment-bottom-sheet/CommentBottomSheet';
@@ -133,25 +134,26 @@ function NoteItem({
                       </Typo>
                     </>
                   )}
-                  {(author_detail.mutual_interest_count ?? 0) +
-                    (author_detail.mutual_persona_count ?? 0) >
-                    0 && (
-                    <>
-                      <Typo type="label-medium" color="MEDIUM_GRAY">
-                        ·
-                      </Typo>
-                      <Typo type="label-medium" color="DARK_GRAY">
-                        {(author_detail.mutual_interest_count ?? 0) +
-                          (author_detail.mutual_persona_count ?? 0)}{' '}
-                        shared{' '}
-                        {(author_detail.mutual_interest_count ?? 0) +
-                          (author_detail.mutual_persona_count ?? 0) ===
-                        1
-                          ? 'trait'
-                          : 'traits'}
-                      </Typo>
-                    </>
-                  )}
+                  {!featureFlags?.postsVerQ &&
+                    (author_detail.mutual_interest_count ?? 0) +
+                      (author_detail.mutual_persona_count ?? 0) >
+                      0 && (
+                      <>
+                        <Typo type="label-medium" color="MEDIUM_GRAY">
+                          ·
+                        </Typo>
+                        <Typo type="label-medium" color="DARK_GRAY">
+                          {(author_detail.mutual_interest_count ?? 0) +
+                            (author_detail.mutual_persona_count ?? 0)}{' '}
+                          shared{' '}
+                          {(author_detail.mutual_interest_count ?? 0) +
+                            (author_detail.mutual_persona_count ?? 0) ===
+                          1
+                            ? 'trait'
+                            : 'traits'}
+                        </Typo>
+                      </>
+                    )}
                 </>
               )}
           </Layout.FlexRow>
@@ -222,7 +224,16 @@ function NoteItem({
     </Layout.FlexCol>
   );
 
-  const footerJsx = featureFlags?.friendList ? (
+  const footerJsx = featureFlags?.postsVerQ ? (
+    <PostFooterLikeOnly
+      isMyPage={isMyPage}
+      post={note}
+      showComments={() => setBottomSheet(true)}
+      setInputFocus={() => setInputFocus(true)}
+      displayType={displayType}
+      refresh={refresh}
+    />
+  ) : featureFlags?.friendList ? (
     <PostFooter
       isMyPage={isMyPage}
       post={note}

--- a/src/components/profile/Profile.tsx
+++ b/src/components/profile/Profile.tsx
@@ -4,15 +4,15 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { useShallow } from 'zustand/react/shallow';
 import FriendStatus from '@components/_common/friend-status/FriendStatus';
 import ProfileImage from '@components/_common/profile-image/ProfileImage';
+import SubscriptionPopup from '@components/friends/subscription-popup/SubscriptionPopup';
 import EditConnectionsBottomSheet from '@components/profile/edit-connections/EditConnectionsBottomSheet';
 import { UserPageContext } from '@components/user-page/UserPage.context';
 import { FeatureFlagKey } from '@constants/featureFlag';
 import { Layout, SvgIcon, Typo } from '@design-system';
 import useAsyncEffect from '@hooks/useAsyncEffect';
-import { useCheckInSubscription } from '@hooks/useCheckInSubscription';
 import { useChipCategories } from '@hooks/useChipCategories';
 import { Connection } from '@models/api/friends';
-import { MyProfile, VersionType } from '@models/api/user';
+import { MyProfile } from '@models/api/user';
 import { normalizeChipText } from '@models/chips';
 import { areFriends, isMyProfile, UserProfile } from '@models/user';
 import { useBoundStore } from '@stores/useBoundStore';
@@ -39,25 +39,23 @@ function Profile({ user }: ProfileProps) {
   const { featureFlags, myProfile } = useBoundStore(useShallow(UserSelector));
   const isMyPage = user?.id === myProfile?.id;
   const [friendData, setFriendData] = useState<UserProfile | null>(null);
-  const checkInEnabled = !!featureFlags?.[FeatureFlagKey.CHECK_IN];
-  const subscriptionBellEnabled = checkInEnabled && myProfile?.current_ver !== VersionType.VER_Q;
+  const subscriptionBellEnabled = !!featureFlags?.[FeatureFlagKey.SUBSCRIPTION_POPUP];
   const isFriendUser = !!user && !isMyProfile(user) && areFriends(user);
+  const [showSubscriptionPopup, setShowSubscriptionPopup] = useState(false);
 
   const { updateUser } = useContext(UserPageContext);
-  const { isSubscribed, toggle: toggleCheckInSubscription } = useCheckInSubscription({
-    userId: isFriendUser ? user.id : undefined,
-    initialSubscribed: isFriendUser ? user.is_check_in_subscribed : undefined,
-    onChange: () => {
-      updateUser();
-    },
-  });
 
   const { username } = useParams();
   const navigate = useNavigate();
 
-  const handleToggleSubscription = (e: MouseEvent) => {
+  const handleOpenSubscriptionPopup = (e: MouseEvent) => {
     e.stopPropagation();
-    toggleCheckInSubscription();
+    setShowSubscriptionPopup(true);
+  };
+
+  const handleCloseSubscriptionPopup = () => {
+    setShowSubscriptionPopup(false);
+    updateUser?.();
   };
 
   const handleClickEditProfile = (e: MouseEvent) => {
@@ -124,12 +122,15 @@ function Profile({ user }: ProfileProps) {
                         {friendData.pronouns}
                       </Typo>
                     )}
-                    {showPronouns && friendData?.pronouns && friendData?.connection_degree && (
-                      <Typo type="label-medium" color="MEDIUM_GRAY">
-                        |
-                      </Typo>
-                    )}
-                    {friendData?.connection_degree && (
+                    {showPronouns &&
+                      friendData?.pronouns &&
+                      friendData?.connection_degree &&
+                      !featureFlags?.postsVerQ && (
+                        <Typo type="label-medium" color="MEDIUM_GRAY">
+                          |
+                        </Typo>
+                      )}
+                    {friendData?.connection_degree && !featureFlags?.postsVerQ && (
                       <Typo type="label-medium" color="DARK_GRAY">
                         {friendData.connection_degree === 2
                           ? '2nd degree connection'
@@ -153,18 +154,11 @@ function Profile({ user }: ProfileProps) {
                       onClick={handleClickChangeConnection}
                     />
                   )}
-                  {subscriptionBellEnabled && (
+                  {subscriptionBellEnabled && isFriendUser && (
                     <button
                       type="button"
-                      onClick={handleToggleSubscription}
-                      aria-label={
-                        t(
-                          isSubscribed
-                            ? 'check_in_subscription.aria.unsubscribe'
-                            : 'check_in_subscription.aria.subscribe',
-                          { defaultValue: '' },
-                        ) ?? ''
-                      }
+                      onClick={handleOpenSubscriptionPopup}
+                      aria-label={t('check_in_subscription.aria.subscribe') ?? ''}
                       style={{
                         background: 'none',
                         border: 'none',
@@ -174,8 +168,17 @@ function Profile({ user }: ProfileProps) {
                         cursor: 'pointer',
                       }}
                     >
-                      {isSubscribed ? '🔔' : '🔕'}
+                      🔔
                     </button>
+                  )}
+                  {subscriptionBellEnabled && isFriendUser && (
+                    <SubscriptionPopup
+                      isOpen={showSubscriptionPopup}
+                      onClose={handleCloseSubscriptionPopup}
+                      friendId={user.id}
+                      username={user.username}
+                      currentVersion={myProfile?.current_ver}
+                    />
                   )}
                   {showEditConnectionsModal && (
                     <EditConnectionsBottomSheet
@@ -241,10 +244,13 @@ function Profile({ user }: ProfileProps) {
           )}
 
           {/* interests placeholder (my page only, when user has no interests) */}
-          {isMyPage && (myProfile?.user_interests ?? []).length === 0 && <InterestPlaceholder />}
+          {!featureFlags?.postsVerQ &&
+            isMyPage &&
+            (myProfile?.user_interests ?? []).length === 0 && <InterestPlaceholder />}
 
           {/* See more details */}
-          {featureFlags?.persona &&
+          {!featureFlags?.postsVerQ &&
+            featureFlags?.persona &&
             (isMyPage || (user && areFriends(user))) &&
             hasInterestsOrPersonas && (
               <Layout.FlexRow onClick={() => setShowMoreAbout(true)} style={{ cursor: 'pointer' }}>
@@ -275,7 +281,8 @@ function Profile({ user }: ProfileProps) {
           )}
           <MutualFriendsInfo mutualFriends={(user as UserProfile).mutuals} />
           {/* Mutual traits for non-friend users (from discover context) */}
-          {!isMyProfile(user) &&
+          {!featureFlags?.postsVerQ &&
+            !isMyProfile(user) &&
             !areFriends(user) &&
             friendData &&
             ((friendData.mutual_interests && friendData.mutual_interests.length > 0) ||

--- a/src/components/profile/edit-connections/EditConnectionsBottomSheet.tsx
+++ b/src/components/profile/edit-connections/EditConnectionsBottomSheet.tsx
@@ -48,7 +48,7 @@ function EditConnectionsBottomSheet({
   const handleClickEdit = () => {
     changeConnection(user.id, {
       choice: connection,
-      update_past_posts: isUpdatePastPosts,
+      update_past_posts: featureFlags?.postsVerQ ? true : isUpdatePastPosts,
     })
       .then(() => {
         closeBottomSheet();
@@ -96,8 +96,8 @@ function EditConnectionsBottomSheet({
                 checked={connection === Connection.CLOSE_FRIEND}
                 onChange={handleChangeConnection}
               />
-              {/* ver. Q 에서만 update_past_posts 체크박스 노출 */}
-              {featureFlags?.friendList && (
+              {/* update_past_posts 체크박스: VER_W (friendList) 일 때만 노출, VER_Q 는 항상 true 강제 */}
+              {featureFlags?.friendList && !featureFlags?.postsVerQ && (
                 <Layout.FlexRow ml={30}>
                   <CheckBox
                     name={t('edit_connections.check_box') || ''}

--- a/src/components/response/response-item/ResponseItem.tsx
+++ b/src/components/response/response-item/ResponseItem.tsx
@@ -141,25 +141,26 @@ function ResponseItem({
                       </Typo>
                     </>
                   )}
-                  {(author_detail.mutual_interest_count ?? 0) +
-                    (author_detail.mutual_persona_count ?? 0) >
-                    0 && (
-                    <>
-                      <Typo type="label-medium" color="MEDIUM_GRAY">
-                        ·
-                      </Typo>
-                      <Typo type="label-medium" color="DARK_GRAY">
-                        {(author_detail.mutual_interest_count ?? 0) +
-                          (author_detail.mutual_persona_count ?? 0)}{' '}
-                        shared{' '}
-                        {(author_detail.mutual_interest_count ?? 0) +
-                          (author_detail.mutual_persona_count ?? 0) ===
-                        1
-                          ? 'trait'
-                          : 'traits'}
-                      </Typo>
-                    </>
-                  )}
+                  {!featureFlags?.postsVerQ &&
+                    (author_detail.mutual_interest_count ?? 0) +
+                      (author_detail.mutual_persona_count ?? 0) >
+                      0 && (
+                      <>
+                        <Typo type="label-medium" color="MEDIUM_GRAY">
+                          ·
+                        </Typo>
+                        <Typo type="label-medium" color="DARK_GRAY">
+                          {(author_detail.mutual_interest_count ?? 0) +
+                            (author_detail.mutual_persona_count ?? 0)}{' '}
+                          shared{' '}
+                          {(author_detail.mutual_interest_count ?? 0) +
+                            (author_detail.mutual_persona_count ?? 0) ===
+                          1
+                            ? 'trait'
+                            : 'traits'}
+                        </Typo>
+                      </>
+                    )}
                 </>
               )}
           </Layout.FlexRow>

--- a/src/components/response/response-item/ResponseItem.tsx
+++ b/src/components/response/response-item/ResponseItem.tsx
@@ -6,6 +6,7 @@ import ContentTranslation from '@components/_common/content-translation/ContentT
 import Icon from '@components/_common/icon/Icon';
 import LinkifiedText from '@components/_common/linkified-text/LinkifiedText';
 import PostFooter from '@components/_common/post-footer/PostFooter';
+import PostFooterLikeOnly from '@components/_common/post-footer/PostFooterLikeOnly';
 import PostMoreModal from '@components/_common/post-more-modal/PostMoreModal';
 import ProfileImage from '@components/_common/profile-image/ProfileImage';
 import CommentBottomSheet from '@components/comments/comment-bottom-sheet/CommentBottomSheet';
@@ -13,6 +14,7 @@ import { SCREEN_WIDTH } from '@constants/layout';
 import { Layout, SvgIcon, Typo } from '@design-system';
 import { POST_DP_TYPE, Response } from '@models/post';
 import { useBoundStore } from '@stores/useBoundStore';
+import { UserSelector } from '@stores/user';
 import { convertTimeDiffByString } from '@utils/timeHelpers';
 import QuestionItem from '../question-item/QuestionItem';
 
@@ -47,6 +49,7 @@ function ResponseItem({
     emojiPickerTarget: state.emojiPickerTarget,
     setEmojiPickerTarget: state.setEmojiPickerTarget,
   }));
+  const { featureFlags } = useBoundStore(UserSelector);
 
   const navigate = useNavigate();
 
@@ -229,7 +232,16 @@ function ResponseItem({
 
   const questionJsx = question ? <QuestionItem question={question} /> : null;
 
-  const footerJsx = (
+  const footerJsx = featureFlags?.postsVerQ ? (
+    <PostFooterLikeOnly
+      isMyPage={isMyPage}
+      post={response}
+      showComments={() => setBottomSheet(true)}
+      setInputFocus={() => setInputFocus(true)}
+      displayType={displayType}
+      refresh={refresh}
+    />
+  ) : (
     <PostFooter
       isMyPage={isMyPage}
       post={response}

--- a/src/components/tab/Tab.tsx
+++ b/src/components/tab/Tab.tsx
@@ -71,6 +71,20 @@ function TabItem({ to, type, size = 48, end = false }: TabItemProps) {
 export default function Tab() {
   const { featureFlags } = useBoundStore(UserSelector);
 
+  if (featureFlags?.checkInPosts) {
+    return (
+      <TabWrapper>
+        <Layout.FlexRow w="100%" justifyContent="space-evenly" alignItems="center" pt={4}>
+          <TabItem to="/feed" type="feed" size={28} />
+          <TabItem to="/share" type="share" size={28} />
+          <TabItem to="/discover" type="discover" size={28} />
+          <TabItem to="/chats" type="chats" size={28} />
+          <TabItem to="/my" type="my" size={28} />
+        </Layout.FlexRow>
+      </TabWrapper>
+    );
+  }
+
   return (
     <TabWrapper>
       <Layout.FlexRow w="100%" h="100%" justifyContent="space-evenly" alignItems="center">
@@ -81,8 +95,6 @@ export default function Tab() {
             <TabItem to="/share" type="share" size={28} />
             <TabItem to="/discover" type="discover" size={28} />
           </>
-        ) : featureFlags?.friendUpdatesTab ? (
-          <TabItem to="/friends-q" type="friends" size={28} />
         ) : featureFlags?.friendFeed ? (
           <TabItem to="/feed" type="friends" size={28} />
         ) : null}

--- a/src/components/version-guard/VersionGuard.tsx
+++ b/src/components/version-guard/VersionGuard.tsx
@@ -29,11 +29,7 @@ function VersionGuard({ allowedVersions, children }: Props) {
 
   if (!isAllowed) {
     const home =
-      currentVer === VersionType.VER_Q
-        ? '/friends-q'
-        : featureFlags?.friendList
-        ? '/friends'
-        : '/feed';
+      currentVer === VersionType.VER_Q ? '/feed' : featureFlags?.friendList ? '/friends' : '/feed';
     return <Navigate to={home} replace />;
   }
   return children;

--- a/src/constants/featureFlag.ts
+++ b/src/constants/featureFlag.ts
@@ -25,6 +25,16 @@ export enum FeatureFlagKey {
   FRIEND_UPDATES_TAB = 'friendUpdatesTab',
   /** 하단 Questions 탭 노출 (QUESTION_RESPONSE_FEATURE 와 별개 — 전자는 탭 가시성, 후자는 피처 전반) */
   QUESTIONS_TAB = 'questionsTab',
+  /** version_q 게시글 단순화: 비밀댓글/이모지 리액션 숨김, visibility close-only 단일 체크박스, update_past_posts 항상 true */
+  POSTS_VER_Q = 'postsVerQ',
+  /** version_q 신규 image+text 체크인 + stories 가로 스크롤 */
+  CHECK_IN_POSTS = 'checkInPosts',
+  /** 하단 nav 에 My 탭 노출 (version_q 전용) */
+  MY_TAB_VISIBLE = 'myTabVisible',
+  /** 하단 nav 에 Share 탭 노출 + version_q 용 placeholder */
+  SHARE_TAB_VISIBLE = 'shareTabVisible',
+  /** 종 아이콘을 multi-checkbox 구독 popup 으로 (양 버전 공통) */
+  SUBSCRIPTION_POPUP = 'subscriptionPopup',
 }
 
 export type FeatureFlagMap = { [feature in FeatureFlagKey]: boolean };
@@ -46,6 +56,11 @@ const DEFAULT_FLAGS = {
   [FeatureFlagKey.CHAT_TAB]: false,
   [FeatureFlagKey.FRIEND_UPDATES_TAB]: false,
   [FeatureFlagKey.QUESTIONS_TAB]: false,
+  [FeatureFlagKey.POSTS_VER_Q]: false,
+  [FeatureFlagKey.CHECK_IN_POSTS]: false,
+  [FeatureFlagKey.MY_TAB_VISIBLE]: false,
+  [FeatureFlagKey.SHARE_TAB_VISIBLE]: false,
+  [FeatureFlagKey.SUBSCRIPTION_POPUP]: false,
 };
 
 export const FEATURE_FLAG_MAP_COLLECTION: FeatureFlagMapCollection = {
@@ -53,11 +68,15 @@ export const FEATURE_FLAG_MAP_COLLECTION: FeatureFlagMapCollection = {
   [VersionType.VER_Q]: {
     ...DEFAULT_FLAGS,
     [FeatureFlagKey.FRIEND_FEED]: false,
-    [FeatureFlagKey.FRIEND_UPDATES_TAB]: true,
-    [FeatureFlagKey.QUESTIONS_TAB]: true,
     [FeatureFlagKey.CHAT_TAB]: true,
     [FeatureFlagKey.QUESTION_RESPONSE_FEATURE]: true,
-    [FeatureFlagKey.CHECK_IN]: true,
+    [FeatureFlagKey.DISCOVER]: true,
+    [FeatureFlagKey.POSTS_VER_Q]: true,
+    [FeatureFlagKey.CHECK_IN_POSTS]: true,
+    [FeatureFlagKey.MY_TAB_VISIBLE]: true,
+    [FeatureFlagKey.SHARE_TAB_VISIBLE]: true,
+    [FeatureFlagKey.SUBSCRIPTION_POPUP]: true,
+    [FeatureFlagKey.POST_VISIBILITY_DEFAULT_CLOSE_FRIEND]: true,
   },
   // Ver. W
   [VersionType.VER_W]: {
@@ -71,6 +90,8 @@ export const FEATURE_FLAG_MAP_COLLECTION: FeatureFlagMapCollection = {
     [FeatureFlagKey.PERSONA]: true,
     [FeatureFlagKey.POST_VISIBILITY_DEFAULT_CLOSE_FRIEND]: true,
     [FeatureFlagKey.DISCOVER]: true,
+    [FeatureFlagKey.SHARE_TAB_VISIBLE]: true,
     [FeatureFlagKey.CHAT_TAB]: true,
+    [FeatureFlagKey.SUBSCRIPTION_POPUP]: true,
   },
 };

--- a/src/constants/url.ts
+++ b/src/constants/url.ts
@@ -12,9 +12,8 @@ export const LEARN_MORE_ABOUT_WHOAMI_TODAY_NOTION_URL =
 export const FRIEND_DEFAULT_REDIRECTION_PATH = '/friends';
 
 // Ver.Q redirection path
-export const FRIENDS_Q_DEFAULT_REDIRECTION_PATH = '/friends-q';
+export const FRIENDS_Q_DEFAULT_REDIRECTION_PATH = '/feed';
 
-// @deprecated - legacy /feed route; use FRIENDS_Q_DEFAULT_REDIRECTION_PATH
 export const FEED_DEFAULT_REDIRECTION_PATH = '/feed';
 
 export const AFTER_SIGNUP_PATH = '/my';

--- a/src/hooks/useSubscriptions.ts
+++ b/src/hooks/useSubscriptions.ts
@@ -1,0 +1,60 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { SubscriptionType } from '@models/subscription';
+import { useBoundStore } from '@stores/useBoundStore';
+import { getSubscriptions, updateSubscriptions } from '@utils/apis/subscription';
+
+interface UseSubscriptionsParams {
+  friendId?: number;
+  enabled?: boolean;
+}
+
+export function useSubscriptions({ friendId, enabled = true }: UseSubscriptionsParams) {
+  const [t] = useTranslation('translation', { keyPrefix: 'check_in_subscription.toast' });
+  const { openToast } = useBoundStore((state) => ({ openToast: state.openToast }));
+
+  const [types, setTypes] = useState<SubscriptionType[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    if (!friendId || !enabled) return;
+    let cancelled = false;
+    setIsLoading(true);
+    getSubscriptions(friendId)
+      .then((next) => {
+        if (!cancelled) setTypes(next);
+      })
+      .catch(() => {
+        if (!cancelled) setTypes([]);
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [friendId, enabled]);
+
+  const save = useCallback(
+    async (nextTypes: SubscriptionType[]) => {
+      if (!friendId || isSaving) return;
+      const previous = types;
+      setIsSaving(true);
+      setTypes(nextTypes);
+      try {
+        const saved = await updateSubscriptions(friendId, nextTypes);
+        setTypes(saved);
+        openToast({ message: t(nextTypes.length > 0 ? 'subscribed' : 'unsubscribed') });
+      } catch (e) {
+        setTypes(previous);
+        openToast({ message: t('error') });
+      } finally {
+        setIsSaving(false);
+      }
+    },
+    [friendId, isSaving, types, openToast, t],
+  );
+
+  return { types, isLoading, isSaving, save };
+}

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -10,6 +10,29 @@
             "unsubscribe": "Unsubscribe from check-in updates"
         }
     },
+    "check_in_post": {
+        "new_title": "New check-in",
+        "add_image": "Add a photo",
+        "stories_title": "Recent check-ins",
+        "no_stories": "No check-ins yet",
+        "compose": "Share a check-in"
+    },
+    "subscription_popup": {
+        "title": "Notify me about",
+        "title_with_user": "Notify me about {{username}}'s",
+        "description": "Choose which updates you'd like to be notified about.",
+        "type": {
+            "battery": "Social battery",
+            "mood": "Mood",
+            "thought": "Random thought",
+            "song": "Song",
+            "mission_of_the_day": "Mission of the day",
+            "question_of_the_day": "Question of the day",
+            "photo_of_the_day": "Photo of the day",
+            "check_in": "Check-ins",
+            "post": "Posts"
+        }
+    },
     "friend": {
         "hide": "Hide",
         "unfriend": "Unfriend",
@@ -336,6 +359,7 @@
         "confirm": "Confirm",
         "friend": "Friends",
         "close_friend": "Close Friends Only",
+        "close_friends_only": "Close friends only",
         "photo_upload_bottom_sheet": {
             "title": "Photo Upload",
             "album": "Select from Album",

--- a/src/i18n/locales/ko/translation.json
+++ b/src/i18n/locales/ko/translation.json
@@ -1,4 +1,27 @@
 {
+  "check_in_post": {
+    "new_title": "새 체크인",
+    "add_image": "사진 추가",
+    "stories_title": "최근 체크인",
+    "no_stories": "아직 체크인이 없어요",
+    "compose": "체크인 공유"
+  },
+  "subscription_popup": {
+    "title": "알림 받기",
+    "title_with_user": "{{username}}님의 업데이트 알림",
+    "description": "어떤 업데이트의 알림을 받을지 선택하세요.",
+    "type": {
+      "battery": "소셜 배터리",
+      "mood": "기분",
+      "thought": "오늘의 생각",
+      "song": "노래",
+      "mission_of_the_day": "오늘의 미션",
+      "question_of_the_day": "오늘의 질문",
+      "photo_of_the_day": "오늘의 사진",
+      "check_in": "체크인",
+      "post": "게시글"
+    }
+  },
   "check_in_subscription": {
     "toast": {
       "subscribed": "구독했어요",
@@ -333,6 +356,7 @@
     "confirm": "확인",
     "friend": "친구",
     "close_friend": "친한 친구",
+    "close_friends_only": "친한 친구에게만 공개",
     "photo_upload_bottom_sheet": {
       "title": "사진 업로드",
       "album": "앨범에서 선택",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -30,6 +30,7 @@ import AllQuestions from './routes/AllQuestions';
 // Chats tab now uses ChatList directly
 import Archive from './routes/check-in/Archive';
 import CheckInEdit from './routes/check-in/CheckInEdit';
+import NewCheckInPost from './routes/check-in-posts/NewCheckInPost';
 import Discover from './routes/discover/Discover';
 import EmailVerificationComplete from './routes/EmailVerificationComplete';
 import ForgotPassword from './routes/ForgotPassword';
@@ -41,7 +42,6 @@ import FriendNewPosts from './routes/friends/FriendNewPosts';
 import FriendPinnedFeed from './routes/friends/FriendPinnedFeed';
 import FriendsFeed from './routes/friends/FriendsFeed';
 import FriendsList from './routes/friends/FriendsList';
-import FriendsUpdates from './routes/friends/FriendsUpdates';
 import Intro from './routes/Intro';
 import Likes from './routes/Likes';
 import My from './routes/My';
@@ -137,16 +137,12 @@ const router = createBrowserRouter([
       },
       {
         path: 'friends-q',
-        element: (
-          <VersionGuard allowedVersions={[VersionType.VER_Q]}>
-            <FriendsUpdates />
-          </VersionGuard>
-        ),
+        element: <Navigate to="/feed" replace />,
       },
       {
         path: 'discover',
         element: (
-          <VersionGuard allowedVersions={[VersionType.VER_W]}>
+          <VersionGuard allowedVersions={[VersionType.VER_W, VersionType.VER_Q]}>
             <Discover />
           </VersionGuard>
         ),
@@ -160,9 +156,17 @@ const router = createBrowserRouter([
         ),
       },
       {
+        path: 'check-in-posts/new',
+        element: (
+          <VersionGuard allowedVersions={[VersionType.VER_Q]}>
+            <NewCheckInPost />
+          </VersionGuard>
+        ),
+      },
+      {
         path: 'share',
         element: (
-          <VersionGuard allowedVersions={[VersionType.VER_W]}>
+          <VersionGuard allowedVersions={[VersionType.VER_W, VersionType.VER_Q]}>
             <Outlet />
           </VersionGuard>
         ),

--- a/src/models/api/common.ts
+++ b/src/models/api/common.ts
@@ -20,7 +20,7 @@ export interface DateRequestParams {
 }
 
 export interface CommonTarget {
-  target_type: 'Moment' | 'Response' | 'Comment' | 'Note' | 'PrivateComment';
+  target_type: 'Moment' | 'Response' | 'Comment' | 'Note' | 'PrivateComment' | 'CheckInPost';
   target_id: number;
 }
 

--- a/src/models/checkInPost.ts
+++ b/src/models/checkInPost.ts
@@ -1,0 +1,31 @@
+import { User } from '@models/user';
+import { CroppedImg } from '@utils/getCroppedImg';
+
+export type CheckInPostVisibility = 'friends' | 'close_friends';
+
+export interface CheckInPost {
+  id: number;
+  type: 'CheckInPost';
+  author_detail: User;
+  image_url: string | null;
+  caption: string;
+  visibility: CheckInPostVisibility;
+  created_at: string;
+  like_count: number | null;
+  current_user_like_id: number | null;
+  current_user_read?: boolean;
+}
+
+export interface CheckInPostStory {
+  id: number;
+  author_detail: User;
+  image_url: string | null;
+  visibility: CheckInPostVisibility;
+  created_at: string;
+}
+
+export interface NewCheckInPostForm {
+  image: CroppedImg | null;
+  caption: string;
+  closeFriendsOnly: boolean;
+}

--- a/src/models/subscription.ts
+++ b/src/models/subscription.ts
@@ -1,0 +1,28 @@
+export enum SubscriptionType {
+  // Ver. W
+  BATTERY = 'battery',
+  MOOD = 'mood',
+  THOUGHT = 'thought',
+  SONG = 'song',
+  MISSION_OF_THE_DAY = 'mission_of_the_day',
+  QUESTION_OF_THE_DAY = 'question_of_the_day',
+  PHOTO_OF_THE_DAY = 'photo_of_the_day',
+  // Ver. Q
+  CHECK_IN = 'check_in',
+  POST = 'post',
+}
+
+export const VER_W_SUBSCRIPTION_TYPES: SubscriptionType[] = [
+  SubscriptionType.BATTERY,
+  SubscriptionType.MOOD,
+  SubscriptionType.THOUGHT,
+  SubscriptionType.SONG,
+  SubscriptionType.MISSION_OF_THE_DAY,
+  SubscriptionType.QUESTION_OF_THE_DAY,
+  SubscriptionType.PHOTO_OF_THE_DAY,
+];
+
+export const VER_Q_SUBSCRIPTION_TYPES: SubscriptionType[] = [
+  SubscriptionType.CHECK_IN,
+  SubscriptionType.POST,
+];

--- a/src/routes/Intro.tsx
+++ b/src/routes/Intro.tsx
@@ -16,7 +16,7 @@ function Intro() {
   if (data) {
     // Use current_ver from data or myProfile to determine redirect path
     const currentVer = data.current_ver || myProfile?.current_ver;
-    const targetPath = currentVer === VersionType.VER_Q ? '/friends-q' : '/friends';
+    const targetPath = currentVer === VersionType.VER_Q ? '/feed' : '/friends';
     return <Navigate to={targetPath} replace />;
   }
   return (

--- a/src/routes/My.tsx
+++ b/src/routes/My.tsx
@@ -1,4 +1,6 @@
 import { useCallback, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
 import { mutate } from 'swr';
 import { useShallow } from 'zustand/react/shallow';
 import Divider from '@components/_common/divider/Divider';
@@ -7,7 +9,7 @@ import { FLOATING_BUTTON_SIZE } from '@components/header/floating-button/Floatin
 import NoteSection from '@components/note/note-section/NoteSection';
 import AllPostSection from '@components/post/AllPostSection';
 import Profile from '@components/profile/Profile';
-import { Layout } from '@design-system';
+import { Layout, SvgIcon, Typo } from '@design-system';
 import { useRestoreScrollPosition } from '@hooks/useRestoreScrollPosition';
 import { useBoundStore } from '@stores/useBoundStore';
 import { UserSelector } from '@stores/user';
@@ -15,6 +17,8 @@ import { getMe, getMyProfile } from '@utils/apis/my';
 import { MainScrollContainer } from './Root';
 
 function My() {
+  const [t] = useTranslation('translation');
+  const navigate = useNavigate();
   const { myProfile, fetchCheckIn } = useBoundStore(
     useShallow((state) => ({
       myProfile: state.myProfile,
@@ -54,6 +58,27 @@ function My() {
           >
             <Profile user={myProfile} />
           </Layout.FlexRow>
+          {featureFlags?.postsVerQ && (
+            <Layout.FlexRow
+              w="100%"
+              alignItems="center"
+              justifyContent="space-between"
+              p={12}
+              bgColor="WHITE"
+              onClick={() => navigate('/my/friends/list')}
+              style={{ cursor: 'pointer', borderTop: '1px solid #EEE' }}
+            >
+              <Typo type="title-medium" color="BLACK">
+                {t('nav_tab.friends')}
+              </Typo>
+              <Layout.FlexRow alignItems="center" gap={4}>
+                <Typo type="label-medium" color="DARK_GRAY">
+                  {myProfile?.friend_count ?? 0}
+                </Typo>
+                <SvgIcon name="arrow_right" size={16} fill="DARK_GRAY" />
+              </Layout.FlexRow>
+            </Layout.FlexRow>
+          )}
           <Divider width={8} bgColor="LIGHT" />
           <Layout.FlexCol pl={12} pb="default" w="100%" bgColor="WHITE" rounded="0px 0px 8px 8px">
             {featureFlags?.questionResponseFeature ? <AllPostSection /> : <NoteSection />}

--- a/src/routes/UserPage.tsx
+++ b/src/routes/UserPage.tsx
@@ -5,6 +5,7 @@ import CommonError from '@components/_common/common-error/CommonError';
 import { Divider } from '@components/_common/divider/Divider.styled';
 import MainContainer from '@components/_common/main-container/MainContainer';
 import PullToRefresh from '@components/_common/pull-to-refresh/PullToRefresh';
+import CheckInPostStories from '@components/check-in-posts/CheckInPostStories';
 import UserHeader from '@components/header/user-header/UserHeader';
 import NoteSection from '@components/note/note-section/NoteSection';
 import AllPostSection from '@components/post/AllPostSection';
@@ -112,6 +113,9 @@ function UserPage() {
                   >
                     <Profile user={user.data} />
                   </Layout.FlexRow>
+                  {featureFlags?.checkInPosts && userId && (
+                    <CheckInPostStories authorUserId={userId} />
+                  )}
                   <Divider width={8} bgColor="LIGHT" />
                   <Layout.FlexCol pt={8} pl={12} pb="default" w="100%" bgColor="WHITE" rounded={8}>
                     {featureFlags?.questionResponseFeature ? (

--- a/src/routes/check-in-posts/NewCheckInPost.tsx
+++ b/src/routes/check-in-posts/NewCheckInPost.tsx
@@ -1,0 +1,183 @@
+import { AxiosError } from 'axios';
+import { ChangeEvent, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import ProfileImage from '@components/_common/profile-image/ProfileImage';
+import UploadLoadingOverlay from '@components/_common/upload-loading-overlay/UploadLoadingOverlay';
+import NewNoteImageEdit from '@components/note/new-note-image-edit/NewNoteImageEdit';
+import { NoteImage, NoteImageWrapper } from '@components/note/note-image/NoteImage.styled';
+import SubHeader from '@components/sub-header/SubHeader';
+import { DEFAULT_MARGIN } from '@constants/layout';
+import { CheckBox, Layout, SvgIcon, Typo } from '@design-system';
+import { useDelayedVisible } from '@hooks/useDelayedVisible';
+import { NewCheckInPostForm } from '@models/checkInPost';
+import { useBoundStore } from '@stores/useBoundStore';
+import { postCheckInPost } from '@utils/apis/checkInPost';
+import { CroppedImg, readFile } from '@utils/getCroppedImg';
+import { MainScrollContainer } from '../Root';
+
+function NewCheckInPost() {
+  const [t] = useTranslation('translation');
+  const navigate = useNavigate();
+  const { myProfile, openToast } = useBoundStore((state) => ({
+    myProfile: state.myProfile,
+    openToast: state.openToast,
+  }));
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [editImageUrl, setEditImageUrl] = useState<string>();
+  const [isEditVisible, setIsEditVisible] = useState(false);
+
+  const [form, setForm] = useState<NewCheckInPostForm>({
+    image: null,
+    caption: '',
+    closeFriendsOnly: false,
+  });
+
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const showUploadOverlay = useDelayedVisible(isSubmitting);
+
+  const onClickAdd = () => inputRef.current?.click();
+
+  const onImageAdd = async (e: ChangeEvent<HTMLInputElement>) => {
+    if (!e.target.files) return;
+    const image = e.target.files[0];
+    try {
+      const imageDataUrl = await readFile(image);
+      if (typeof imageDataUrl !== 'string') throw new Error('read file error');
+      setEditImageUrl(imageDataUrl);
+      setIsEditVisible(true);
+    } catch (error) {
+      openToast({ message: (error as Error).message });
+    }
+  };
+
+  const onCompleteImageCrop = (croppedImage: CroppedImg) => {
+    setForm((prev) => ({ ...prev, image: croppedImage }));
+  };
+
+  const handleDeleteImage = () => {
+    setForm((prev) => ({ ...prev, image: null }));
+  };
+
+  const handleChangeCaption = (e: ChangeEvent<HTMLTextAreaElement>) => {
+    setForm((prev) => ({ ...prev, caption: e.target.value }));
+  };
+
+  const handleToggleCloseFriendsOnly = () => {
+    setForm((prev) => ({ ...prev, closeFriendsOnly: !prev.closeFriendsOnly }));
+  };
+
+  const handleCancel = () => navigate(-1);
+
+  const handleShare = async () => {
+    if (isSubmitting || !form.image) return;
+    setIsSubmitting(true);
+    try {
+      await postCheckInPost(form);
+      openToast({ message: t('notes.posted') ?? '' });
+      navigate('/feed');
+    } catch (e) {
+      const err = e as AxiosError<{ error?: string }>;
+      openToast({
+        message: err.response?.data?.error || t('notes.temporary_error') || '',
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const canSubmit = !!form.image && !isSubmitting;
+
+  return (
+    <MainScrollContainer>
+      <SubHeader
+        title={t('check_in_post.new_title') || 'New check-in'}
+        RightComponent={
+          <button type="button" onClick={handleShare} disabled={!canSubmit}>
+            <Typo type="title-large" color={canSubmit ? 'PRIMARY' : 'MEDIUM_GRAY'}>
+              {t('notes.post')}
+            </Typo>
+          </button>
+        }
+        onGoBack={handleCancel}
+      />
+      <Layout.FlexCol w="100%" ph={DEFAULT_MARGIN} pv={12} gap={16} pb={100}>
+        <Layout.FlexRow w="100%" alignItems="center" gap={8} pv={8}>
+          <ProfileImage
+            imageUrl={myProfile?.profile_image}
+            username={myProfile?.username}
+            size={50}
+          />
+          <Typo type="title-medium">{myProfile?.username}</Typo>
+        </Layout.FlexRow>
+
+        <textarea
+          value={form.caption}
+          placeholder={t('notes.whats_on_your_mind') || ''}
+          onChange={handleChangeCaption}
+          rows={4}
+          style={{
+            width: '100%',
+            border: 'none',
+            outline: 'none',
+            resize: 'none',
+            fontSize: 16,
+            padding: 8,
+            background: 'transparent',
+          }}
+        />
+
+        {form.image?.url ? (
+          <Layout.FlexCol w="100%" alignItems="center" mt={16}>
+            <NoteImageWrapper ph={DEFAULT_MARGIN} style={{ width: '100%' }}>
+              <NoteImage src={form.image.url} alt="check-in" />
+              <Layout.Absolute t={0} r={15}>
+                <SvgIcon name="delete_image" size={50} onClick={handleDeleteImage} />
+              </Layout.Absolute>
+            </NoteImageWrapper>
+          </Layout.FlexCol>
+        ) : (
+          <Layout.FlexRow w="100%" alignItems="center" justifyContent="flex-start" mt={20}>
+            <SvgIcon name="chat_media_image" size={24} onClick={onClickAdd} fill="DARK_GRAY" />
+            <Typo type="label-medium" color="MEDIUM_GRAY" ml={8}>
+              {t('check_in_post.add_image') || 'Add a photo'}
+            </Typo>
+          </Layout.FlexRow>
+        )}
+
+        <Layout.FlexRow w="100%" justifyContent="flex-end" alignItems="center" mt={20} gap={6}>
+          <CheckBox
+            name={t('notes.close_friends_only') || 'Close friends only'}
+            checked={form.closeFriendsOnly}
+            onChange={handleToggleCloseFriendsOnly}
+          />
+          <Typo type="label-medium" color="DARK_GRAY">
+            {t('notes.close_friends_only')}
+          </Typo>
+        </Layout.FlexRow>
+
+        <input
+          ref={inputRef}
+          type="file"
+          accept="image/jpeg, image/png"
+          onChange={onImageAdd}
+          multiple={false}
+          style={{ display: 'none' }}
+        />
+      </Layout.FlexCol>
+
+      {isEditVisible && (
+        <NewNoteImageEdit
+          imageUrl={editImageUrl}
+          setIsVisible={setIsEditVisible}
+          onCompleteImageCrop={onCompleteImageCrop}
+        />
+      )}
+
+      <UploadLoadingOverlay visible={showUploadOverlay} />
+    </MainScrollContainer>
+  );
+}
+
+export default NewCheckInPost;

--- a/src/routes/check-in-posts/NewCheckInPost.tsx
+++ b/src/routes/check-in-posts/NewCheckInPost.tsx
@@ -140,9 +140,6 @@ function NewCheckInPost() {
         ) : (
           <Layout.FlexRow w="100%" alignItems="center" justifyContent="flex-start" mt={20}>
             <SvgIcon name="chat_media_image" size={24} onClick={onClickAdd} fill="DARK_GRAY" />
-            <Typo type="label-medium" color="MEDIUM_GRAY" ml={8}>
-              {t('check_in_post.add_image') || 'Add a photo'}
-            </Typo>
           </Layout.FlexRow>
         )}
 
@@ -152,9 +149,6 @@ function NewCheckInPost() {
             checked={form.closeFriendsOnly}
             onChange={handleToggleCloseFriendsOnly}
           />
-          <Typo type="label-medium" color="DARK_GRAY">
-            {t('notes.close_friends_only')}
-          </Typo>
         </Layout.FlexRow>
 
         <input

--- a/src/routes/discover/Discover.tsx
+++ b/src/routes/discover/Discover.tsx
@@ -28,6 +28,7 @@ import {
   DiscoverResultItem,
 } from '@models/discover';
 import { useBoundStore } from '@stores/useBoundStore';
+import { UserSelector } from '@stores/user';
 import { getDiscoverFeed } from '@utils/apis/discover';
 import { getMe } from '@utils/apis/my';
 import { getItemFromSessionStorage, setItemToSessionStorage } from '@utils/sessionStorage';
@@ -59,6 +60,8 @@ function Discover() {
   } = useSaveAndHide();
 
   const myProfile = useBoundStore((state) => state.myProfile);
+  const { featureFlags } = useBoundStore(UserSelector);
+  const isVerQ = !!featureFlags?.postsVerQ;
 
   const discoverFilterList = [DiscoverFilter.MUTUAL_FRIENDS, DiscoverFilter.MUTUAL_TRAITS];
   const { scrollRef } = useRestoreScrollPosition('discoverPage');
@@ -187,6 +190,10 @@ function Discover() {
 
   const renderDiscoverItem = useCallback(
     (item: DiscoverResultItem, index: number) => {
+      // VER_Q: only show Note/Response items, drop all injection cards
+      if (isVerQ && item.type !== 'Note' && item.type !== 'Response') {
+        return null;
+      }
       switch (item.type) {
         case 'Response':
           return (
@@ -251,6 +258,7 @@ function Discover() {
       showPersonaCard,
       handlePersonaSave,
       isPersonaAnimating,
+      isVerQ,
     ],
   );
 
@@ -275,24 +283,26 @@ function Discover() {
       >
         {/* Filter + shared playlist sit outside ptr__children so WebView can pan horizontal lists. */}
         <Layout.FlexCol w="100%" pb={FLOATING_BUTTON_SIZE + 20}>
-          <S.ScrollableFilterRow gap={8} ph={16} pv={12}>
-            {discoverFilterList.map((filter) => (
-              <FilterChip
-                key={filter}
-                label={DiscoverFilterLabel[filter]}
-                isSelected={selectedFilter.includes(filter)}
-                onClick={() => {
-                  if (selectedFilter.includes(filter)) {
-                    setSelectedFilter(selectedFilter.filter((f) => f !== filter));
-                  } else {
-                    setSelectedFilter([...selectedFilter, filter]);
-                  }
-                }}
-              />
-            ))}
-          </S.ScrollableFilterRow>
+          {!isVerQ && (
+            <S.ScrollableFilterRow gap={8} ph={16} pv={12}>
+              {discoverFilterList.map((filter) => (
+                <FilterChip
+                  key={filter}
+                  label={DiscoverFilterLabel[filter]}
+                  isSelected={selectedFilter.includes(filter)}
+                  onClick={() => {
+                    if (selectedFilter.includes(filter)) {
+                      setSelectedFilter(selectedFilter.filter((f) => f !== filter));
+                    } else {
+                      setSelectedFilter([...selectedFilter, filter]);
+                    }
+                  }}
+                />
+              ))}
+            </S.ScrollableFilterRow>
+          )}
 
-          {!isLoading && <SharedPlaylistSection tracks={musicTracks} />}
+          {!isVerQ && !isLoading && <SharedPlaylistSection tracks={musicTracks} />}
 
           <PullToRefresh onRefresh={handleRefresh}>
             <Layout.FlexCol

--- a/src/routes/friends/DefaultMyFriendsList.tsx
+++ b/src/routes/friends/DefaultMyFriendsList.tsx
@@ -7,6 +7,8 @@ import SubHeader from '@components/sub-header/SubHeader';
 import { Layout, Typo } from '@design-system';
 import useInfiniteFetchFriends from '@hooks/useInfiniteFetchFriends';
 import { useRestoreScrollPosition } from '@hooks/useRestoreScrollPosition';
+import { useBoundStore } from '@stores/useBoundStore';
+import { UserSelector } from '@stores/user';
 import { MainScrollContainer } from 'src/routes/Root';
 import { AllFriendItemLoader, AllFriendListLoader } from './FriendsLoader';
 
@@ -17,6 +19,8 @@ function DefaultMyFriendsList() {
     useInfiniteFetchFriends({ type: 'all' });
 
   const navigate = useNavigate();
+  const { featureFlags } = useBoundStore(UserSelector);
+  const showMoreButton = !!featureFlags?.postsVerQ;
 
   const handleRefresh = async () => {
     await refetchAllFriends();
@@ -41,7 +45,15 @@ function DefaultMyFriendsList() {
                     results?.map((user) => {
                       if (user.is_hidden) return null;
                       return (
-                        <UpdatedFriendItemDefault key={`friends_${user.id}`} isMyPage user={user} />
+                        <UpdatedFriendItemDefault
+                          key={`friends_${user.id}`}
+                          isMyPage
+                          user={user}
+                          showMoreButton={showMoreButton}
+                          onAfterUserMoreAction={async () => {
+                            await refetchAllFriends();
+                          }}
+                        />
                       );
                     }),
                   )}

--- a/src/routes/friends/ExploreFriends.tsx
+++ b/src/routes/friends/ExploreFriends.tsx
@@ -33,7 +33,7 @@ function ExploreFriends() {
   const [query, setQuery] = useState('');
 
   const handleClickDone = () => {
-    navigate(featureFlags?.friendUpdatesTab ? '/friends-q' : '/friends');
+    navigate(featureFlags?.checkInPosts ? '/feed' : '/friends');
   };
 
   return (

--- a/src/routes/friends/FriendsFeed.tsx
+++ b/src/routes/friends/FriendsFeed.tsx
@@ -67,7 +67,7 @@ function FriendsFeed() {
           {isLoading ? (
             <NoteLoader />
           ) : feedItems?.[0] && feedItems[0].count > 0 ? (
-            <>
+            <Layout.FlexCol gap={20} ph={16} pt={20} w="100%" style={{ boxSizing: 'border-box' }}>
               {feedItems.map(({ results }) => results?.map((item) => renderFeedItem(item)))}
               <div ref={targetRef} />
               {isFeedItemsLoadingMore && (
@@ -75,7 +75,7 @@ function FriendsFeed() {
                   <Loader />
                 </Layout.FlexRow>
               )}
-            </>
+            </Layout.FlexCol>
           ) : (
             <Layout.FlexRow alignItems="center" w="100%" h="100%">
               <NoContents title={t('no_contents.notes')} />

--- a/src/routes/friends/FriendsFeed.tsx
+++ b/src/routes/friends/FriendsFeed.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import Loader from '@components/_common/loader/Loader';
 import NoContents from '@components/_common/no-contents/NoContents';
 import PullToRefresh from '@components/_common/pull-to-refresh/PullToRefresh';
+import CheckInPostStories from '@components/check-in-posts/CheckInPostStories';
 import NoteItem from '@components/note/note-item/NoteItem';
 import NoteLoader from '@components/note/note-loader/NoteLoader';
 import ResponseItem from '@components/response/response-item/ResponseItem';
@@ -11,6 +12,7 @@ import { useRestoreScrollPosition } from '@hooks/useRestoreScrollPosition';
 import { useSWRInfiniteScroll } from '@hooks/useSWRInfiniteScroll';
 import { Note, POST_TYPE, Response } from '@models/post';
 import { useBoundStore } from '@stores/useBoundStore';
+import { UserSelector } from '@stores/user';
 import { getMe } from '@utils/apis/my';
 import { MainScrollContainer } from 'src/routes/Root';
 
@@ -23,6 +25,7 @@ function FriendsFeed() {
     myProfile: state.myProfile,
     fetchCheckIn: state.fetchCheckIn,
   }));
+  const { featureFlags } = useBoundStore(UserSelector);
 
   const {
     targetRef,
@@ -60,6 +63,7 @@ function FriendsFeed() {
     <MainScrollContainer scrollRef={scrollRef} showNotificationPermission>
       <PullToRefresh onRefresh={handleRefresh}>
         <Layout.FlexCol w="100%">
+          {featureFlags?.checkInPosts && <CheckInPostStories showCompose />}
           {isLoading ? (
             <NoteLoader />
           ) : feedItems?.[0] && feedItems[0].count > 0 ? (

--- a/src/routes/settings/EditProfile.tsx
+++ b/src/routes/settings/EditProfile.tsx
@@ -221,7 +221,7 @@ function EditProfile() {
     if (isFromResetPassword) {
       navigate('/my');
     } else if (isFromSignUp) {
-      navigate(featureFlags?.friendUpdatesTab ? '/friends-q' : '/friends');
+      navigate(featureFlags?.checkInPosts ? '/feed' : '/friends');
     } else {
       navigate(-1);
     }
@@ -333,24 +333,26 @@ function EditProfile() {
         </Layout.FlexCol>
       </Layout.FlexCol>
       <Layout.FlexCol pt={32} ph={24} pb={40} gap={16} w="100%">
-        <EditProfileTabRow w="100%">
-          <EditProfileTabButton
-            type="button"
-            $active={activeTab === 'pronouns_bio'}
-            onClick={() => setActiveTab('pronouns_bio')}
-          >
-            Pronouns/Bio
-          </EditProfileTabButton>
-          <EditProfileTabButton
-            type="button"
-            $active={activeTab === 'interests'}
-            onClick={() => setActiveTab('interests')}
-          >
-            Interests
-          </EditProfileTabButton>
-        </EditProfileTabRow>
+        {!featureFlags?.postsVerQ && (
+          <EditProfileTabRow w="100%">
+            <EditProfileTabButton
+              type="button"
+              $active={activeTab === 'pronouns_bio'}
+              onClick={() => setActiveTab('pronouns_bio')}
+            >
+              Pronouns/Bio
+            </EditProfileTabButton>
+            <EditProfileTabButton
+              type="button"
+              $active={activeTab === 'interests'}
+              onClick={() => setActiveTab('interests')}
+            >
+              Interests
+            </EditProfileTabButton>
+          </EditProfileTabRow>
+        )}
 
-        {activeTab === 'pronouns_bio' ? (
+        {activeTab === 'pronouns_bio' || featureFlags?.postsVerQ ? (
           <>
             <ValidatedInput
               label={t('username')}

--- a/src/routes/share/Share.tsx
+++ b/src/routes/share/Share.tsx
@@ -10,6 +10,8 @@ import { DEFAULT_MARGIN } from '@constants/layout';
 import { Layout, Typo } from '@design-system';
 import { useRestoreScrollPosition } from '@hooks/useRestoreScrollPosition';
 import { DailyQuestion } from '@models/post';
+import { useBoundStore } from '@stores/useBoundStore';
+import { UserSelector } from '@stores/user';
 import { getMe } from '@utils/apis/my';
 import { getTodayQuestions } from '@utils/apis/question';
 import { MainScrollContainer } from '../Root';
@@ -22,6 +24,7 @@ function Share() {
   const navigate = useNavigate();
   const { scrollRef } = useRestoreScrollPosition('sharePage');
   const photoInputRef = useRef<HTMLInputElement>(null);
+  const { featureFlags } = useBoundStore(UserSelector);
 
   const { data: todayQuestions, mutate } = useSWR<DailyQuestion[]>(
     '/qna/questions/daily/',
@@ -31,6 +34,24 @@ function Share() {
   const handleRefresh = useCallback(async () => {
     await Promise.all([mutate(), getMe()]);
   }, [mutate]);
+
+  if (featureFlags?.shareTabVisible && featureFlags?.postsVerQ) {
+    return (
+      <MainScrollContainer>
+        <Layout.FlexCol
+          w="100%"
+          h="100%"
+          alignItems="center"
+          justifyContent="center"
+          ph={DEFAULT_MARGIN}
+        >
+          <Typo type="head-line" color="MEDIUM_GRAY">
+            Coming soon
+          </Typo>
+        </Layout.FlexCol>
+      </MainScrollContainer>
+    );
+  }
 
   const handleClickSharePhoto = () => {
     photoInputRef.current?.click();

--- a/src/utils/apis/checkInPost.ts
+++ b/src/utils/apis/checkInPost.ts
@@ -1,0 +1,47 @@
+import { PaginationResponse } from '@models/api/common';
+import { CheckInPost, CheckInPostStory, NewCheckInPostForm } from '@models/checkInPost';
+import axios, { axiosFormDataInstance } from '@utils/apis/axios';
+
+export const getCheckInPostFeed = async (page: string | null) => {
+  const requestPage = page ? page.split('page=')[1] : null;
+  const { data } = await axios.get<PaginationResponse<CheckInPost[]>>(
+    `/check_in/posts/${requestPage ? `?page=${requestPage}` : ''}`,
+  );
+  return data;
+};
+
+export const getCheckInPostStories = async () => {
+  const { data } = await axios.get<PaginationResponse<CheckInPostStory[]>>(
+    '/check_in/posts/stories/',
+  );
+  return data;
+};
+
+export const getUserCheckInPosts = async (userId: number) => {
+  const { data } = await axios.get<PaginationResponse<CheckInPostStory[]>>(
+    `/check_in/posts/by-user/${userId}/`,
+  );
+  return data;
+};
+
+export const getCheckInPost = async (postId: number) => {
+  const { data } = await axios.get<CheckInPost>(`/check_in/posts/${postId}/`);
+  return data;
+};
+
+export const postCheckInPost = async (form: NewCheckInPostForm) => {
+  if (!form.image) {
+    throw new Error('Image is required for check-in post.');
+  }
+  const formData = new FormData();
+  formData.append('image', form.image.file);
+  if (form.caption) formData.append('caption', form.caption);
+  formData.append('visibility', form.closeFriendsOnly ? 'close_friends' : 'friends');
+
+  const { data } = await axiosFormDataInstance.post<CheckInPost>('check_in/posts/', formData);
+  return data;
+};
+
+export const deleteCheckInPost = async (postId: number) => {
+  await axios.delete(`/check_in/posts/${postId}/`);
+};

--- a/src/utils/apis/subscription.ts
+++ b/src/utils/apis/subscription.ts
@@ -1,0 +1,24 @@
+import { SubscriptionType } from '@models/subscription';
+import axios from '@utils/apis/axios';
+
+interface SubscriptionsResponse {
+  types: SubscriptionType[];
+}
+
+export const getSubscriptions = async (friendId: number): Promise<SubscriptionType[]> => {
+  const { data } = await axios.get<SubscriptionsResponse>(
+    `/user/friends/${friendId}/subscriptions/`,
+  );
+  return data.types ?? [];
+};
+
+export const updateSubscriptions = async (
+  friendId: number,
+  types: SubscriptionType[],
+): Promise<SubscriptionType[]> => {
+  const { data } = await axios.post<SubscriptionsResponse>(
+    `/user/friends/${friendId}/subscriptions/`,
+    { types },
+  );
+  return data.types ?? [];
+};


### PR DESCRIPTION
## Summary
- refine post-compose and friends-feed presentation (compose label sizing, feed container spacing, reduced redundant labels)
- hide legacy social metadata in Ver.Q mode by gating pinned chip/shared traits behind `postsVerQ`
- switch friend item chat icon to Ver.Q variant under feature flag

## Test plan
- [ ] Verify `CheckInPostStories` compose bubble layout in mobile widths
- [ ] Verify `NewCheckInPost` image/close-friends rows still align without removed labels
- [ ] Verify `FriendsFeed` card spacing and infinite-scroll loader position
- [ ] With `postsVerQ=true`, confirm pinned chip/shared traits are hidden and chat icon is `friend_item_chat`
- [ ] With `postsVerQ=false`, confirm previous pinned chip/shared traits behavior remains

Made with [Cursor](https://cursor.com)