### PR TITLE
feat(view-as): Phase 1 — shadow-viewer profile preview with friend picker

### DIFF
--- a/src/components/check-in/CheckIn.tsx
+++ b/src/components/check-in/CheckIn.tsx
@@ -1,14 +1,15 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
-import CheckInArchiveChip from '@components/check-in/archive/CheckInArchiveChip';
 import FriendPinnedChip from '@components/friends/friend-pinned-chip/FriendPinnedChip';
 import SpotifyMusic from '@components/music/spotify-music/SpotifyMusic';
 import MoodPlaceholder from '@components/profile/placeholders/MoodPlaceholder';
 import MusicPlaceholder from '@components/profile/placeholders/MusicPlaceholder';
 import SocialBatteryPlaceholder from '@components/profile/placeholders/SocialBatteryPlaceholder';
 import ThoughtPlaceholder from '@components/profile/placeholders/ThoughtPlaceholder';
-import { Layout, SvgIcon, Typo } from '@design-system';
+import { useIsPreviewMode } from '@components/view-as/PreviewModeContext';
+import { Layout, Typo } from '@design-system';
+import { useArchiveCounts } from '@hooks/useArchiveCounts';
 import useAsyncEffect from '@hooks/useAsyncEffect';
 import { useFriendPinnedCount } from '@hooks/useFriendPinnedCount';
 import { MyProfile } from '@models/api/user';
@@ -33,9 +34,11 @@ function CheckIn({ user }: CheckInProps) {
     checkIn: state.checkIn,
     fetchCheckIn: state.fetchCheckIn,
   }));
-  const isMyPage = user?.id === myProfile?.id;
+  const previewMode = useIsPreviewMode();
+  const isMyPage = !previewMode && user?.id === myProfile?.id;
   const friendUsername = !isMyPage && 'username' in user ? (user as UserProfile).username : null;
   const { pinnedCount: friendPinnedCount } = useFriendPinnedCount(friendUsername);
+  const { archivedCount } = useArchiveCounts();
   const [checkIn, setCheckIn] = useState<CheckInBase | null | undefined>(
     isMyPage ? initialCheckIn : user.check_in,
   );
@@ -80,15 +83,11 @@ function CheckIn({ user }: CheckInProps) {
           <Typo type="label-large" color="BLACK">
             {t('title')}
           </Typo>
-          {isMyPage ? (
-            <CheckInArchiveChip />
-          ) : (
-            friendUsername && (
-              <FriendPinnedChip
-                pinnedCount={friendPinnedCount}
-                to={`/users/${friendUsername}/check-in/pinned`}
-              />
-            )
+          {!isMyPage && friendUsername && (
+            <FriendPinnedChip
+              pinnedCount={friendPinnedCount}
+              to={`/users/${friendUsername}/check-in/pinned`}
+            />
           )}
         </Layout.FlexRow>
         <Layout.FlexRow w="100%" alignItems="center" justifyContent="space-between">
@@ -203,12 +202,32 @@ function CheckIn({ user }: CheckInProps) {
               <span />
             )}
             {isMyPage && (
-              <SvgIcon
-                name="edit_filled"
-                fill="DARK_GRAY"
-                size={20}
-                onClick={handleClickEditCheckIn}
-              />
+              <Layout.FlexRow
+                alignItems="center"
+                gap={4}
+                onClick={() => navigate('/check-in/archive?tab=all')}
+                style={{ cursor: 'pointer' }}
+              >
+                <svg
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden
+                  style={{ color: '#8C8C8C' }}
+                >
+                  <rect x="3" y="3" width="18" height="5" rx="1" />
+                  <path d="M5 8v11a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V8" />
+                  <path d="M10 12h4" />
+                </svg>
+                <Typo type="label-medium" color="DARK_GRAY" underline>
+                  Archive ({archivedCount})
+                </Typo>
+              </Layout.FlexRow>
             )}
           </Layout.FlexRow>
         )}

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -1,14 +1,12 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useLocation, useNavigate } from 'react-router-dom';
-import Icon from '@components/_common/icon/Icon';
+import { useLocation } from 'react-router-dom';
 import SubHeader from '@components/sub-header/SubHeader';
 import CommonHeader from './common-header/CommonHeader';
 import FriendHeader from './friends-header/FriendsHeader';
 
 function Header() {
   const location = useLocation();
-  const navigate = useNavigate();
   const [t] = useTranslation('translation');
 
   switch (location.pathname) {
@@ -21,14 +19,7 @@ function Header() {
     case '/discover':
       return <CommonHeader title={t('header.discover')} />;
     case '/my':
-      return (
-        <CommonHeader
-          title={t('header.my')}
-          extraActions={
-            <Icon name="hide_false" size={44} onClick={() => navigate('/my/view-as')} />
-          }
-        />
-      );
+      return <CommonHeader title={t('header.my')} />;
     case '/update':
       return <CommonHeader title="Check-In" />;
     case '/share':

--- a/src/components/profile/Profile.tsx
+++ b/src/components/profile/Profile.tsx
@@ -1,4 +1,4 @@
-import { MouseEvent, useContext, useState } from 'react';
+import { MouseEvent, ReactNode, useContext, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useShallow } from 'zustand/react/shallow';
@@ -8,6 +8,7 @@ import ProfileImage from '@components/_common/profile-image/ProfileImage';
 import SubscriptionPopup from '@components/friends/subscription-popup/SubscriptionPopup';
 import EditConnectionsBottomSheet from '@components/profile/edit-connections/EditConnectionsBottomSheet';
 import { UserPageContext } from '@components/user-page/UserPage.context';
+import { useIsPreviewMode, useViewAs, useViewAsUser } from '@components/view-as/PreviewModeContext';
 import { FeatureFlagKey } from '@constants/featureFlag';
 import { Layout, SvgIcon, Typo } from '@design-system';
 import useAsyncEffect from '@hooks/useAsyncEffect';
@@ -35,10 +36,14 @@ interface ProfileProps {
 
 function Profile({ user }: ProfileProps) {
   const [t] = useTranslation('translation', { keyPrefix: 'user_page' });
+  const [tViewAs] = useTranslation('translation', { keyPrefix: 'view_as' });
   const { categories } = useChipCategories();
 
   const { featureFlags, myProfile } = useBoundStore(useShallow(UserSelector));
-  const isMyPage = user?.id === myProfile?.id;
+  const previewMode = useIsPreviewMode();
+  const viewAs = useViewAs();
+  const viewAsUser = useViewAsUser();
+  const isMyPage = !previewMode && user?.id === myProfile?.id;
   const [friendData, setFriendData] = useState<UserProfile | null>(null);
   const subscriptionBellEnabled = !!featureFlags?.[FeatureFlagKey.SUBSCRIPTION_POPUP];
   const isFriendUser = !!user && !isMyProfile(user) && areFriends(user);
@@ -66,10 +71,10 @@ function Profile({ user }: ProfileProps) {
 
   useAsyncEffect(async () => {
     if (isMyPage || !username) return;
-    const friend = await getUserProfile(username);
+    const friend = await getUserProfile(username, viewAs, viewAsUser);
 
     setFriendData(friend);
-  }, [isMyPage, username]);
+  }, [isMyPage, username, viewAs, viewAsUser]);
 
   const reloadPage = () => window.location.reload();
 
@@ -194,21 +199,6 @@ function Profile({ user }: ProfileProps) {
                 </>
               )}
             </Layout.FlexRow>
-            {/* edit icon */}
-            {isMyPage && (
-              <Layout.FlexRow
-                w="100%"
-                alignItems="center"
-                gap={2}
-                justifyContent="flex-end"
-                onClick={handleClickEditProfile}
-              >
-                <SvgIcon name="edit_filled" fill="DARK_GRAY" size={16} />
-                <Typo type="label-medium" color="DARK_GRAY" underline>
-                  {t('edit_profile')}
-                </Typo>
-              </Layout.FlexRow>
-            )}
           </Layout.FlexRow>
           {/* pronouns + bio (my page only — friend page shows inline above) */}
           {isMyPage ? (
@@ -287,6 +277,7 @@ function Profile({ user }: ProfileProps) {
             </>
           )}
           <MutualFriendsInfo mutualFriends={(user as UserProfile).mutuals} />
+
           {/* Mutual traits for non-friend users (from discover context) */}
           {!featureFlags?.postsVerQ &&
             !isMyProfile(user) &&
@@ -322,6 +313,18 @@ function Profile({ user }: ProfileProps) {
             )}
         </>
       )}
+      {/* my-page actions: Edit Profile + View As (Privacy) — sit directly above the check-in card */}
+      {isMyPage && (
+        <Layout.FlexRow w="100%" gap={8}>
+          <PrimaryActionButton onClick={handleClickEditProfile}>
+            {t('edit_profile')}
+          </PrimaryActionButton>
+          <PrimaryActionButton onClick={() => navigate('/my/view-as')}>
+            {tViewAs('entry_label_long', { defaultValue: 'View As (Privacy)' })}
+          </PrimaryActionButton>
+        </Layout.FlexRow>
+      )}
+
       {/* 체크인 (status) */}
       {featureFlags?.checkIn && user && <CheckInSection user={user} />}
 
@@ -340,3 +343,32 @@ function Profile({ user }: ProfileProps) {
 }
 
 export default Profile;
+
+function PrimaryActionButton({
+  onClick,
+  children,
+}: {
+  onClick: (e: MouseEvent) => void;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      style={{
+        flex: 1,
+        padding: '5px 12px',
+        borderRadius: 8,
+        border: '2px solid #555555',
+        background: 'rgba(217, 217, 217, 0.4)',
+        color: '#555555',
+        fontSize: 13,
+        fontWeight: 700,
+        cursor: 'pointer',
+        whiteSpace: 'nowrap',
+      }}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/components/user-page/UserPage.context.tsx
+++ b/src/components/user-page/UserPage.context.tsx
@@ -1,5 +1,6 @@
 import { createContext, ReactNode, useCallback, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
+import { useViewAs, useViewAsUser } from '@components/view-as/PreviewModeContext';
 import useAsyncEffect from '@hooks/useAsyncEffect';
 import { FetchState } from '@models/api/common';
 import { UserProfile } from '@models/user';
@@ -7,6 +8,7 @@ import { getUserProfile } from '@utils/apis/user';
 
 interface Props {
   children?: ReactNode | ReactNode[];
+  usernameOverride?: string;
 }
 
 export const UserPageContext = createContext<{
@@ -17,8 +19,11 @@ export const UserPageContext = createContext<{
   updateUser: async () => {},
 });
 
-export function UserPageContextProvider({ children }: Props) {
-  const { username } = useParams();
+export function UserPageContextProvider({ children, usernameOverride }: Props) {
+  const params = useParams();
+  const username = usernameOverride ?? params.username;
+  const viewAs = useViewAs();
+  const viewAsUser = useViewAsUser();
 
   const [user, setUser] = useState<FetchState<UserProfile>>({ state: 'loading' });
 
@@ -29,13 +34,13 @@ export function UserPageContextProvider({ children }: Props) {
     }
 
     try {
-      const res = await getUserProfile(username);
+      const res = await getUserProfile(username, viewAs, viewAsUser);
       setUser({ state: 'hasValue', data: res });
     } catch (error) {
       setUser({ state: 'hasError' });
     }
-  }, [username]);
-  useAsyncEffect(updateUser, [username]);
+  }, [username, viewAs, viewAsUser]);
+  useAsyncEffect(updateUser, [username, viewAs, viewAsUser]);
 
   const value = useMemo(
     () => ({

--- a/src/components/view-as/PreviewModeContext.tsx
+++ b/src/components/view-as/PreviewModeContext.tsx
@@ -4,25 +4,32 @@ import { VisibilityTier } from '@models/viewAs';
 interface PreviewModeContextValue {
   previewMode: boolean;
   viewAs: VisibilityTier | null;
+  viewAsUser: string | null;
 }
 
 const DEFAULT_VALUE: PreviewModeContextValue = {
   previewMode: false,
   viewAs: null,
+  viewAsUser: null,
 };
 
 const PreviewModeContext = createContext<PreviewModeContextValue>(DEFAULT_VALUE);
 
 interface PreviewModeProviderProps {
-  viewAs: VisibilityTier;
+  viewAs?: VisibilityTier | null;
+  viewAsUser?: string | null;
   children: ReactNode;
 }
 
-export function PreviewModeProvider({ viewAs, children }: PreviewModeProviderProps) {
-  const value = useMemo(() => ({ previewMode: true, viewAs }), [viewAs]);
-
+export function PreviewModeProvider({
+  viewAs = null,
+  viewAsUser = null,
+  children,
+}: PreviewModeProviderProps) {
+  const value = useMemo(() => ({ previewMode: true, viewAs, viewAsUser }), [viewAs, viewAsUser]);
   return <PreviewModeContext.Provider value={value}>{children}</PreviewModeContext.Provider>;
 }
 
 export const useIsPreviewMode = (): boolean => useContext(PreviewModeContext).previewMode;
 export const useViewAs = (): VisibilityTier | null => useContext(PreviewModeContext).viewAs;
+export const useViewAsUser = (): string | null => useContext(PreviewModeContext).viewAsUser;

--- a/src/components/view-as/ViewAsBanner.styled.ts
+++ b/src/components/view-as/ViewAsBanner.styled.ts
@@ -12,11 +12,33 @@ export const Banner = styled.div`
   border-bottom: 1px solid ${({ theme }) => theme.LIGHT_GRAY};
 `;
 
+export const LabelRow = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  flex: 1;
+  min-width: 0;
+`;
+
 export const Label = styled.span`
   font-size: 14px;
   color: ${({ theme }) => theme.BLACK};
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `;
 
 export const Strong = styled.strong`
   font-weight: 600;
+`;
+
+export const ChangeHint = styled.span`
+  font-size: 12px;
+  color: ${({ theme }) => theme.MEDIUM_GRAY};
+  text-decoration: underline;
+  flex-shrink: 0;
 `;

--- a/src/components/view-as/ViewAsBanner.tsx
+++ b/src/components/view-as/ViewAsBanner.tsx
@@ -5,18 +5,25 @@ import { VisibilityTier } from '@models/viewAs';
 import * as S from './ViewAsBanner.styled';
 
 interface ViewAsBannerProps {
-  tier: VisibilityTier;
+  tier?: VisibilityTier | null;
+  viewAsUser?: string | null;
+  onChange: () => void;
 }
 
-function ViewAsBanner({ tier }: ViewAsBannerProps) {
+function ViewAsBanner({ tier, viewAsUser, onChange }: ViewAsBannerProps) {
   const [t] = useTranslation('translation', { keyPrefix: 'view_as' });
   const navigate = useNavigate();
 
+  const subjectLabel = viewAsUser ? `@${viewAsUser}` : t(`tier.${tier ?? 'public'}`);
+
   return (
     <S.Banner>
-      <S.Label>
-        {t('banner_prefix')} <S.Strong>{t(`tier.${tier}`)}</S.Strong>
-      </S.Label>
+      <S.LabelRow type="button" onClick={onChange}>
+        <S.Label>
+          {t('banner_prefix')} <S.Strong>{subjectLabel}</S.Strong>
+        </S.Label>
+        <S.ChangeHint>{t('banner_change')}</S.ChangeHint>
+      </S.LabelRow>
       <Icon name="close" size={24} onClick={() => navigate('/my')} />
     </S.Banner>
   );

--- a/src/components/view-as/ViewAsPicker.styled.ts
+++ b/src/components/view-as/ViewAsPicker.styled.ts
@@ -1,0 +1,24 @@
+import styled from 'styled-components';
+
+export const Row = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  padding: 8px 4px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+`;
+
+export const PublicAvatar = styled.div`
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 18px;
+  background: ${({ theme }) => theme.LIGHT};
+`;

--- a/src/components/view-as/ViewAsPicker.tsx
+++ b/src/components/view-as/ViewAsPicker.tsx
@@ -1,0 +1,129 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import BottomModal from '@components/_common/bottom-modal/BottomModal';
+import ProfileImage from '@components/_common/profile-image/ProfileImage';
+import { Layout, Typo } from '@design-system';
+import { Connection } from '@models/api/friends';
+import { User } from '@models/user';
+import { getFriendList } from '@utils/apis/user';
+import * as S from './ViewAsPicker.styled';
+
+export type ViewAsSelection = { kind: 'tier'; tier: 'public' } | { kind: 'user'; username: string };
+
+interface ViewAsPickerProps {
+  visible: boolean;
+  onClose: () => void;
+  onSelect: (selection: ViewAsSelection) => void;
+}
+
+function ViewAsPicker({ visible, onClose, onSelect }: ViewAsPickerProps) {
+  const [t] = useTranslation('translation', { keyPrefix: 'view_as.picker' });
+  const [friends, setFriends] = useState<User[] | null>(null);
+
+  useEffect(() => {
+    if (!visible || friends !== null) return;
+    let cancelled = false;
+    getFriendList()
+      .then((res) => {
+        if (cancelled) return;
+        const list = Array.isArray((res as any).results)
+          ? (res as any).results
+          : (res as unknown as User[]);
+        setFriends(list);
+      })
+      .catch(() => {
+        if (!cancelled) setFriends([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [visible, friends]);
+
+  const closeFriends = (friends ?? []).filter(
+    (f) => f.connection_status === Connection.CLOSE_FRIEND,
+  );
+  const regularFriends = (friends ?? []).filter((f) => f.connection_status === Connection.FRIEND);
+
+  const handleSelectPublic = () => {
+    onSelect({ kind: 'tier', tier: 'public' });
+    onClose();
+  };
+
+  const handleSelectFriend = (username: string) => {
+    onSelect({ kind: 'user', username });
+    onClose();
+  };
+
+  return (
+    <BottomModal visible={visible} onClose={onClose} heightMode="full">
+      <Layout.FlexCol w="100%" p={16} gap={16}>
+        <Typo type="title-large" color="BLACK">
+          {t('title')}
+        </Typo>
+
+        {/* Public section */}
+        <Layout.FlexCol w="100%" gap={8}>
+          <Typo type="label-medium" color="MEDIUM_GRAY">
+            {t('public_section')}
+          </Typo>
+          <S.Row onClick={handleSelectPublic}>
+            <S.PublicAvatar>🌐</S.PublicAvatar>
+            <Typo type="body-medium" color="BLACK">
+              {t('public_label')}
+            </Typo>
+          </S.Row>
+        </Layout.FlexCol>
+
+        {/* Loading state */}
+        {friends === null && (
+          <Typo type="body-medium" color="MEDIUM_GRAY">
+            {t('loading')}
+          </Typo>
+        )}
+
+        {/* Close Friends section */}
+        {closeFriends.length > 0 && (
+          <Layout.FlexCol w="100%" gap={8}>
+            <Typo type="label-medium" color="MEDIUM_GRAY">
+              {t('close_friends_section')}
+            </Typo>
+            {closeFriends.map((f) => (
+              <S.Row key={f.id} onClick={() => handleSelectFriend(f.username)}>
+                <ProfileImage imageUrl={f.profile_image} username={f.username} size={32} />
+                <Typo type="body-medium" color="BLACK">
+                  {f.username}
+                </Typo>
+              </S.Row>
+            ))}
+          </Layout.FlexCol>
+        )}
+
+        {/* Regular Friends section */}
+        {regularFriends.length > 0 && (
+          <Layout.FlexCol w="100%" gap={8}>
+            <Typo type="label-medium" color="MEDIUM_GRAY">
+              {t('friends_section')}
+            </Typo>
+            {regularFriends.map((f) => (
+              <S.Row key={f.id} onClick={() => handleSelectFriend(f.username)}>
+                <ProfileImage imageUrl={f.profile_image} username={f.username} size={32} />
+                <Typo type="body-medium" color="BLACK">
+                  {f.username}
+                </Typo>
+              </S.Row>
+            ))}
+          </Layout.FlexCol>
+        )}
+
+        {/* Empty state when fetched but no friends */}
+        {friends !== null && closeFriends.length === 0 && regularFriends.length === 0 && (
+          <Typo type="body-medium" color="MEDIUM_GRAY">
+            {t('empty_friends')}
+          </Typo>
+        )}
+      </Layout.FlexCol>
+    </BottomModal>
+  );
+}
+
+export default ViewAsPicker;

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -526,7 +526,6 @@
                 "max_persona_limit": "Maximum 10 personas can be selected",
                 "edit": "Edit"
             },
-            "persona": "Persona",
             "persona_placeholder": "For eg: #Lurker",
             "interests": "Interests",
             "interests_placeholder": "For eg: #Climbing",
@@ -669,8 +668,8 @@
         "not_found_post": "This post does not exist.",
         "forbidden_comment": "This comment is not accessible.",
         "not_found_comment": "This comment does not exist.",
-        "responses_not_friend": "Only friends can view this response.",
-        "notes_not_friend": "Only friends can view this notes."
+        "responses_not_friend": "No responses to show.",
+        "notes_not_friend": "No posts to show."
     },
     "chats": {
         "title": "Chats",
@@ -741,7 +740,7 @@
                 "add_to_close_friends": "Add to close friends",
                 "success": "Added as close friends",
                 "error": "An error occurred"
-            }, 
+            },
             "latest_updates": {
                 "title": "{{username}} this week"
             }
@@ -1024,6 +1023,18 @@
             "close_friends": "Close Friends"
         },
         "disabled_tooltip": "Disabled in preview",
-        "entry_button_aria_label": "View profile as another audience"
+        "entry_button_aria_label": "View profile as another audience",
+        "entry_label": "View As",
+        "entry_label_long": "View As (Privacy)",
+        "banner_change": "Change",
+        "picker": {
+            "title": "Preview as",
+            "public_section": "Public",
+            "public_label": "Anyone (Public)",
+            "close_friends_section": "Close Friends",
+            "friends_section": "Friends",
+            "empty_friends": "You haven't added any friends yet.",
+            "loading": "Loading friends..."
+        }
     }
 }

--- a/src/i18n/locales/ko/translation.json
+++ b/src/i18n/locales/ko/translation.json
@@ -661,8 +661,8 @@
     "not_found_post": "존재하지 않는 게시글입니다.",
     "forbidden_comment": "접근이 불가능한 댓글입니다.",
     "not_found_comment": "존재하지 않는 댓글입니다.",
-    "responses_not_friend": "친구에게만 공개된 답변입니다.",
-    "notes_not_friend": "친구에게만 공개된 게시글입니다."
+    "responses_not_friend": "표시할 응답이 없어요.",
+    "notes_not_friend": "표시할 게시물이 없어요."
   },
   "chats": {
     "title": "채팅",
@@ -1014,6 +1014,18 @@
       "close_friends": "친한 친구"
     },
     "disabled_tooltip": "미리보기에서는 사용할 수 없어요",
-    "entry_button_aria_label": "다른 사람이 보는 내 프로필 미리보기"
+    "entry_label": "다른 사람으로 보기",
+    "entry_label_long": "다른 사람으로 보기 (공개 설정 미리보기)",
+    "entry_button_aria_label": "다른 사람이 보는 내 프로필 미리보기",
+    "banner_change": "변경",
+    "picker": {
+      "title": "이렇게 보기",
+      "public_section": "전체공개",
+      "public_label": "모두에게 보이는 모습",
+      "close_friends_section": "친한 친구",
+      "friends_section": "친구",
+      "empty_friends": "아직 친구를 추가하지 않았어요.",
+      "loading": "친구 목록을 불러오는 중..."
+    }
   }
 }

--- a/src/routes/UserPage.tsx
+++ b/src/routes/UserPage.tsx
@@ -21,8 +21,13 @@ import { useBoundStore } from '@stores/useBoundStore';
 import { UserSelector } from '@stores/user';
 import { readFriendCheckIn } from '@utils/apis/checkIn';
 
-function UserPage() {
-  const { username } = useParams();
+interface UserPageProps {
+  usernameOverride?: string;
+}
+
+function UserPage({ usernameOverride }: UserPageProps = {}) {
+  const params = useParams();
+  const username = usernameOverride ?? params.username;
   const { myProfile } = useBoundStore((state) => ({ myProfile: state.myProfile }));
   const isMyPage = username === myProfile?.username;
   const previewMode = useIsPreviewMode();
@@ -71,22 +76,26 @@ function UserPage() {
         key={username}
         style={{ height: '100vh', overflow: 'hidden', display: outlet ? 'none' : 'block' }}
       >
-        <UserHeader
-          username={username}
-          onClickMore={handleClickMore}
-          userId={userId}
-          unreadCount={unreadCount}
-        />
+        {!previewMode && (
+          <UserHeader
+            username={username}
+            onClickMore={handleClickMore}
+            userId={userId}
+            unreadCount={unreadCount}
+          />
+        )}
         <div
           id={MAIN_SCROLL_CONTAINER_ID}
           style={{
-            height: `calc(100vh - ${TITLE_HEADER_HEIGHT}px - ${BOTTOM_TABBAR_HEIGHT}px)`,
+            height: previewMode
+              ? `calc(100vh - ${BOTTOM_TABBAR_HEIGHT}px)`
+              : `calc(100vh - ${TITLE_HEADER_HEIGHT}px - ${BOTTOM_TABBAR_HEIGHT}px)`,
             overflowY: 'auto',
             WebkitOverflowScrolling: 'touch',
             msOverflowStyle: 'none',
             scrollbarWidth: 'none',
             width: '100%',
-            marginTop: `${TITLE_HEADER_HEIGHT}px`,
+            marginTop: previewMode ? 0 : `${TITLE_HEADER_HEIGHT}px`,
             paddingBottom: '24px', // 하단 여유 공간 추가
             position: 'relative',
           }}

--- a/src/routes/ViewAsPage.tsx
+++ b/src/routes/ViewAsPage.tsx
@@ -1,31 +1,54 @@
+import { useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
+import { useShallow } from 'zustand/react/shallow';
+import { UserPageContextProvider } from '@components/user-page/UserPage.context';
 import { PreviewModeProvider } from '@components/view-as/PreviewModeContext';
 import ViewAsBanner from '@components/view-as/ViewAsBanner';
-import ViewAsTabs from '@components/view-as/ViewAsTabs';
+import ViewAsPicker, { ViewAsSelection } from '@components/view-as/ViewAsPicker';
 import { Layout } from '@design-system';
 import { isVisibilityTier, VisibilityTier } from '@models/viewAs';
+import { useBoundStore } from '@stores/useBoundStore';
+import UserPage from './UserPage';
 
 const DEFAULT_TIER: VisibilityTier = 'public';
 
 function ViewAsPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const rawAs = searchParams.get('as');
-  const tier: VisibilityTier = isVisibilityTier(rawAs) ? rawAs : DEFAULT_TIER;
+  const rawUser = searchParams.get('view_as_user');
 
-  const handleSelect = (next: VisibilityTier) => {
-    setSearchParams({ as: next }, { replace: true });
+  const viewAsUser = rawUser && rawUser.trim() !== '' ? rawUser : null;
+  const tier: VisibilityTier | null = viewAsUser
+    ? null
+    : isVisibilityTier(rawAs)
+    ? rawAs
+    : DEFAULT_TIER;
+
+  const { myProfile } = useBoundStore(useShallow((state) => ({ myProfile: state.myProfile })));
+  const [pickerVisible, setPickerVisible] = useState(false);
+
+  const handleOpenPicker = () => setPickerVisible(true);
+  const handleClosePicker = () => setPickerVisible(false);
+
+  const handleSelect = (selection: ViewAsSelection) => {
+    if (selection.kind === 'tier') {
+      setSearchParams({ as: selection.tier }, { replace: true });
+    } else {
+      setSearchParams({ view_as_user: selection.username }, { replace: true });
+    }
   };
 
+  if (!myProfile?.username) return null;
+
   return (
-    <PreviewModeProvider viewAs={tier}>
+    <PreviewModeProvider viewAs={tier} viewAsUser={viewAsUser}>
       <Layout.FlexCol w="100%">
-        <ViewAsBanner tier={tier} />
-        <ViewAsTabs selected={tier} onSelect={handleSelect} />
-        {/* Phase 1 Task 1.6 replaces this placeholder with <UserPage /> */}
-        <Layout.FlexCol w="100%" p={16}>
-          <span>View As — {tier} (placeholder)</span>
-        </Layout.FlexCol>
+        <ViewAsBanner tier={tier} viewAsUser={viewAsUser} onChange={handleOpenPicker} />
+        <UserPageContextProvider usernameOverride={myProfile.username}>
+          <UserPage usernameOverride={myProfile.username} />
+        </UserPageContextProvider>
       </Layout.FlexCol>
+      <ViewAsPicker visible={pickerVisible} onClose={handleClosePicker} onSelect={handleSelect} />
     </PreviewModeProvider>
   );
 }

--- a/src/utils/apis/user.ts
+++ b/src/utils/apis/user.ts
@@ -19,11 +19,13 @@ import {
 } from '@models/api/user';
 import { Note, Response } from '@models/post';
 import { User, UserProfile } from '@models/user';
+import { VisibilityTier } from '@models/viewAs';
 import { resetBoundStores } from '@stores/resetSlices';
 import { useBoundStore } from '@stores/useBoundStore';
 import axios, { axiosFormDataInstance } from '@utils/apis/axios';
 import { setItemToSessionStorage } from '@utils/sessionStorage';
 import { getMe, syncTimeZone } from './my';
+import { withViewAs } from './withViewAs';
 
 export const signIn = ({
   signInInfo,
@@ -294,8 +296,13 @@ export const getFriendList = async (next?: string | null) => {
   return data;
 };
 
-export const getUserProfile = async (username: string) => {
-  const { data } = await axios.get<UserProfile>(`/user/${encodeURIComponent(username)}/profile/`);
+export const getUserProfile = async (
+  username: string,
+  viewAs?: VisibilityTier | null,
+  viewAsUser?: string | null,
+) => {
+  const url = withViewAs(`/user/${encodeURIComponent(username)}/profile/`, { viewAs, viewAsUser });
+  const { data } = await axios.get<UserProfile>(url);
   // Map friendship_level string to numeric connection_degree
   if (data.friendship_level && !data.connection_degree) {
     if (data.friendship_level === '2nd') {

--- a/src/utils/apis/withViewAs.ts
+++ b/src/utils/apis/withViewAs.ts
@@ -1,7 +1,31 @@
 import { VisibilityTier } from '@models/viewAs';
 
-export const withViewAs = (url: string, viewAs: VisibilityTier | null | undefined): string => {
-  if (!viewAs) return url;
-  const separator = url.includes('?') ? '&' : '?';
-  return `${url}${separator}view_as=${encodeURIComponent(viewAs)}`;
+interface ViewAsParams {
+  viewAs?: VisibilityTier | null;
+  viewAsUser?: string | null;
+}
+
+/**
+ * Append View As query parameters to a URL.
+ *
+ * - `viewAsUser` takes precedence: when set, appends `?view_as_user=<username>` only.
+ *   Backend uses that user as the shadow viewer (real friendship status, real mutuals).
+ * - `viewAs` (tier mode) is used when `viewAsUser` is not set: appends `?view_as=<tier>`.
+ *   Used for the synthetic "Public stranger" preview where there's no specific viewer.
+ * - When both are null/undefined, the URL is returned unchanged.
+ *
+ * The two modes are mutually exclusive on the backend — passing both is an error
+ * we silently avoid here.
+ */
+export const withViewAs = (url: string, params: ViewAsParams = {}): string => {
+  const { viewAs, viewAsUser } = params;
+  if (viewAsUser) {
+    const sep = url.includes('?') ? '&' : '?';
+    return `${url}${sep}view_as_user=${encodeURIComponent(viewAsUser)}`;
+  }
+  if (viewAs) {
+    const sep = url.includes('?') ? '&' : '?';
+    return `${url}${sep}view_as=${encodeURIComponent(viewAs)}`;
+  }
+  return url;
 };


### PR DESCRIPTION
## Summary

Phase 1 of the View As feature — the actual preview behavior. Stacked on top of #1258 (Phase 0 foundation, already merged).

- **Shadow-viewer architecture**: when the owner picks a specific friend, the backend renders the response *as if* that friend were the requester — real `connection_status`, real `mutuals`, real `friendship_level`, real `_passes_close_friends` cutoff. No mocking.
- **Friend picker** bottom sheet replaces the original tier tabs. Select Public (uses `wit_bot` as a non-friend proxy), or any specific friend. URL: `?view_as_user=<username>` for friends; `?view_as=public` for non-friend proxy.
- **Owner-page polish**: View As entry moved from header to a dedicated "View As (Privacy)" button next to "Edit Profile" above the Most Recent Check-In card. Owner-only check-in chrome (edit pencil + segmented archive chip) replaced with a single Archive (N) link in the bottom-right.
- **Empty-state strings** (`no_contents.notes_not_friend` / `responses_not_friend`) rephrased to remove the "only friends can view" leak and fix grammar.

Backend support for this PR ships in the matching backend PR.

Spec / Plan: `docs/superpowers/specs/2026-04-25-view-as-profile-preview-design.md` (§11 documents the pivot to per-user shadow viewer).

## Test plan

- [ ] `npx craco build` clean
- [ ] Backend running with the matching `feat/view-as-phase-1` branch
- [ ] On `/my`: tap "View As (Privacy)" → opens `/my/view-as` with bottom-sheet picker
- [ ] Picker shows Public + Close Friends + Friends sections with profile pics
- [ ] Selecting a friend → preview re-renders from that friend's perspective (mutuals, connection status, friend-status icons all real)
- [ ] Selecting Public → preview renders from `wit_bot`'s perspective (non-friend, no mutuals if no overlap, "Request" button visible)
- [ ] Banner ✕ → returns to `/my`
- [ ] No console errors at runtime