### PR TITLE
feat: #1268 public/private account setting for ver.Q

### DIFF
--- a/src/components/note/new-note-content/NewNoteContent.tsx
+++ b/src/components/note/new-note-content/NewNoteContent.tsx
@@ -218,7 +218,9 @@ function NewNoteContent({
                   onChange={() =>
                     handleChangeVisibility([
                       noteInfo.visibility[0] === PostVisibility.CLOSE_FRIENDS
-                        ? PostVisibility.FRIENDS
+                        ? myProfile?.is_public
+                          ? PostVisibility.PUBLIC
+                          : PostVisibility.FRIENDS
                         : PostVisibility.CLOSE_FRIENDS,
                     ])
                   }

--- a/src/components/profile/Profile.tsx
+++ b/src/components/profile/Profile.tsx
@@ -19,6 +19,7 @@ import { normalizeChipText } from '@models/chips';
 import { areFriends, isMyProfile, UserProfile } from '@models/user';
 import { useBoundStore } from '@stores/useBoundStore';
 import { UserSelector } from '@stores/user';
+import { editProfile } from '@utils/apis/my';
 import { getUserProfile } from '@utils/apis/user';
 import CheckInSection from '../check-in/CheckIn';
 import CategoryChip from './chip/CategoryChip';
@@ -67,6 +68,29 @@ function Profile({ user }: ProfileProps) {
   const handleClickEditProfile = (e: MouseEvent) => {
     e.stopPropagation();
     return navigate('/settings/edit-profile');
+  };
+
+  const { updateMyProfile } = useBoundStore((state) => ({
+    updateMyProfile: state.updateMyProfile,
+  }));
+
+  const handleTogglePublicPrivate = (e: MouseEvent) => {
+    e.stopPropagation();
+    if (!myProfile) return;
+
+    const goingPrivate = myProfile.is_public;
+    if (goingPrivate) {
+      // eslint-disable-next-line no-alert
+      const confirmed = window.confirm(t('switch_to_private_warning'));
+      if (!confirmed) return;
+    }
+
+    editProfile({
+      profile: { is_public: !myProfile.is_public },
+      onSuccess: (data) => {
+        updateMyProfile({ is_public: data.is_public });
+      },
+    });
   };
 
   useAsyncEffect(async () => {
@@ -325,15 +349,21 @@ function Profile({ user }: ProfileProps) {
             )}
         </>
       )}
-      {/* my-page actions: Edit Profile + View As (Privacy) — sit directly above the check-in card */}
+      {/* my-page actions: Edit Profile + Public/Private toggle (Q) or View As (W) */}
       {isMyPage && (
         <Layout.FlexRow w="100%" gap={8}>
           <PrimaryActionButton onClick={handleClickEditProfile}>
             {t('edit_profile')}
           </PrimaryActionButton>
-          <PrimaryActionButton onClick={() => navigate('/my/view-as')}>
-            {tViewAs('entry_label_long', { defaultValue: 'View As (Privacy)' })}
-          </PrimaryActionButton>
+          {featureFlags?.postsVerQ ? (
+            <PrimaryActionButton onClick={handleTogglePublicPrivate}>
+              {myProfile?.is_public ? t('public_account') : t('private_account')}
+            </PrimaryActionButton>
+          ) : (
+            <PrimaryActionButton onClick={() => navigate('/my/view-as')}>
+              {tViewAs('entry_label_long', { defaultValue: 'View As (Privacy)' })}
+            </PrimaryActionButton>
+          )}
         </Layout.FlexRow>
       )}
 

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -346,6 +346,9 @@
             }
         },
         "edit_profile": "Edit Profile",
+        "public_account": "Public Account",
+        "private_account": "Private Account",
+        "switch_to_private_warning": "All your public posts will become friends-only. This cannot be undone. Continue?",
         "interests": "Interests",
         "persona": "Persona",
         "see_more_details": "See more details",

--- a/src/i18n/locales/ko/translation.json
+++ b/src/i18n/locales/ko/translation.json
@@ -343,6 +343,9 @@
       }
     },
     "edit_profile": "프로필 수정",
+    "public_account": "공개 계정",
+    "private_account": "비공개 계정",
+    "switch_to_private_warning": "모든 공개 게시글이 친구 공개로 전환됩니다. 이 작업은 되돌릴 수 없습니다. 계속하시겠습니까?",
     "interests": "관심사",
     "persona": "페르소나",
     "see_more_details": "자세히 보기",

--- a/src/models/api/user.ts
+++ b/src/models/api/user.ts
@@ -136,6 +136,7 @@ export interface MyProfile extends User {
   follower_count: number;
   following_count: number;
   friend_count: number;
+  is_public: boolean;
 }
 
 export interface FriendRequest {

--- a/src/routes/notes/NewNote.tsx
+++ b/src/routes/notes/NewNote.tsx
@@ -2,7 +2,8 @@ import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 import NewNoteHeader from '@components/note/new-note-header/NewNoteHeader';
-import { NewNoteForm, ShareType } from '@models/post';
+import { NewNoteForm, PostVisibility, ShareType } from '@models/post';
+import { useBoundStore } from '@stores/useBoundStore';
 import { convertImagesToFiles } from '@utils/convertImageToFiles';
 import NewNoteContent from '../../components/note/new-note-content/NewNoteContent';
 import { MainScrollContainer } from '../Root';
@@ -10,6 +11,7 @@ import { MainScrollContainer } from '../Root';
 function NewNote() {
   const location = useLocation();
   const [t] = useTranslation('translation', { keyPrefix: 'notes.note_header' });
+  const { myProfile } = useBoundStore.getState();
 
   const status = location.state?.status;
   const shareType: ShareType | undefined = location.state?.shareType;
@@ -19,7 +21,10 @@ function NewNote() {
   const title = !isEditing ? t('new_note') : t('edit_note');
   const noteId = location.state?.post?.id || '';
   const content = location.state?.post?.content || '';
-  const visibility = location.state?.post?.visibility || ['friends'];
+  const defaultVisibility = myProfile?.is_public
+    ? [PostVisibility.PUBLIC]
+    : [PostVisibility.FRIENDS];
+  const visibility = location.state?.post?.visibility || defaultVisibility;
   const images = useMemo(() => location.state?.post?.images || [], [location.state?.post?.images]);
 
   const [noteInfo, setNoteInfo] = useState<NewNoteForm>({

--- a/src/routes/responses/NewResponse.tsx
+++ b/src/routes/responses/NewResponse.tsx
@@ -8,12 +8,13 @@ import { StyledNewResponsePrompt } from '@components/_common/prompt/PromptCard.s
 import VisibilityToggle from '@components/check-in/visibility-toggle/VisibilityToggle';
 import { markMissionCompleted } from '@components/share/MissionOfTheDay';
 import SubHeader from '@components/sub-header/SubHeader';
-import { TextArea, Typo } from '@design-system';
+import { CheckBox, Layout, TextArea, Typo } from '@design-system';
 import useAsyncEffect from '@hooks/useAsyncEffect';
 import { FetchState } from '@models/api/common';
 import { ComponentVisibility } from '@models/checkIn';
 import { PostVisibility, Question } from '@models/post';
 import { useBoundStore } from '@stores/useBoundStore';
+import { UserSelector } from '@stores/user';
 import { getQuestionDetail, patchResponse, postResponse } from '@utils/apis/question';
 import { getResponse } from '@utils/apis/responses';
 import { FlexRow, LayoutBase } from 'src/design-system/layouts';
@@ -29,15 +30,15 @@ function NewResponse() {
   const missionMode = location.state?.missionMode;
 
   const currentUser = useBoundStore.getState().myProfile;
+  const { featureFlags } = useBoundStore(UserSelector);
 
   const [t] = useTranslation('translation');
   const [question, setQuestion] = useState<FetchState<Question>>({ state: 'loading' });
 
   const [newResponse, setNewResponse] = useState<string | null>(null);
 
-  // NOTE: QUESTION_RESPONSE_FEATURE 플래그가 true인 경우만 해당 NewResponse 페이지 노출
-  // 따라서 Note처럼 공개 범위 분기가 필요없음
-  const [visibilityList, setVisibilityList] = useState<PostVisibility[]>([]);
+  const defaultVisibility = currentUser?.is_public ? PostVisibility.PUBLIC : PostVisibility.FRIENDS;
+  const [visibilityList, setVisibilityList] = useState<PostVisibility[]>([defaultVisibility]);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const title = !isEdit
@@ -197,7 +198,28 @@ function NewResponse() {
 
         {/** visibility options */}
         <FlexRow pt={15} w="100%" justifyContent="flex-end">
-          <VisibilityToggle value={currentVisibility} onChange={handleChangeVisibility} />
+          {featureFlags?.postsVerQ ? (
+            <Layout.FlexRow gap={6} alignItems="center">
+              <CheckBox
+                name={t('notes.close_friends_only') || 'Close friends only'}
+                checked={visibilityList[0] === PostVisibility.CLOSE_FRIENDS}
+                onChange={() =>
+                  setVisibilityList([
+                    visibilityList[0] === PostVisibility.CLOSE_FRIENDS
+                      ? currentUser?.is_public
+                        ? PostVisibility.PUBLIC
+                        : PostVisibility.FRIENDS
+                      : PostVisibility.CLOSE_FRIENDS,
+                  ])
+                }
+              />
+              <Typo type="label-medium" color="DARK_GRAY">
+                {t('notes.close_friends_only')}
+              </Typo>
+            </Layout.FlexRow>
+          ) : (
+            <VisibilityToggle value={currentVisibility} onChange={handleChangeVisibility} />
+          )}
         </FlexRow>
         <FlexRow w="100%" justifyContent="flex-end" pt={10}>
           <Typo type="label-medium" color="MEDIUM_GRAY" mt={8}>

--- a/src/utils/apis/my.ts
+++ b/src/utils/apis/my.ts
@@ -40,6 +40,7 @@ export const editProfile = ({
       | 'noti_period_days'
       | 'user_personas'
       | 'user_interests'
+      | 'is_public'
     >
   > & {
     profile_image?: File;


### PR DESCRIPTION
# Ver.Q Public/Private Account Setting

## Overview

Instagram-style account privacy toggle for ver.q users. Public accounts can create posts visible to everyone; private accounts are limited to friends/close friends.

## Account Setting

- Field: `User.is_public` (BooleanField, default `True`)
- Toggle: My Page button (replaces "View As" for ver.q)
- New accounts default to **public**

## Post Visibility by Account Type

| Account | Default visibility | Options |
|---------|-------------------|---------|
| Public | `public` | public, close friends |
| Private | `friends` | friends, close friends |

Applies to both Note and Response creation.

## Public-to-Private Conversion

When switching from public to private:
- All existing posts with `visibility=['public']` are bulk-converted to `['friends']`
- This is **irreversible** — switching back to public does not restore previous visibility
- User is warned via confirmation dialog before proceeding
- Conversion runs in the same DB transaction as the profile update

## Discover Feed Integration

`QDiscoverFeed` already filters by `visibility__contains=['public']`. No changes needed — when a user goes private, their posts automatically disappear from discover.

## API

`PATCH /api/q/user/me/` with `{ "is_public": false }` (or `true`)

The `is_public` field is included in `GET /api/q/user/me/` response.

## Files Changed

### Backend

| File | Change |
|------|--------|
| `account/models.py` | Added `is_public` field |
| `account/serializers.py` | Exposed `is_public` in `CurrentUserSerializer` |
| `account/views_q.py` | `QCurrentUserDetail.perform_update` — bulk converts posts on public-to-private switch |
| `account/migrations/0051-0053` | 3-step migration (nullable add, backfill, NOT NULL) |

### Frontend

| File | Change |
|------|--------|
| `models/api/user.ts` | Added `is_public` to `MyProfile` |
| `utils/apis/my.ts` | Added `is_public` to `editProfile` type |
| `components/profile/Profile.tsx` | Replaced "View As" button with public/private toggle (ver.q only) |
| `routes/notes/NewNote.tsx` | Default visibility based on `is_public` |
| `components/note/new-note-content/NewNoteContent.tsx` | Checkbox toggles between public/friends based on account type |
| `routes/responses/NewResponse.tsx` | Same visibility logic + ver.q checkbox UI |
| `i18n/locales/{en,ko}/translation.json` | Added translations |
