### PR TITLE
feat(view-as): Phase 0 — foundation (route, banner, tabs, context, helper, tooltip, eye icon)

### DIFF
--- a/src/components/_common/tooltip/Tooltip.styled.ts
+++ b/src/components/_common/tooltip/Tooltip.styled.ts
@@ -1,0 +1,24 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  position: relative;
+  display: inline-flex;
+`;
+
+export const Bubble = styled.div<{ visible: boolean }>`
+  position: absolute;
+  bottom: calc(100% + 4px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: ${({ theme }) => theme.DARK};
+  color: ${({ theme }) => theme.WHITE};
+  font-size: 12px;
+  line-height: 1.2;
+  padding: 4px 8px;
+  border-radius: 4px;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: ${({ visible }) => (visible ? 1 : 0)};
+  transition: opacity 120ms ease-out;
+  z-index: 10;
+`;

--- a/src/components/_common/tooltip/Tooltip.tsx
+++ b/src/components/_common/tooltip/Tooltip.tsx
@@ -1,0 +1,39 @@
+import { ReactNode, useEffect, useRef, useState } from 'react';
+import * as S from './Tooltip.styled';
+
+interface TooltipProps {
+  label: string;
+  children: ReactNode;
+  /** ms to keep visible after a tap; 0 = persist until next tap elsewhere */
+  durationMs?: number;
+}
+
+const DEFAULT_DURATION = 1500;
+
+function Tooltip({ label, children, durationMs = DEFAULT_DURATION }: TooltipProps) {
+  const [visible, setVisible] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  const handleShow = () => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    setVisible(true);
+    if (durationMs > 0) {
+      timerRef.current = setTimeout(() => setVisible(false), durationMs);
+    }
+  };
+
+  return (
+    <S.Container onClick={handleShow} onTouchStart={handleShow}>
+      {children}
+      <S.Bubble visible={visible}>{label}</S.Bubble>
+    </S.Container>
+  );
+}
+
+export default Tooltip;

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
+import Icon from '@components/_common/icon/Icon';
 import SubHeader from '@components/sub-header/SubHeader';
 import CommonHeader from './common-header/CommonHeader';
 import FriendHeader from './friends-header/FriendsHeader';
 
 function Header() {
   const location = useLocation();
+  const navigate = useNavigate();
   const [t] = useTranslation('translation');
 
   switch (location.pathname) {
@@ -19,7 +21,19 @@ function Header() {
     case '/discover':
       return <CommonHeader title={t('header.discover')} />;
     case '/my':
-      return <CommonHeader title={t('header.my')} />;
+      return (
+        <CommonHeader
+          title={t('header.my')}
+          extraActions={
+            <Icon
+              name="hide_false"
+              size={44}
+              onClick={() => navigate('/my/view-as')}
+              aria-label={t('view_as.entry_button_aria_label') ?? undefined}
+            />
+          }
+        />
+      );
     case '/update':
       return <CommonHeader title="Check-In" />;
     case '/share':

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -25,12 +25,7 @@ function Header() {
         <CommonHeader
           title={t('header.my')}
           extraActions={
-            <Icon
-              name="hide_false"
-              size={44}
-              onClick={() => navigate('/my/view-as')}
-              aria-label={t('view_as.entry_button_aria_label') ?? undefined}
-            />
+            <Icon name="hide_false" size={44} onClick={() => navigate('/my/view-as')} />
           }
         />
       );

--- a/src/components/header/common-header/CommonHeader.tsx
+++ b/src/components/header/common-header/CommonHeader.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { ReactNode, useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import Icon from '@components/_common/icon/Icon';
 import IconNudge from '@components/_common/icon-nudge/IconNudge';
@@ -12,9 +12,10 @@ import SideMenu from '../side-menu/SideMenu';
 
 interface CommonHeaderProps {
   title: string;
+  extraActions?: ReactNode;
 }
 
-function CommonHeader({ title }: CommonHeaderProps) {
+function CommonHeader({ title, extraActions }: CommonHeaderProps) {
   const [searchParams] = useSearchParams();
   // show_side_menu 파라미터가 true인 경우 사이드 메뉴 표시
   const initialShowSideMenu = searchParams.get('show_side_menu') === 'true' || false;
@@ -38,6 +39,7 @@ function CommonHeader({ title }: CommonHeaderProps) {
         title={title}
         rightButtons={
           <>
+            {extraActions}
             <Noti to="/notifications">
               <Icon
                 name="notification"

--- a/src/components/view-as/PreviewModeContext.tsx
+++ b/src/components/view-as/PreviewModeContext.tsx
@@ -1,0 +1,28 @@
+import { createContext, ReactNode, useContext, useMemo } from 'react';
+import { VisibilityTier } from '@models/viewAs';
+
+interface PreviewModeContextValue {
+  previewMode: boolean;
+  viewAs: VisibilityTier | null;
+}
+
+const DEFAULT_VALUE: PreviewModeContextValue = {
+  previewMode: false,
+  viewAs: null,
+};
+
+const PreviewModeContext = createContext<PreviewModeContextValue>(DEFAULT_VALUE);
+
+interface PreviewModeProviderProps {
+  viewAs: VisibilityTier;
+  children: ReactNode;
+}
+
+export function PreviewModeProvider({ viewAs, children }: PreviewModeProviderProps) {
+  const value = useMemo(() => ({ previewMode: true, viewAs }), [viewAs]);
+
+  return <PreviewModeContext.Provider value={value}>{children}</PreviewModeContext.Provider>;
+}
+
+export const useIsPreviewMode = (): boolean => useContext(PreviewModeContext).previewMode;
+export const useViewAs = (): VisibilityTier | null => useContext(PreviewModeContext).viewAs;

--- a/src/components/view-as/ViewAsBanner.styled.ts
+++ b/src/components/view-as/ViewAsBanner.styled.ts
@@ -1,0 +1,22 @@
+import styled from 'styled-components';
+
+export const Banner = styled.div`
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  background: ${({ theme }) => theme.LIGHT};
+  border-bottom: 1px solid ${({ theme }) => theme.LIGHT_GRAY};
+`;
+
+export const Label = styled.span`
+  font-size: 14px;
+  color: ${({ theme }) => theme.BLACK};
+`;
+
+export const Strong = styled.strong`
+  font-weight: 600;
+`;

--- a/src/components/view-as/ViewAsBanner.tsx
+++ b/src/components/view-as/ViewAsBanner.tsx
@@ -1,0 +1,25 @@
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import Icon from '@components/_common/icon/Icon';
+import { VisibilityTier } from '@models/viewAs';
+import * as S from './ViewAsBanner.styled';
+
+interface ViewAsBannerProps {
+  tier: VisibilityTier;
+}
+
+function ViewAsBanner({ tier }: ViewAsBannerProps) {
+  const [t] = useTranslation('translation', { keyPrefix: 'view_as' });
+  const navigate = useNavigate();
+
+  return (
+    <S.Banner>
+      <S.Label>
+        {t('banner_prefix')} <S.Strong>{t(`tier.${tier}`)}</S.Strong>
+      </S.Label>
+      <Icon name="close" size={24} onClick={() => navigate('/my')} />
+    </S.Banner>
+  );
+}
+
+export default ViewAsBanner;

--- a/src/components/view-as/ViewAsTabs.styled.ts
+++ b/src/components/view-as/ViewAsTabs.styled.ts
@@ -8,12 +8,12 @@ export const TabsRow = styled.div`
   border-bottom: 1px solid ${({ theme }) => theme.LIGHT_GRAY};
 `;
 
-export const TabButton = styled.button<{ selected: boolean }>`
+export const TabButton = styled.button<{ $selected: boolean }>`
   border-radius: 8px;
   padding: 4px 8px;
   font-size: 14px;
-  border: 1px solid ${({ theme, selected }) => (selected ? '#8700FF' : theme.LIGHT_GRAY)};
-  background: ${({ selected }) => (selected ? '#F3E8FF' : 'white')};
-  color: ${({ theme, selected }) => (selected ? '#8700FF' : theme.DARK)};
+  border: 1px solid ${({ theme, $selected }) => ($selected ? '#8700FF' : theme.LIGHT_GRAY)};
+  background: ${({ $selected }) => ($selected ? '#F3E8FF' : 'white')};
+  color: ${({ theme, $selected }) => ($selected ? '#8700FF' : theme.DARK)};
   cursor: pointer;
 `;

--- a/src/components/view-as/ViewAsTabs.styled.ts
+++ b/src/components/view-as/ViewAsTabs.styled.ts
@@ -1,0 +1,19 @@
+import styled from 'styled-components';
+
+export const TabsRow = styled.div`
+  display: flex;
+  gap: 8px;
+  padding: 8px 12px;
+  background: ${({ theme }) => theme.WHITE};
+  border-bottom: 1px solid ${({ theme }) => theme.LIGHT_GRAY};
+`;
+
+export const TabButton = styled.button<{ selected: boolean }>`
+  border-radius: 8px;
+  padding: 4px 8px;
+  font-size: 14px;
+  border: 1px solid ${({ theme, selected }) => (selected ? '#8700FF' : theme.LIGHT_GRAY)};
+  background: ${({ selected }) => (selected ? '#F3E8FF' : 'white')};
+  color: ${({ theme, selected }) => (selected ? '#8700FF' : theme.DARK)};
+  cursor: pointer;
+`;

--- a/src/components/view-as/ViewAsTabs.tsx
+++ b/src/components/view-as/ViewAsTabs.tsx
@@ -18,7 +18,7 @@ function ViewAsTabs({ selected, onSelect }: ViewAsTabsProps) {
           type="button"
           role="tab"
           aria-selected={tier === selected}
-          selected={tier === selected}
+          $selected={tier === selected}
           onClick={() => onSelect(tier)}
         >
           {t(tier)}

--- a/src/components/view-as/ViewAsTabs.tsx
+++ b/src/components/view-as/ViewAsTabs.tsx
@@ -1,0 +1,31 @@
+import { useTranslation } from 'react-i18next';
+import { VIEW_AS_TIERS, VisibilityTier } from '@models/viewAs';
+import * as S from './ViewAsTabs.styled';
+
+interface ViewAsTabsProps {
+  selected: VisibilityTier;
+  onSelect: (tier: VisibilityTier) => void;
+}
+
+function ViewAsTabs({ selected, onSelect }: ViewAsTabsProps) {
+  const [t] = useTranslation('translation', { keyPrefix: 'view_as.tab' });
+
+  return (
+    <S.TabsRow role="tablist">
+      {VIEW_AS_TIERS.map((tier) => (
+        <S.TabButton
+          key={tier}
+          type="button"
+          role="tab"
+          aria-selected={tier === selected}
+          selected={tier === selected}
+          onClick={() => onSelect(tier)}
+        >
+          {t(tier)}
+        </S.TabButton>
+      ))}
+    </S.TabsRow>
+  );
+}
+
+export default ViewAsTabs;

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -1010,5 +1010,20 @@
         "entry_title_one": "{{count}} pinned post",
         "entry_title_other": "{{count}} pinned posts",
         "no_contents": "No pinned posts yet."
+    },
+    "view_as": {
+        "banner_prefix": "Previewing your profile as",
+        "tab": {
+            "public": "Public",
+            "friends": "Friends",
+            "close_friends": "Close Friends"
+        },
+        "tier": {
+            "public": "Public",
+            "friends": "Friends",
+            "close_friends": "Close Friends"
+        },
+        "disabled_tooltip": "Disabled in preview",
+        "entry_button_aria_label": "View profile as another audience"
     }
 }

--- a/src/i18n/locales/ko/translation.json
+++ b/src/i18n/locales/ko/translation.json
@@ -1000,5 +1000,20 @@
     "title": "고정 게시글",
     "entry_title": "{{count}} 고정 게시글",
     "no_contents": "고정된 게시글이 없습니다."
+  },
+  "view_as": {
+    "banner_prefix": "내 프로필 미리보기 — 보는 사람:",
+    "tab": {
+      "public": "전체공개",
+      "friends": "친구",
+      "close_friends": "친한 친구"
+    },
+    "tier": {
+      "public": "전체공개",
+      "friends": "친구",
+      "close_friends": "친한 친구"
+    },
+    "disabled_tooltip": "미리보기에서는 사용할 수 없어요",
+    "entry_button_aria_label": "다른 사람이 보는 내 프로필 미리보기"
   }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -74,6 +74,7 @@ import SignUp from './routes/SignUp';
 import SuggestQuestions from './routes/SuggestQuestions';
 import UpdateCheckin from './routes/update/UpdateCheckin';
 import UserPage from './routes/UserPage';
+import ViewAsPage from './routes/ViewAsPage';
 
 const router = createBrowserRouter([
   // intro route
@@ -113,10 +114,11 @@ const router = createBrowserRouter([
         path: 'my',
         children: [
           { path: '', element: <My /> },
-          { path: 'friends/list', element: <DefaultMyFriendsList /> },
-          { path: 'responses', element: <AllResponses from="my" /> },
-          { path: 'pinned-posts', element: <PinnedPosts /> },
           { path: 'chats', element: <ChatList /> },
+          { path: 'friends/list', element: <DefaultMyFriendsList /> },
+          { path: 'pinned-posts', element: <PinnedPosts /> },
+          { path: 'responses', element: <AllResponses from="my" /> },
+          { path: 'view-as', element: <ViewAsPage /> },
         ],
       },
       {

--- a/src/models/viewAs.ts
+++ b/src/models/viewAs.ts
@@ -1,0 +1,5 @@
+export const VIEW_AS_TIERS = ['public', 'friends', 'close_friends'] as const;
+export type VisibilityTier = (typeof VIEW_AS_TIERS)[number];
+
+export const isVisibilityTier = (value: unknown): value is VisibilityTier =>
+  typeof value === 'string' && (VIEW_AS_TIERS as readonly string[]).includes(value);

--- a/src/routes/UserPage.tsx
+++ b/src/routes/UserPage.tsx
@@ -12,6 +12,7 @@ import AllPostSection from '@components/post/AllPostSection';
 import Profile from '@components/profile/Profile';
 import UserMoreModal from '@components/user-page/UserMoreModal';
 import { UserPageContext } from '@components/user-page/UserPage.context';
+import { useIsPreviewMode } from '@components/view-as/PreviewModeContext';
 import { BOTTOM_TABBAR_HEIGHT, TITLE_HEADER_HEIGHT } from '@constants/layout';
 import { MAIN_SCROLL_CONTAINER_ID } from '@constants/scroll';
 import { Layout } from '@design-system';
@@ -24,6 +25,7 @@ function UserPage() {
   const { username } = useParams();
   const { myProfile } = useBoundStore((state) => ({ myProfile: state.myProfile }));
   const isMyPage = username === myProfile?.username;
+  const previewMode = useIsPreviewMode();
   const [showMore, setShowMore] = useState(false);
   const navigate = useNavigate();
   const { featureFlags } = useBoundStore(UserSelector);
@@ -42,10 +44,10 @@ function UserPage() {
   const outlet = useOutlet();
 
   useEffect(() => {
-    if (isMyPage) {
+    if (isMyPage && !previewMode) {
       navigate('/my');
     }
-  }, [isMyPage, navigate]);
+  }, [isMyPage, navigate, previewMode]);
 
   const handleClickMore = () => {
     setShowMore(true);

--- a/src/routes/ViewAsPage.tsx
+++ b/src/routes/ViewAsPage.tsx
@@ -1,0 +1,33 @@
+import { useSearchParams } from 'react-router-dom';
+import { PreviewModeProvider } from '@components/view-as/PreviewModeContext';
+import ViewAsBanner from '@components/view-as/ViewAsBanner';
+import ViewAsTabs from '@components/view-as/ViewAsTabs';
+import { Layout } from '@design-system';
+import { isVisibilityTier, VisibilityTier } from '@models/viewAs';
+
+const DEFAULT_TIER: VisibilityTier = 'public';
+
+function ViewAsPage() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const rawAs = searchParams.get('as');
+  const tier: VisibilityTier = isVisibilityTier(rawAs) ? rawAs : DEFAULT_TIER;
+
+  const handleSelect = (next: VisibilityTier) => {
+    setSearchParams({ as: next }, { replace: true });
+  };
+
+  return (
+    <PreviewModeProvider viewAs={tier}>
+      <Layout.FlexCol w="100%">
+        <ViewAsBanner tier={tier} />
+        <ViewAsTabs selected={tier} onSelect={handleSelect} />
+        {/* Phase 1 Task 1.6 replaces this placeholder with <UserPage /> */}
+        <Layout.FlexCol w="100%" p={16}>
+          <span>View As — {tier} (placeholder)</span>
+        </Layout.FlexCol>
+      </Layout.FlexCol>
+    </PreviewModeProvider>
+  );
+}
+
+export default ViewAsPage;

--- a/src/utils/apis/withViewAs.ts
+++ b/src/utils/apis/withViewAs.ts
@@ -1,0 +1,7 @@
+import { VisibilityTier } from '@models/viewAs';
+
+export const withViewAs = (url: string, viewAs: VisibilityTier | null | undefined): string => {
+  if (!viewAs) return url;
+  const separator = url.includes('?') ? '&' : '?';
+  return `${url}${separator}view_as=${encodeURIComponent(viewAs)}`;
+};


### PR DESCRIPTION
## Summary

Phase 0 of the View As feature — foundation only, no user-visible behavior beyond a placeholder route.

- Adds `/my/view-as` route that renders banner + three tier tabs (Public / Friends / Close Friends) and an empty body
- Adds the underlying primitives: `VisibilityTier` type, `withViewAs(url, tier)` URL helper, `PreviewModeContext` + `useIsPreviewMode` / `useViewAs` hooks, tap-to-show `Tooltip` primitive
- Adds entry-point eye icon on the `/my` header (later phases relocate it next to the username)
- Bypasses `UserPage`'s self-redirect to `/my` when in preview mode (so a later phase can render the owner's profile inside the preview)
- i18n keys for banner / tabs / tooltip in both `en` and `ko`

Spec: `docs/superpowers/specs/2026-04-25-view-as-profile-preview-design.md`
Plan: `docs/superpowers/plans/2026-04-25-view-as-phase-0-and-1.md`

## Test plan

- [ ] `npx craco build` clean
- [ ] Navigate to `/my/view-as` from `/my` via the eye icon — see banner + three tabs + empty placeholder body
- [ ] Tab switches update `?as=` URL with `replace: true`
- [ ] Banner ✕ navigates back to `/my`
- [ ] Invalid `?as=enemies` falls back to Public tab
- [ ] Renders cleanly at 320px viewport