### PR TITLE
feat(surveys): Survey of the Day — bundled card, answer flow, results panels, Discover card

### DIFF
--- a/src/components/discover/SurveyResultsCard/SurveyResultsCard.styled.ts
+++ b/src/components/discover/SurveyResultsCard/SurveyResultsCard.styled.ts
@@ -1,0 +1,28 @@
+import styled from 'styled-components';
+
+import { Colors, Layout } from '@design-system';
+
+export const SurveyResultsWrapper = styled(Layout.FlexCol)`
+  background: linear-gradient(135deg, #0072ec 0%, #003e99 100%);
+  border-radius: 16px;
+  padding: 24px;
+  gap: 16px;
+  width: 100%;
+  box-sizing: border-box;
+`;
+
+export const ViewResultsButton = styled.div`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 24px;
+  border-radius: 8px;
+  background-color: ${Colors.WHITE};
+  cursor: pointer;
+  align-self: flex-start;
+  -webkit-tap-highlight-color: transparent;
+
+  &:active {
+    opacity: 0.8;
+  }
+`;

--- a/src/components/discover/SurveyResultsCard/SurveyResultsCard.tsx
+++ b/src/components/discover/SurveyResultsCard/SurveyResultsCard.tsx
@@ -1,0 +1,48 @@
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+
+import { Layout, Typo } from '@design-system';
+import i18n from '@i18n/index';
+import { SurveyResultsCardBody } from '@models/discover';
+
+import * as S from './SurveyResultsCard.styled';
+
+interface SurveyResultsCardProps {
+  card: SurveyResultsCardBody;
+}
+
+const pickLocalized = (en: string, ko: string) => (i18n.language === 'ko' ? ko : en);
+
+function SurveyResultsCard({ card }: SurveyResultsCardProps) {
+  const navigate = useNavigate();
+  const { t } = useTranslation('translation', { keyPrefix: 'surveys' });
+
+  const handleClick = () => {
+    navigate(`/surveys/${card.slug}/results`);
+  };
+
+  return (
+    <S.SurveyResultsWrapper>
+      <Layout.FlexCol gap={8} w="100%">
+        <Layout.LayoutBase style={{ opacity: 0.8 }}>
+          <Typo type="label-medium" color="WHITE">
+            {t('section_results_released')}
+          </Typo>
+        </Layout.LayoutBase>
+        <Typo type="title-medium" color="WHITE">
+          {pickLocalized(card.titleEn, card.titleKo)}
+        </Typo>
+        <Typo type="label-medium" color="WHITE">
+          {card.date}
+        </Typo>
+      </Layout.FlexCol>
+      <S.ViewResultsButton onClick={handleClick}>
+        <Typo type="label-large" color="PRIMARY" fontWeight={600}>
+          {t('view_results')}
+        </Typo>
+      </S.ViewResultsButton>
+    </S.SurveyResultsWrapper>
+  );
+}
+
+export default SurveyResultsCard;

--- a/src/components/header/side-menu/SideMenu.tsx
+++ b/src/components/header/side-menu/SideMenu.tsx
@@ -10,6 +10,7 @@ import { usePostAppMessage } from '@hooks/useAppMessage';
 
 const SIDE_MENU_LIST = [
   { key: 'my_profile', path: '/my' },
+  { key: 'survey_results', path: '/surveys' },
   { key: 'settings', path: '/settings' },
 ];
 

--- a/src/components/notification/NotificationItem/NotificationItem.tsx
+++ b/src/components/notification/NotificationItem/NotificationItem.tsx
@@ -23,9 +23,6 @@ function NotificationItem({ item }: NotificationItemProps) {
     if (notification_type === 'QuestionSuggest') {
       // Navigate to question suggestion page
       navigate('/suggest-questions');
-    } else if (notification_type === 'DailySurvey') {
-      // Open side menu
-      navigate('/my?show_side_menu=true');
     } else {
       navigate(redirect_url);
     }

--- a/src/components/share/SurveyOfTheDay.tsx
+++ b/src/components/share/SurveyOfTheDay.tsx
@@ -1,11 +1,9 @@
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
-import { mutate } from 'swr';
 
-import { SurveyAnswerForm } from '@components/survey/SurveyAnswerForm';
 import { Colors, Layout, Typo } from '@design-system';
-import { SURVEY_OF_THE_DAY_KEY, useSurveyOfTheDay } from '@hooks/useSurveyOfTheDay';
+import { useSurveyOfTheDay } from '@hooks/useSurveyOfTheDay';
 import i18n from '@i18n/index';
 import { useBoundStore } from '@stores/useBoundStore';
 
@@ -16,6 +14,18 @@ const Card = styled(Layout.FlexCol)`
   padding: 16px;
   gap: 12px;
   width: 100%;
+`;
+
+const PrimaryButton = styled.button`
+  align-self: flex-start;
+  border: 1px solid ${Colors.PRIMARY};
+  border-radius: 12px;
+  padding: 8px 16px;
+  background: ${Colors.PRIMARY};
+  color: ${Colors.WHITE};
+  font-size: 14px;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
 `;
 
 const ResultsLink = styled.button`
@@ -30,13 +40,27 @@ const ResultsLink = styled.button`
   -webkit-tap-highlight-color: transparent;
 `;
 
+const DRAFT_KEY_PREFIX = 'whoami_survey_draft_';
+
 const pickLocalized = (en: string, ko: string) => (i18n.language === 'ko' ? ko : en);
+
+const hasExistingDraft = (userId: number | null, slug: string): boolean => {
+  try {
+    const key = `${DRAFT_KEY_PREFIX}${userId ?? 'anon'}_${slug}`;
+    const raw = localStorage.getItem(key);
+    if (!raw) return false;
+    const parsed = JSON.parse(raw);
+    return parsed && parsed.answers && Object.keys(parsed.answers).length > 0;
+  } catch {
+    return false;
+  }
+};
 
 function SurveyOfTheDay() {
   const { t } = useTranslation('translation', { keyPrefix: 'surveys' });
   const { data, isLoading } = useSurveyOfTheDay();
   const navigate = useNavigate();
-  const openToast = useBoundStore((s) => s.openToast);
+  const userId = useBoundStore((s) => s.myProfile?.id ?? null);
 
   if (isLoading) return null;
   const survey = data?.survey;
@@ -58,6 +82,9 @@ function SurveyOfTheDay() {
     );
   }
 
+  const hasDraft = hasExistingDraft(userId, survey.slug);
+  const ctaLabel = hasDraft ? t('continue_survey') : t('start_survey');
+
   return (
     <Card>
       <Typo type="title-medium" color="BLACK">
@@ -68,14 +95,12 @@ function SurveyOfTheDay() {
           {pickLocalized(survey.description_en, survey.description_ko)}
         </Typo>
       )}
-      <SurveyAnswerForm
-        survey={survey}
-        onSubmitted={() => {
-          mutate(SURVEY_OF_THE_DAY_KEY);
-          openToast({ message: t('toast.submitted') });
-        }}
-        onError={(message) => openToast({ message })}
-      />
+      <Typo type="label-medium" color="DARK_GRAY">
+        {t('question_total', { total: survey.questions.length })}
+      </Typo>
+      <PrimaryButton type="button" onClick={() => navigate(`/surveys/${survey.slug}/answer`)}>
+        {ctaLabel}
+      </PrimaryButton>
     </Card>
   );
 }

--- a/src/components/share/SurveyOfTheDay.tsx
+++ b/src/components/share/SurveyOfTheDay.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
-import { Layout, Typo } from '@design-system';
+import { Typo } from '@design-system';
 import { useSurveyOfTheDay } from '@hooks/useSurveyOfTheDay';
 import i18n from '@i18n/index';
 import { useBoundStore } from '@stores/useBoundStore';
@@ -97,16 +97,11 @@ function SurveyOfTheDay() {
     <ColorCard>
       {sectionTitle}
       {surveyTitle}
-      {survey.description_en && (
-        <Typo type="title-medium" color="WHITE">
-          {pickLocalized(survey.description_en, survey.description_ko)}
-        </Typo>
-      )}
-      <Layout.FlexRow alignItems="center" gap={8}>
-        <Typo type="label-medium" color="WHITE">
-          {t('question_total', { total: survey.questions.length })}
-        </Typo>
-      </Layout.FlexRow>
+      <Typo type="label-medium" color="WHITE">
+        {survey.responder_count > 0
+          ? t('responder_count_today', { count: survey.responder_count })
+          : t('responder_count_today_zero')}
+      </Typo>
       <ActionButton onClick={() => navigate(`/surveys/${survey.slug}/answer`)}>
         <Typo type="label-large" fontWeight={600}>
           {ctaLabel}

--- a/src/components/share/SurveyOfTheDay.tsx
+++ b/src/components/share/SurveyOfTheDay.tsx
@@ -1,0 +1,83 @@
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
+import { mutate } from 'swr';
+
+import { SurveyAnswerForm } from '@components/survey/SurveyAnswerForm';
+import { Colors, Layout, Typo } from '@design-system';
+import { SURVEY_OF_THE_DAY_KEY, useSurveyOfTheDay } from '@hooks/useSurveyOfTheDay';
+import i18n from '@i18n/index';
+import { useBoundStore } from '@stores/useBoundStore';
+
+const Card = styled(Layout.FlexCol)`
+  border: 1px solid ${Colors.LIGHT_GRAY};
+  border-radius: 12px;
+  background: ${Colors.WHITE};
+  padding: 16px;
+  gap: 12px;
+  width: 100%;
+`;
+
+const ResultsLink = styled.button`
+  align-self: flex-start;
+  border: 1px solid ${Colors.LIGHT_GRAY};
+  border-radius: 8px;
+  padding: 4px 8px;
+  font-size: 14px;
+  background: ${Colors.WHITE};
+  color: ${Colors.PRIMARY};
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+`;
+
+const pickLocalized = (en: string, ko: string) => (i18n.language === 'ko' ? ko : en);
+
+function SurveyOfTheDay() {
+  const { t } = useTranslation('translation', { keyPrefix: 'surveys' });
+  const { data, isLoading } = useSurveyOfTheDay();
+  const navigate = useNavigate();
+  const openToast = useBoundStore((s) => s.openToast);
+
+  if (isLoading) return null;
+  const survey = data?.survey;
+  if (!survey) return null;
+
+  if (survey.user_has_responded) {
+    return (
+      <Card>
+        <Typo type="title-medium" color="BLACK">
+          {pickLocalized(survey.title_en, survey.title_ko)}
+        </Typo>
+        <Typo type="body-medium" color="DARK_GRAY">
+          {t('thanks_results_tomorrow')}
+        </Typo>
+        <ResultsLink type="button" onClick={() => navigate(`/surveys/${survey.slug}/results`)}>
+          {t('view_results')}
+        </ResultsLink>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <Typo type="title-medium" color="BLACK">
+        {pickLocalized(survey.title_en, survey.title_ko)}
+      </Typo>
+      {survey.description_en && (
+        <Typo type="body-medium" color="DARK_GRAY">
+          {pickLocalized(survey.description_en, survey.description_ko)}
+        </Typo>
+      )}
+      <SurveyAnswerForm
+        survey={survey}
+        onSubmitted={() => {
+          mutate(SURVEY_OF_THE_DAY_KEY);
+          openToast({ message: t('toast.submitted') });
+        }}
+        onError={(message) => openToast({ message })}
+      />
+    </Card>
+  );
+}
+
+export default SurveyOfTheDay;

--- a/src/components/share/SurveyOfTheDay.tsx
+++ b/src/components/share/SurveyOfTheDay.tsx
@@ -2,42 +2,38 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
-import { Colors, Layout, Typo } from '@design-system';
+import { Layout, Typo } from '@design-system';
 import { useSurveyOfTheDay } from '@hooks/useSurveyOfTheDay';
 import i18n from '@i18n/index';
 import { useBoundStore } from '@stores/useBoundStore';
 
-const Card = styled(Layout.FlexCol)`
-  border: 1px solid ${Colors.LIGHT_GRAY};
-  border-radius: 12px;
-  background: ${Colors.WHITE};
-  padding: 16px;
-  gap: 12px;
+const SURVEY_GRADIENT = 'linear-gradient(135deg, #0072EC 0%, #003E99 100%)';
+
+const ColorCard = styled.div`
   width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 20px;
+  border-radius: 16px;
+  background: ${SURVEY_GRADIENT};
+  text-align: left;
 `;
 
-const PrimaryButton = styled.button`
-  align-self: flex-start;
-  border: 1px solid ${Colors.PRIMARY};
+const ActionButton = styled.div`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 24px;
   border-radius: 12px;
-  padding: 8px 16px;
-  background: ${Colors.PRIMARY};
-  color: ${Colors.WHITE};
-  font-size: 14px;
+  background-color: rgba(255, 255, 255, 0.95);
   cursor: pointer;
-  -webkit-tap-highlight-color: transparent;
-`;
-
-const ResultsLink = styled.button`
   align-self: flex-start;
-  border: 1px solid ${Colors.LIGHT_GRAY};
-  border-radius: 8px;
-  padding: 4px 8px;
-  font-size: 14px;
-  background: ${Colors.WHITE};
-  color: ${Colors.PRIMARY};
-  cursor: pointer;
   -webkit-tap-highlight-color: transparent;
+
+  &:active {
+    opacity: 0.8;
+  }
 `;
 
 const DRAFT_KEY_PREFIX = 'whoami_survey_draft_';
@@ -66,19 +62,31 @@ function SurveyOfTheDay() {
   const survey = data?.survey;
   if (!survey) return null;
 
+  const sectionTitle = (
+    <Typo type="head-line" color="WHITE" bold>
+      {t('section_title')}
+    </Typo>
+  );
+  const surveyTitle = (
+    <Typo type="title-medium" color="WHITE">
+      {pickLocalized(survey.title_en, survey.title_ko)}
+    </Typo>
+  );
+
   if (survey.user_has_responded) {
     return (
-      <Card>
-        <Typo type="title-medium" color="BLACK">
-          {pickLocalized(survey.title_en, survey.title_ko)}
-        </Typo>
-        <Typo type="body-medium" color="DARK_GRAY">
+      <ColorCard>
+        {sectionTitle}
+        {surveyTitle}
+        <Typo type="title-medium" color="WHITE">
           {t('thanks_results_tomorrow')}
         </Typo>
-        <ResultsLink type="button" onClick={() => navigate(`/surveys/${survey.slug}/results`)}>
-          {t('view_results')}
-        </ResultsLink>
-      </Card>
+        <ActionButton onClick={() => navigate(`/surveys/${survey.slug}/results`)}>
+          <Typo type="label-large" fontWeight={600}>
+            {t('view_results')}
+          </Typo>
+        </ActionButton>
+      </ColorCard>
     );
   }
 
@@ -86,22 +94,25 @@ function SurveyOfTheDay() {
   const ctaLabel = hasDraft ? t('continue_survey') : t('start_survey');
 
   return (
-    <Card>
-      <Typo type="title-medium" color="BLACK">
-        {pickLocalized(survey.title_en, survey.title_ko)}
-      </Typo>
+    <ColorCard>
+      {sectionTitle}
+      {surveyTitle}
       {survey.description_en && (
-        <Typo type="body-medium" color="DARK_GRAY">
+        <Typo type="title-medium" color="WHITE">
           {pickLocalized(survey.description_en, survey.description_ko)}
         </Typo>
       )}
-      <Typo type="label-medium" color="DARK_GRAY">
-        {t('question_total', { total: survey.questions.length })}
-      </Typo>
-      <PrimaryButton type="button" onClick={() => navigate(`/surveys/${survey.slug}/answer`)}>
-        {ctaLabel}
-      </PrimaryButton>
-    </Card>
+      <Layout.FlexRow alignItems="center" gap={8}>
+        <Typo type="label-medium" color="WHITE">
+          {t('question_total', { total: survey.questions.length })}
+        </Typo>
+      </Layout.FlexRow>
+      <ActionButton onClick={() => navigate(`/surveys/${survey.slug}/answer`)}>
+        <Typo type="label-large" fontWeight={600}>
+          {ctaLabel}
+        </Typo>
+      </ActionButton>
+    </ColorCard>
   );
 }
 

--- a/src/components/survey/Chip.styled.ts
+++ b/src/components/survey/Chip.styled.ts
@@ -1,0 +1,21 @@
+import styled, { css } from 'styled-components';
+
+import { Colors } from '@design-system';
+
+export const Chip = styled.button<{ selected: boolean }>`
+  border-radius: 8px;
+  padding: 4px 8px;
+  font-size: 14px;
+  border: 1px solid ${Colors.LIGHT_GRAY};
+  background: ${Colors.WHITE};
+  color: ${Colors.BLACK};
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  ${({ selected }) =>
+    selected &&
+    css`
+      color: ${Colors.PRIMARY};
+      background: #f3e8ff;
+      border-color: ${Colors.PRIMARY};
+    `}
+`;

--- a/src/components/survey/ChoiceChips.tsx
+++ b/src/components/survey/ChoiceChips.tsx
@@ -1,0 +1,51 @@
+import styled from 'styled-components';
+
+import { Layout } from '@design-system';
+
+import { Chip } from './Chip.styled';
+
+const ChipsRow = styled(Layout.FlexRow)`
+  flex-wrap: wrap;
+  gap: 8px;
+`;
+
+interface ChoiceChipsProps {
+  options: { value: number; label: string }[];
+  multi: boolean;
+  selected: number | number[] | null;
+  onSelect: (v: number | number[]) => void;
+}
+
+export function ChoiceChips({ options, multi, selected, onSelect }: ChoiceChipsProps) {
+  const isSelected = (value: number) => {
+    if (Array.isArray(selected)) return selected.includes(value);
+    return selected === value;
+  };
+
+  const handleClick = (value: number) => {
+    if (multi) {
+      const current = Array.isArray(selected) ? selected : [];
+      const next = current.includes(value)
+        ? current.filter((v) => v !== value)
+        : [...current, value];
+      onSelect(next);
+    } else {
+      onSelect(value);
+    }
+  };
+
+  return (
+    <ChipsRow>
+      {options.map((o) => (
+        <Chip
+          key={o.value}
+          type="button"
+          selected={isSelected(o.value)}
+          onClick={() => handleClick(o.value)}
+        >
+          {o.label}
+        </Chip>
+      ))}
+    </ChipsRow>
+  );
+}

--- a/src/components/survey/FreeTextInput.tsx
+++ b/src/components/survey/FreeTextInput.tsx
@@ -1,0 +1,32 @@
+import styled from 'styled-components';
+
+import { Colors } from '@design-system';
+
+const TextArea = styled.textarea`
+  width: 100%;
+  min-height: 96px;
+  border: 1px solid ${Colors.LIGHT_GRAY};
+  border-radius: 8px;
+  padding: 12px;
+  font-size: 14px;
+  resize: vertical;
+  font-family: inherit;
+  color: ${Colors.BLACK};
+  background: ${Colors.WHITE};
+  &:focus {
+    outline: none;
+    border-color: ${Colors.PRIMARY};
+  }
+`;
+
+interface Props {
+  value: string;
+  onChange: (next: string) => void;
+  placeholder?: string;
+}
+
+export function FreeTextInput({ value, onChange, placeholder }: Props) {
+  return (
+    <TextArea value={value} placeholder={placeholder} onChange={(e) => onChange(e.target.value)} />
+  );
+}

--- a/src/components/survey/LikertChips.tsx
+++ b/src/components/survey/LikertChips.tsx
@@ -1,0 +1,43 @@
+import styled from 'styled-components';
+
+import { Layout, Typo } from '@design-system';
+
+import { Chip } from './Chip.styled';
+
+const ChipsRow = styled(Layout.FlexRow)`
+  flex-wrap: wrap;
+  gap: 8px;
+`;
+
+interface LikertChipsProps {
+  selected: number | null;
+  onSelect: (v: number) => void;
+  lowLabel?: string;
+  highLabel?: string;
+}
+
+const VALUES = [1, 2, 3, 4, 5];
+
+export function LikertChips({ selected, onSelect, lowLabel, highLabel }: LikertChipsProps) {
+  return (
+    <Layout.FlexCol gap={4} w="100%">
+      <ChipsRow>
+        {VALUES.map((v) => (
+          <Chip key={v} type="button" selected={selected === v} onClick={() => onSelect(v)}>
+            {v}
+          </Chip>
+        ))}
+      </ChipsRow>
+      {(lowLabel || highLabel) && (
+        <Layout.FlexRow w="100%" justifyContent="space-between">
+          <Typo type="label-medium" color="MEDIUM_GRAY">
+            {lowLabel}
+          </Typo>
+          <Typo type="label-medium" color="MEDIUM_GRAY">
+            {highLabel}
+          </Typo>
+        </Layout.FlexRow>
+      )}
+    </Layout.FlexCol>
+  );
+}

--- a/src/components/survey/SuppressedBucketPlaceholder.tsx
+++ b/src/components/survey/SuppressedBucketPlaceholder.tsx
@@ -16,6 +16,7 @@ const REASON_TO_KEY: Record<NonNullable<SuppressedReason>, string> = {
   too_few_responders: 'reasons.too_few_responders',
   too_few_close_friends: 'reasons.too_few_close_friends',
   delta_too_small: 'reasons.delta_too_small',
+  view_friend_disabled: 'reasons.view_friend_disabled',
 };
 
 interface Props {

--- a/src/components/survey/SuppressedBucketPlaceholder.tsx
+++ b/src/components/survey/SuppressedBucketPlaceholder.tsx
@@ -1,0 +1,35 @@
+import { useTranslation } from 'react-i18next';
+import styled from 'styled-components';
+
+import { PlaceholderWrapper } from '@components/profile/placeholders/Placeholder.styled';
+import { Colors, Typo } from '@design-system';
+import { SuppressedReason } from '@models/survey';
+
+const Wrapper = styled(PlaceholderWrapper)`
+  padding: 16px;
+  border-color: ${Colors.LIGHT_GRAY};
+  width: 100%;
+`;
+
+const REASON_TO_KEY: Record<NonNullable<SuppressedReason>, string> = {
+  too_few_friends: 'reasons.too_few_friends',
+  too_few_responders: 'reasons.too_few_responders',
+  too_few_close_friends: 'reasons.too_few_close_friends',
+  delta_too_small: 'reasons.delta_too_small',
+};
+
+interface Props {
+  reason: SuppressedReason;
+}
+
+export function SuppressedBucketPlaceholder({ reason }: Props) {
+  const { t } = useTranslation('translation', { keyPrefix: 'surveys' });
+  if (!reason) return null;
+  return (
+    <Wrapper>
+      <Typo type="body-medium" color="DARK_GRAY">
+        {t(REASON_TO_KEY[reason])}
+      </Typo>
+    </Wrapper>
+  );
+}

--- a/src/components/survey/SurveyAnswerForm.tsx
+++ b/src/components/survey/SurveyAnswerForm.tsx
@@ -1,0 +1,97 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import styled from 'styled-components';
+
+import { Colors, Layout, Typo } from '@design-system';
+import i18n from '@i18n/index';
+import { Survey, SurveyAnswerInput } from '@models/survey';
+import { submitSurveyResponse } from '@utils/apis/survey';
+
+import { ChoiceChips } from './ChoiceChips';
+import { LikertChips } from './LikertChips';
+
+const SubmitButton = styled.button<{ disabled: boolean }>`
+  margin-top: 12px;
+  align-self: flex-start;
+  border: 1px solid ${({ disabled }) => (disabled ? Colors.LIGHT_GRAY : Colors.PRIMARY)};
+  border-radius: 12px;
+  padding: 8px 16px;
+  background: ${({ disabled }) => (disabled ? Colors.LIGHT : Colors.PRIMARY)};
+  color: ${({ disabled }) => (disabled ? Colors.MEDIUM_GRAY : Colors.WHITE)};
+  cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
+  -webkit-tap-highlight-color: transparent;
+`;
+
+interface SurveyAnswerFormProps {
+  survey: Survey;
+  onSubmitted: () => void;
+  onError?: (message: string) => void;
+}
+
+const pickLocalized = (en: string, ko: string) => (i18n.language === 'ko' ? ko : en);
+
+export function SurveyAnswerForm({ survey, onSubmitted, onError }: SurveyAnswerFormProps) {
+  const { t } = useTranslation('translation', { keyPrefix: 'surveys' });
+  const [draft, setDraft] = useState<Record<number, number | number[]>>({});
+  const [submitting, setSubmitting] = useState(false);
+
+  const allAnswered =
+    survey.questions.length > 0 &&
+    survey.questions.every((q) => {
+      const v = draft[q.id];
+      if (v === undefined) return false;
+      if (Array.isArray(v)) return v.length > 0;
+      return true;
+    });
+
+  const handleSubmit = async () => {
+    if (!allAnswered || submitting) return;
+    const answers: SurveyAnswerInput[] = survey.questions.map((q) => ({
+      question_id: q.id,
+      value: draft[q.id],
+    }));
+    setSubmitting(true);
+    try {
+      await submitSurveyResponse(survey.slug, answers);
+      onSubmitted();
+    } catch (e) {
+      if (onError) onError(t('toast.submit_failed'));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Layout.FlexCol gap={12} w="100%">
+      {survey.questions.map((q) => (
+        <Layout.FlexCol key={q.id} gap={6} w="100%">
+          <Typo type="body-medium" color="BLACK">
+            {pickLocalized(q.prompt_en, q.prompt_ko)}
+          </Typo>
+          {survey.type === 'likert_5' && (
+            <LikertChips
+              selected={(draft[q.id] as number | undefined) ?? null}
+              onSelect={(v) => setDraft((d) => ({ ...d, [q.id]: v }))}
+              lowLabel={pickLocalized(q.low_label_en, q.low_label_ko)}
+              highLabel={pickLocalized(q.high_label_en, q.high_label_ko)}
+            />
+          )}
+          {(survey.type === 'single_choice' || survey.type === 'multi_choice') && (
+            <ChoiceChips
+              options={q.options.map((o) => ({
+                value: o.value,
+                label: pickLocalized(o.label_en, o.label_ko),
+              }))}
+              multi={survey.type === 'multi_choice'}
+              selected={draft[q.id] ?? null}
+              onSelect={(v) => setDraft((d) => ({ ...d, [q.id]: v }))}
+            />
+          )}
+        </Layout.FlexCol>
+      ))}
+      <SubmitButton type="button" onClick={handleSubmit} disabled={!allAnswered || submitting}>
+        {t('submit')}
+      </SubmitButton>
+    </Layout.FlexCol>
+  );
+}

--- a/src/components/survey/SurveyAnswerForm.tsx
+++ b/src/components/survey/SurveyAnswerForm.tsx
@@ -1,8 +1,9 @@
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
 import { Colors, Layout, Typo } from '@design-system';
+import { useSurveyDraft } from '@hooks/useSurveyDraft';
 import i18n from '@i18n/index';
 import { Survey, SurveyAnswerInput } from '@models/survey';
 import { submitSurveyResponse } from '@utils/apis/survey';
@@ -10,16 +11,47 @@ import { submitSurveyResponse } from '@utils/apis/survey';
 import { ChoiceChips } from './ChoiceChips';
 import { LikertChips } from './LikertChips';
 
-const SubmitButton = styled.button<{ disabled: boolean }>`
-  margin-top: 12px;
-  align-self: flex-start;
-  border: 1px solid ${({ disabled }) => (disabled ? Colors.LIGHT_GRAY : Colors.PRIMARY)};
+const ProgressBarTrack = styled.div`
+  width: 100%;
+  height: 4px;
+  background: ${Colors.LIGHT_GRAY};
+  border-radius: 2px;
+  overflow: hidden;
+`;
+
+const ProgressBarFill = styled.div<{ pct: number }>`
+  height: 100%;
+  width: ${({ pct }) => pct}%;
+  background: ${Colors.PRIMARY};
+  border-radius: 2px;
+  transition: width 200ms ease-out;
+`;
+
+const NavRow = styled(Layout.FlexRow)`
+  width: 100%;
+  justify-content: space-between;
+  margin-top: 16px;
+`;
+
+const NavButton = styled.button<{ disabled: boolean; primary?: boolean }>`
+  border: 1px solid
+    ${({ disabled, primary }) => {
+      if (disabled) return Colors.LIGHT_GRAY;
+      return primary ? Colors.PRIMARY : Colors.LIGHT_GRAY;
+    }};
   border-radius: 12px;
   padding: 8px 16px;
-  background: ${({ disabled }) => (disabled ? Colors.LIGHT : Colors.PRIMARY)};
-  color: ${({ disabled }) => (disabled ? Colors.MEDIUM_GRAY : Colors.WHITE)};
+  background: ${({ disabled, primary }) => {
+    if (disabled) return Colors.LIGHT;
+    return primary ? Colors.PRIMARY : Colors.WHITE;
+  }};
+  color: ${({ disabled, primary }) => {
+    if (disabled) return Colors.MEDIUM_GRAY;
+    return primary ? Colors.WHITE : Colors.BLACK;
+  }};
   cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
   -webkit-tap-highlight-color: transparent;
+  font-size: 14px;
 `;
 
 interface SurveyAnswerFormProps {
@@ -30,68 +62,125 @@ interface SurveyAnswerFormProps {
 
 const pickLocalized = (en: string, ko: string) => (i18n.language === 'ko' ? ko : en);
 
+const isAnswered = (value: number | number[] | undefined) => {
+  if (value === undefined) return false;
+  if (Array.isArray(value)) return value.length > 0;
+  return true;
+};
+
 export function SurveyAnswerForm({ survey, onSubmitted, onError }: SurveyAnswerFormProps) {
   const { t } = useTranslation('translation', { keyPrefix: 'surveys' });
-  const [draft, setDraft] = useState<Record<number, number | number[]>>({});
+  const { answers, setAnswer, clear, hydrated } = useSurveyDraft(survey.slug);
+  const [index, setIndex] = useState(0);
   const [submitting, setSubmitting] = useState(false);
 
-  const allAnswered =
-    survey.questions.length > 0 &&
-    survey.questions.every((q) => {
-      const v = draft[q.id];
-      if (v === undefined) return false;
-      if (Array.isArray(v)) return v.length > 0;
-      return true;
-    });
+  const questions = useMemo(
+    () => [...survey.questions].sort((a, b) => a.order - b.order),
+    [survey.questions],
+  );
+  const total = questions.length;
+
+  // After hydration, jump to the first unanswered question (or last if all answered)
+  useEffect(() => {
+    if (!hydrated || total === 0) return;
+    const firstUnanswered = questions.findIndex((q) => !isAnswered(answers[q.id]));
+    setIndex(firstUnanswered === -1 ? total - 1 : firstUnanswered);
+    // intentionally only run on first hydration
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hydrated]);
+
+  if (total === 0) return null;
+
+  const currentQuestion = questions[index];
+  const currentValue = answers[currentQuestion.id];
+  const currentAnswered = isAnswered(currentValue);
+  const allAnswered = questions.every((q) => isAnswered(answers[q.id]));
+  const isLast = index === total - 1;
+
+  const handleNext = () => {
+    if (!currentAnswered) return;
+    if (!isLast) setIndex((i) => i + 1);
+  };
+
+  const handleBack = () => {
+    if (index > 0) setIndex((i) => i - 1);
+  };
 
   const handleSubmit = async () => {
     if (!allAnswered || submitting) return;
-    const answers: SurveyAnswerInput[] = survey.questions.map((q) => ({
-      question_id: q.id,
-      value: draft[q.id],
-    }));
     setSubmitting(true);
+    const payload: SurveyAnswerInput[] = questions.map((q) => ({
+      question_id: q.id,
+      value: answers[q.id],
+    }));
     try {
-      await submitSurveyResponse(survey.slug, answers);
+      await submitSurveyResponse(survey.slug, payload);
+      clear();
       onSubmitted();
-    } catch (e) {
+    } catch {
       if (onError) onError(t('toast.submit_failed'));
     } finally {
       setSubmitting(false);
     }
   };
 
+  const progressPct = ((index + 1) / total) * 100;
+
   return (
     <Layout.FlexCol gap={12} w="100%">
-      {survey.questions.map((q) => (
-        <Layout.FlexCol key={q.id} gap={6} w="100%">
-          <Typo type="body-medium" color="BLACK">
-            {pickLocalized(q.prompt_en, q.prompt_ko)}
-          </Typo>
-          {survey.type === 'likert_5' && (
-            <LikertChips
-              selected={(draft[q.id] as number | undefined) ?? null}
-              onSelect={(v) => setDraft((d) => ({ ...d, [q.id]: v }))}
-              lowLabel={pickLocalized(q.low_label_en, q.low_label_ko)}
-              highLabel={pickLocalized(q.high_label_en, q.high_label_ko)}
-            />
-          )}
-          {(survey.type === 'single_choice' || survey.type === 'multi_choice') && (
-            <ChoiceChips
-              options={q.options.map((o) => ({
-                value: o.value,
-                label: pickLocalized(o.label_en, o.label_ko),
-              }))}
-              multi={survey.type === 'multi_choice'}
-              selected={draft[q.id] ?? null}
-              onSelect={(v) => setDraft((d) => ({ ...d, [q.id]: v }))}
-            />
-          )}
-        </Layout.FlexCol>
-      ))}
-      <SubmitButton type="button" onClick={handleSubmit} disabled={!allAnswered || submitting}>
-        {t('submit')}
-      </SubmitButton>
+      <Layout.FlexCol gap={6} w="100%">
+        <Typo type="label-medium" color="DARK_GRAY">
+          {t('question_progress', { current: index + 1, total })}
+        </Typo>
+        <ProgressBarTrack>
+          <ProgressBarFill pct={progressPct} />
+        </ProgressBarTrack>
+      </Layout.FlexCol>
+
+      <Layout.FlexCol gap={6} w="100%">
+        <Typo type="title-medium" color="BLACK">
+          {pickLocalized(currentQuestion.prompt_en, currentQuestion.prompt_ko)}
+        </Typo>
+        {survey.type === 'likert_5' && (
+          <LikertChips
+            selected={(currentValue as number | undefined) ?? null}
+            onSelect={(v) => setAnswer(currentQuestion.id, v)}
+            lowLabel={pickLocalized(currentQuestion.low_label_en, currentQuestion.low_label_ko)}
+            highLabel={pickLocalized(currentQuestion.high_label_en, currentQuestion.high_label_ko)}
+          />
+        )}
+        {(survey.type === 'single_choice' || survey.type === 'multi_choice') && (
+          <ChoiceChips
+            options={currentQuestion.options.map((o) => ({
+              value: o.value,
+              label: pickLocalized(o.label_en, o.label_ko),
+            }))}
+            multi={survey.type === 'multi_choice'}
+            selected={currentValue ?? null}
+            onSelect={(v) => setAnswer(currentQuestion.id, v)}
+          />
+        )}
+      </Layout.FlexCol>
+
+      <NavRow>
+        <NavButton type="button" onClick={handleBack} disabled={index === 0}>
+          {t('back')}
+        </NavButton>
+        {isLast ? (
+          <NavButton
+            type="button"
+            primary
+            onClick={handleSubmit}
+            disabled={!allAnswered || submitting}
+          >
+            {t('submit')}
+          </NavButton>
+        ) : (
+          <NavButton type="button" primary onClick={handleNext} disabled={!currentAnswered}>
+            {t('next')}
+          </NavButton>
+        )}
+      </NavRow>
     </Layout.FlexCol>
   );
 }

--- a/src/components/survey/SurveyAnswerForm.tsx
+++ b/src/components/survey/SurveyAnswerForm.tsx
@@ -166,7 +166,7 @@ export function SurveyAnswerForm({ survey, onSubmitted, onError }: SurveyAnswerF
           <FreeTextInput
             value={(currentValue as string | undefined) ?? ''}
             onChange={(v) => setAnswer(currentQuestion.id, v)}
-            placeholder={t('free_text_placeholder')}
+            placeholder={t('free_text_placeholder') ?? undefined}
           />
         )}
       </Layout.FlexCol>

--- a/src/components/survey/SurveyAnswerForm.tsx
+++ b/src/components/survey/SurveyAnswerForm.tsx
@@ -9,6 +9,7 @@ import { Survey, SurveyAnswerInput } from '@models/survey';
 import { submitSurveyResponse } from '@utils/apis/survey';
 
 import { ChoiceChips } from './ChoiceChips';
+import { FreeTextInput } from './FreeTextInput';
 import { LikertChips } from './LikertChips';
 
 const ProgressBarTrack = styled.div`
@@ -62,9 +63,10 @@ interface SurveyAnswerFormProps {
 
 const pickLocalized = (en: string, ko: string) => (i18n.language === 'ko' ? ko : en);
 
-const isAnswered = (value: number | number[] | undefined) => {
-  if (value === undefined) return false;
+const isAnswered = (value: number | number[] | string | undefined) => {
+  if (value === undefined || value === null) return false;
   if (Array.isArray(value)) return value.length > 0;
+  if (typeof value === 'string') return value.trim().length > 0;
   return true;
 };
 
@@ -141,7 +143,7 @@ export function SurveyAnswerForm({ survey, onSubmitted, onError }: SurveyAnswerF
         <Typo type="title-medium" color="BLACK">
           {pickLocalized(currentQuestion.prompt_en, currentQuestion.prompt_ko)}
         </Typo>
-        {survey.type === 'likert_5' && (
+        {currentQuestion.type === 'likert_5' && (
           <LikertChips
             selected={(currentValue as number | undefined) ?? null}
             onSelect={(v) => setAnswer(currentQuestion.id, v)}
@@ -149,15 +151,22 @@ export function SurveyAnswerForm({ survey, onSubmitted, onError }: SurveyAnswerF
             highLabel={pickLocalized(currentQuestion.high_label_en, currentQuestion.high_label_ko)}
           />
         )}
-        {(survey.type === 'single_choice' || survey.type === 'multi_choice') && (
+        {(currentQuestion.type === 'single_choice' || currentQuestion.type === 'multi_choice') && (
           <ChoiceChips
             options={currentQuestion.options.map((o) => ({
               value: o.value,
               label: pickLocalized(o.label_en, o.label_ko),
             }))}
-            multi={survey.type === 'multi_choice'}
-            selected={currentValue ?? null}
+            multi={currentQuestion.type === 'multi_choice'}
+            selected={(currentValue as number | number[] | undefined) ?? null}
             onSelect={(v) => setAnswer(currentQuestion.id, v)}
+          />
+        )}
+        {currentQuestion.type === 'free_text' && (
+          <FreeTextInput
+            value={(currentValue as string | undefined) ?? ''}
+            onChange={(v) => setAnswer(currentQuestion.id, v)}
+            placeholder={t('free_text_placeholder')}
           />
         )}
       </Layout.FlexCol>

--- a/src/components/survey/SurveyResultsBucket.tsx
+++ b/src/components/survey/SurveyResultsBucket.tsx
@@ -1,0 +1,56 @@
+import { useTranslation } from 'react-i18next';
+import styled from 'styled-components';
+
+import { Colors, Layout, Typo } from '@design-system';
+import { BucketResult, SuppressedReason } from '@models/survey';
+
+import { SuppressedBucketPlaceholder } from './SuppressedBucketPlaceholder';
+import { SurveyResultsChart } from './SurveyResultsChart';
+
+const Section = styled(Layout.FlexCol)`
+  width: 100%;
+  gap: 8px;
+  border: 1px solid ${Colors.LIGHT_GRAY};
+  border-radius: 12px;
+  background: ${Colors.WHITE};
+  padding: 16px;
+`;
+
+interface Props {
+  title: string;
+  available: boolean;
+  reason: SuppressedReason;
+  bucket: BucketResult | null;
+  interpretation?: string;
+}
+
+export function SurveyResultsBucket({ title, available, reason, bucket, interpretation }: Props) {
+  const { t } = useTranslation('translation', { keyPrefix: 'surveys' });
+  return (
+    <Section>
+      <Typo type="title-medium" color="BLACK">
+        {title}
+      </Typo>
+      {available && bucket ? (
+        <>
+          <Typo type="label-large" color="DARK_GRAY">
+            {t('n_responders', { n: bucket.n })}
+          </Typo>
+          <SurveyResultsChart distribution={bucket.distribution} />
+          {bucket.user_percentile !== null && (
+            <Typo type="body-medium" color="DARK_GRAY">
+              {t('your_percentile', { p: Math.round(bucket.user_percentile * 100) })}
+            </Typo>
+          )}
+          {interpretation && (
+            <Typo type="body-medium" color="BLACK">
+              {interpretation}
+            </Typo>
+          )}
+        </>
+      ) : (
+        <SuppressedBucketPlaceholder reason={reason} />
+      )}
+    </Section>
+  );
+}

--- a/src/components/survey/SurveyResultsChart.tsx
+++ b/src/components/survey/SurveyResultsChart.tsx
@@ -1,0 +1,91 @@
+import styled from 'styled-components';
+
+import { Colors, Layout } from '@design-system';
+import i18n from '@i18n/index';
+import { SurveyDistribution } from '@models/survey';
+
+const Col = styled(Layout.FlexCol)`
+  width: 100%;
+  gap: 6px;
+`;
+
+const Row = styled(Layout.FlexRow)`
+  width: 100%;
+  align-items: center;
+  gap: 8px;
+`;
+
+const ScoreLabel = styled.div`
+  width: 64px;
+  font-size: 14px;
+  color: ${Colors.DARK_GRAY};
+  flex-shrink: 0;
+`;
+
+const BarTrack = styled.div`
+  flex: 1;
+  height: 14px;
+  background: transparent;
+  border-radius: 7px;
+  overflow: hidden;
+`;
+
+const Bar = styled.div<{ highlighted: boolean }>`
+  height: 100%;
+  background: ${({ highlighted }) => (highlighted ? Colors.PRIMARY : Colors.LIGHT_GRAY)};
+  border-radius: 7px;
+  transition: width 200ms ease-out;
+`;
+
+const Count = styled.div`
+  width: 32px;
+  font-size: 14px;
+  color: ${Colors.DARK_GRAY};
+  text-align: right;
+  flex-shrink: 0;
+`;
+
+interface SurveyResultsChartProps {
+  distribution: SurveyDistribution;
+}
+
+const pickLabel = (en: string, ko: string) => (i18n.language === 'ko' ? ko : en);
+
+export function SurveyResultsChart({ distribution }: SurveyResultsChartProps) {
+  if (distribution.kind === 'aggregated_likert') {
+    const max = Math.max(1, ...distribution.bins.map((b) => b.count));
+    return (
+      <Col>
+        {distribution.bins.map((b) => {
+          const isUser = b.score === distribution.user_score;
+          return (
+            <Row key={b.score}>
+              <ScoreLabel>{b.score}</ScoreLabel>
+              <BarTrack>
+                <Bar style={{ width: `${(b.count / max) * 100}%` }} highlighted={isUser} />
+              </BarTrack>
+              <Count>{b.count}</Count>
+            </Row>
+          );
+        })}
+      </Col>
+    );
+  }
+  const max = Math.max(1, ...distribution.options.map((o) => o.count));
+  const userChoice = distribution.user_choice;
+  const isUser = (value: number) =>
+    Array.isArray(userChoice) ? userChoice.includes(value) : userChoice === value;
+  return (
+    <Col>
+      {distribution.options.map((o) => (
+        <Row key={o.option_id}>
+          <ScoreLabel>{pickLabel(o.label_en, o.label_ko)}</ScoreLabel>
+          <BarTrack>
+            <Bar style={{ width: `${(o.count / max) * 100}%` }} highlighted={isUser(o.value)} />
+          </BarTrack>
+          <Count>{o.count}</Count>
+        </Row>
+      ))}
+    </Col>
+  );
+}

--- a/src/components/survey/SurveyResultsChart.tsx
+++ b/src/components/survey/SurveyResultsChart.tsx
@@ -1,91 +1,18 @@
-import styled from 'styled-components';
-
-import { Colors, Layout } from '@design-system';
-import i18n from '@i18n/index';
 import { SurveyDistribution } from '@models/survey';
 
-const Col = styled(Layout.FlexCol)`
-  width: 100%;
-  gap: 6px;
-`;
+import { RENDERER_REGISTRY } from './results/registry';
 
-const Row = styled(Layout.FlexRow)`
-  width: 100%;
-  align-items: center;
-  gap: 8px;
-`;
-
-const ScoreLabel = styled.div`
-  width: 64px;
-  font-size: 14px;
-  color: ${Colors.DARK_GRAY};
-  flex-shrink: 0;
-`;
-
-const BarTrack = styled.div`
-  flex: 1;
-  height: 14px;
-  background: transparent;
-  border-radius: 7px;
-  overflow: hidden;
-`;
-
-const Bar = styled.div<{ highlighted: boolean }>`
-  height: 100%;
-  background: ${({ highlighted }) => (highlighted ? Colors.PRIMARY : Colors.LIGHT_GRAY)};
-  border-radius: 7px;
-  transition: width 200ms ease-out;
-`;
-
-const Count = styled.div`
-  width: 32px;
-  font-size: 14px;
-  color: ${Colors.DARK_GRAY};
-  text-align: right;
-  flex-shrink: 0;
-`;
-
-interface SurveyResultsChartProps {
+interface Props {
   distribution: SurveyDistribution;
 }
 
-const pickLabel = (en: string, ko: string) => (i18n.language === 'ko' ? ko : en);
-
-export function SurveyResultsChart({ distribution }: SurveyResultsChartProps) {
-  if (distribution.kind === 'aggregated_likert') {
-    const max = Math.max(1, ...distribution.bins.map((b) => b.count));
-    return (
-      <Col>
-        {distribution.bins.map((b) => {
-          const isUser = b.score === distribution.user_score;
-          return (
-            <Row key={b.score}>
-              <ScoreLabel>{b.score}</ScoreLabel>
-              <BarTrack>
-                <Bar style={{ width: `${(b.count / max) * 100}%` }} highlighted={isUser} />
-              </BarTrack>
-              <Count>{b.count}</Count>
-            </Row>
-          );
-        })}
-      </Col>
-    );
-  }
-  const max = Math.max(1, ...distribution.options.map((o) => o.count));
-  const userChoice = distribution.user_choice;
-  const isUser = (value: number) =>
-    Array.isArray(userChoice) ? userChoice.includes(value) : userChoice === value;
-  return (
-    <Col>
-      {distribution.options.map((o) => (
-        <Row key={o.option_id}>
-          <ScoreLabel>{pickLabel(o.label_en, o.label_ko)}</ScoreLabel>
-          <BarTrack>
-            <Bar style={{ width: `${(o.count / max) * 100}%` }} highlighted={isUser(o.value)} />
-          </BarTrack>
-          <Count>{o.count}</Count>
-        </Row>
-      ))}
-    </Col>
-  );
+/**
+ * Thin dispatcher — looks up the renderer in RENDERER_REGISTRY by `distribution.kind`.
+ * Add new kinds in src/components/survey/results/registry.ts (and the mirrored
+ * backend strategy in surveys/aggregation.py).
+ */
+export function SurveyResultsChart({ distribution }: Props) {
+  const Renderer = RENDERER_REGISTRY[distribution.kind];
+  if (!Renderer) return null;
+  return <Renderer distribution={distribution} />;
 }

--- a/src/components/survey/results/AggregatedLikertRenderer.tsx
+++ b/src/components/survey/results/AggregatedLikertRenderer.tsx
@@ -1,0 +1,69 @@
+import styled from 'styled-components';
+
+import { Colors, Layout } from '@design-system';
+import { AggregatedLikertDistribution } from '@models/survey';
+
+const Col = styled(Layout.FlexCol)`
+  width: 100%;
+  gap: 6px;
+`;
+
+const Row = styled(Layout.FlexRow)`
+  width: 100%;
+  align-items: center;
+  gap: 8px;
+`;
+
+const ScoreLabel = styled.div`
+  width: 64px;
+  font-size: 14px;
+  color: ${Colors.DARK_GRAY};
+  flex-shrink: 0;
+`;
+
+const BarTrack = styled.div`
+  flex: 1;
+  height: 14px;
+  background: transparent;
+  border-radius: 7px;
+  overflow: hidden;
+`;
+
+const Bar = styled.div<{ highlighted: boolean }>`
+  height: 100%;
+  background: ${({ highlighted }) => (highlighted ? Colors.PRIMARY : Colors.LIGHT_GRAY)};
+  border-radius: 7px;
+  transition: width 200ms ease-out;
+`;
+
+const Count = styled.div`
+  width: 32px;
+  font-size: 14px;
+  color: ${Colors.DARK_GRAY};
+  text-align: right;
+  flex-shrink: 0;
+`;
+
+interface Props {
+  distribution: AggregatedLikertDistribution;
+}
+
+export function AggregatedLikertRenderer({ distribution }: Props) {
+  const max = Math.max(1, ...distribution.bins.map((b) => b.count));
+  return (
+    <Col>
+      {distribution.bins.map((b) => {
+        const isUser = b.score === distribution.user_score;
+        return (
+          <Row key={b.score}>
+            <ScoreLabel>{b.score}</ScoreLabel>
+            <BarTrack>
+              <Bar style={{ width: `${(b.count / max) * 100}%` }} highlighted={isUser} />
+            </BarTrack>
+            <Count>{b.count}</Count>
+          </Row>
+        );
+      })}
+    </Col>
+  );
+}

--- a/src/components/survey/results/OptionCountsRenderer.tsx
+++ b/src/components/survey/results/OptionCountsRenderer.tsx
@@ -1,0 +1,70 @@
+import styled from 'styled-components';
+
+import { Colors, Layout } from '@design-system';
+import i18n from '@i18n/index';
+import { OptionCountsDistribution } from '@models/survey';
+
+const Col = styled(Layout.FlexCol)`
+  width: 100%;
+  gap: 6px;
+`;
+
+const Row = styled(Layout.FlexRow)`
+  width: 100%;
+  align-items: center;
+  gap: 8px;
+`;
+
+const Label = styled.div`
+  width: 96px;
+  font-size: 14px;
+  color: ${Colors.DARK_GRAY};
+  flex-shrink: 0;
+`;
+
+const BarTrack = styled.div`
+  flex: 1;
+  height: 14px;
+  border-radius: 7px;
+`;
+
+const Bar = styled.div<{ highlighted: boolean }>`
+  height: 100%;
+  background: ${({ highlighted }) => (highlighted ? Colors.PRIMARY : Colors.LIGHT_GRAY)};
+  border-radius: 7px;
+  transition: width 200ms ease-out;
+`;
+
+const Count = styled.div`
+  width: 32px;
+  font-size: 14px;
+  color: ${Colors.DARK_GRAY};
+  text-align: right;
+  flex-shrink: 0;
+`;
+
+const pickLabel = (en: string, ko: string) => (i18n.language === 'ko' ? ko : en);
+
+interface Props {
+  distribution: OptionCountsDistribution;
+}
+
+export function OptionCountsRenderer({ distribution }: Props) {
+  const max = Math.max(1, ...distribution.options.map((o) => o.count));
+  const userChoice = distribution.user_choice;
+  const isUser = (value: number) =>
+    Array.isArray(userChoice) ? userChoice.includes(value) : userChoice === value;
+  return (
+    <Col>
+      {distribution.options.map((o) => (
+        <Row key={o.option_id}>
+          <Label>{pickLabel(o.label_en, o.label_ko)}</Label>
+          <BarTrack>
+            <Bar style={{ width: `${(o.count / max) * 100}%` }} highlighted={isUser(o.value)} />
+          </BarTrack>
+          <Count>{o.count}</Count>
+        </Row>
+      ))}
+    </Col>
+  );
+}

--- a/src/components/survey/results/WordcloudRenderer.tsx
+++ b/src/components/survey/results/WordcloudRenderer.tsx
@@ -1,0 +1,83 @@
+import { useTranslation } from 'react-i18next';
+import styled from 'styled-components';
+
+import { Colors, Layout, Typo } from '@design-system';
+import { WordcloudDistribution } from '@models/survey';
+
+const Cloud = styled(Layout.FlexRow)`
+  width: 100%;
+  flex-wrap: wrap;
+  gap: 8px 12px;
+  align-items: baseline;
+`;
+
+const Token = styled.span<{ size: number; isViewer: boolean }>`
+  font-size: ${({ size }) => size}px;
+  font-weight: ${({ isViewer }) => (isViewer ? 600 : 500)};
+  color: ${({ isViewer }) => (isViewer ? Colors.PRIMARY : Colors.DARK_GRAY)};
+  line-height: 1.1;
+`;
+
+const Footnote = styled.div`
+  margin-top: 12px;
+  font-size: 12px;
+  color: ${Colors.MEDIUM_GRAY};
+`;
+
+interface Props {
+  distribution: WordcloudDistribution;
+}
+
+const MIN_SIZE = 14;
+const MAX_SIZE = 32;
+
+export function WordcloudRenderer({ distribution }: Props) {
+  const { t } = useTranslation('translation', { keyPrefix: 'surveys' });
+
+  if (distribution.tokens.length === 0) {
+    return (
+      <Layout.FlexCol gap={4} w="100%">
+        <Typo type="body-medium" color="DARK_GRAY">
+          {t('wordcloud.empty')}
+        </Typo>
+        {distribution.suppressed_token_count > 0 && (
+          <Footnote>
+            {t('wordcloud.suppressed', {
+              count: distribution.suppressed_token_count,
+              min: distribution.min_token_frequency,
+            })}
+          </Footnote>
+        )}
+      </Layout.FlexCol>
+    );
+  }
+
+  const maxCount = Math.max(...distribution.tokens.map((entry) => entry.count));
+  const minCount = Math.min(...distribution.tokens.map((entry) => entry.count));
+  const range = Math.max(1, maxCount - minCount);
+  const viewerSet = new Set(distribution.viewer_tokens);
+
+  return (
+    <Layout.FlexCol gap={8} w="100%">
+      <Cloud>
+        {distribution.tokens.map(({ token, count }) => {
+          const ratio = (count - minCount) / range;
+          const size = MIN_SIZE + ratio * (MAX_SIZE - MIN_SIZE);
+          return (
+            <Token key={token} size={size} isViewer={viewerSet.has(token)}>
+              {token}
+            </Token>
+          );
+        })}
+      </Cloud>
+      {distribution.suppressed_token_count > 0 && (
+        <Footnote>
+          {t('wordcloud.suppressed', {
+            count: distribution.suppressed_token_count,
+            min: distribution.min_token_frequency,
+          })}
+        </Footnote>
+      )}
+    </Layout.FlexCol>
+  );
+}

--- a/src/components/survey/results/registry.ts
+++ b/src/components/survey/results/registry.ts
@@ -1,0 +1,34 @@
+/**
+ * Renderer registry — maps a distribution `kind` to its React component.
+ *
+ * To add a new view type:
+ *   1. Add the new variant to the `SurveyDistribution` discriminated union in
+ *      src/models/survey.ts (mirror surveys/aggregation.py STRATEGIES key).
+ *   2. Drop a new component at src/components/survey/results/<Kind>Renderer.tsx
+ *      that takes a single `{ distribution }` prop typed to that variant.
+ *   3. Register the kind → component pair below.
+ *
+ * The dispatcher in `SurveyResultsChart` reads from this map; everything else is
+ * existing infrastructure.
+ */
+import { ComponentType } from 'react';
+
+import { SurveyDistribution } from '@models/survey';
+
+import { AggregatedLikertRenderer } from './AggregatedLikertRenderer';
+import { OptionCountsRenderer } from './OptionCountsRenderer';
+import { WordcloudRenderer } from './WordcloudRenderer';
+
+type RendererProps<K extends SurveyDistribution['kind']> = {
+  distribution: Extract<SurveyDistribution, { kind: K }>;
+};
+
+type RendererComponent = ComponentType<{ distribution: SurveyDistribution }>;
+
+export const RENDERER_REGISTRY: Record<SurveyDistribution['kind'], RendererComponent> = {
+  aggregated_likert: AggregatedLikertRenderer as RendererComponent,
+  option_counts: OptionCountsRenderer as RendererComponent,
+  wordcloud: WordcloudRenderer as RendererComponent,
+};
+
+export type AnyRendererProps = RendererProps<SurveyDistribution['kind']>;

--- a/src/hooks/useSurveyDraft.ts
+++ b/src/hooks/useSurveyDraft.ts
@@ -1,0 +1,73 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { useBoundStore } from '@stores/useBoundStore';
+
+export type DraftAnswers = Record<number, number | number[]>;
+
+interface DraftPayload {
+  answers: DraftAnswers;
+  savedAt: string;
+}
+
+const KEY_PREFIX = 'whoami_survey_draft_';
+
+const buildKey = (userId: number | null, slug: string) =>
+  `${KEY_PREFIX}${userId ?? 'anon'}_${slug}`;
+
+const readDraft = (key: string): DraftAnswers => {
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as DraftPayload;
+    return parsed.answers ?? {};
+  } catch {
+    return {};
+  }
+};
+
+const writeDraft = (key: string, answers: DraftAnswers) => {
+  try {
+    const payload: DraftPayload = { answers, savedAt: new Date().toISOString() };
+    localStorage.setItem(key, JSON.stringify(payload));
+  } catch {
+    // localStorage may be unavailable (private mode, quota); fail silently
+  }
+};
+
+export function useSurveyDraft(slug: string | undefined) {
+  const userId = useBoundStore((s) => s.myProfile?.id ?? null);
+  const key = slug ? buildKey(userId, slug) : null;
+
+  const [answers, setAnswers] = useState<DraftAnswers>({});
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    if (!key) return;
+    setAnswers(readDraft(key));
+    setHydrated(true);
+  }, [key]);
+
+  const setAnswer = useCallback(
+    (questionId: number, value: number | number[]) => {
+      setAnswers((prev) => {
+        const next = { ...prev, [questionId]: value };
+        if (key) writeDraft(key, next);
+        return next;
+      });
+    },
+    [key],
+  );
+
+  const clear = useCallback(() => {
+    if (key) {
+      try {
+        localStorage.removeItem(key);
+      } catch {
+        // ignore
+      }
+    }
+    setAnswers({});
+  }, [key]);
+
+  return { answers, setAnswer, clear, hydrated };
+}

--- a/src/hooks/useSurveyDraft.ts
+++ b/src/hooks/useSurveyDraft.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 
 import { useBoundStore } from '@stores/useBoundStore';
 
-export type DraftAnswers = Record<number, number | number[]>;
+export type DraftAnswers = Record<number, number | number[] | string>;
 
 interface DraftPayload {
   answers: DraftAnswers;
@@ -48,7 +48,7 @@ export function useSurveyDraft(slug: string | undefined) {
   }, [key]);
 
   const setAnswer = useCallback(
-    (questionId: number, value: number | number[]) => {
+    (questionId: number, value: number | number[] | string) => {
       setAnswers((prev) => {
         const next = { ...prev, [questionId]: value };
         if (key) writeDraft(key, next);

--- a/src/hooks/useSurveyOfTheDay.ts
+++ b/src/hooks/useSurveyOfTheDay.ts
@@ -1,0 +1,12 @@
+import useSWR from 'swr';
+
+import { getSurveyOfTheDay } from '@utils/apis/survey';
+
+export const SURVEY_OF_THE_DAY_KEY = '/surveys/today/';
+
+export const useSurveyOfTheDay = () => {
+  return useSWR(SURVEY_OF_THE_DAY_KEY, getSurveyOfTheDay, {
+    revalidateOnFocus: false,
+    dedupingInterval: 60_000,
+  });
+};

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -1159,7 +1159,19 @@
             "too_few_friends": "Available once you have 5 friends.",
             "too_few_responders": "Available once 5 of your friends have responded.",
             "too_few_close_friends": "Available once you have 5 close friends.",
-            "delta_too_small": "Available once you have at least 5 more friends than close friends."
+            "delta_too_small": "Available once you have at least 5 more friends than close friends.",
+            "view_friend_disabled": "Friend-level breakdown is disabled for this view to protect individual responses."
+        },
+        "panel_kinds": {
+            "aggregated_likert": "Score distribution",
+            "option_counts": "Choices",
+            "wordcloud": "Reflections"
+        },
+        "panel_questions_count": "{{count}} questions aggregated",
+        "free_text_placeholder": "Type your response…",
+        "wordcloud": {
+            "empty": "No words shared yet — the population is too small to display.",
+            "suppressed": "{{count}} words said by fewer than {{min}} people are hidden to protect privacy."
         }
     }
 }

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -1128,6 +1128,7 @@
         }
     },
     "surveys": {
+        "section_title": "Survey of the Day",
         "thanks_results_tomorrow": "Thanks! Results available tomorrow.",
         "submit": "Submit",
         "next": "Next",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -1129,6 +1129,7 @@
     },
     "surveys": {
         "section_title": "Survey of the Day",
+        "section_results_released": "Survey results",
         "thanks_results_tomorrow": "Thanks! Results available tomorrow.",
         "submit": "Submit",
         "next": "Next",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -196,6 +196,7 @@
                 "explore_friends": "Add Friends",
                 "questions": "Questions",
                 "my_profile": "My Profile",
+                "survey_results": "Survey Results",
                 "settings": "Settings",
                 "edit_profile": "Edit Profile",
                 "inquiry": "Contact & Inquiries",
@@ -1124,6 +1125,33 @@
             "step2": "Tap the Widgets option",
             "step3": "Find WhoAmI Today\nin the widget list",
             "step4": "Drag the widget\nto your Home Screen"
+        }
+    },
+    "surveys": {
+        "thanks_results_tomorrow": "Thanks! Results available tomorrow.",
+        "submit": "Submit",
+        "view_results": "View results",
+        "answered_view_results": "Answered — view results",
+        "answer_to_view_results": "Answer to view results",
+        "locked_title": "Results not yet available",
+        "archive_title": "Survey Results",
+        "archive_empty": "No surveys have been scheduled yet.",
+        "n_responders": "n = {{n}}",
+        "your_percentile": "You scored higher than {{p}}% of responders.",
+        "toast": {
+            "submitted": "Survey submitted!",
+            "submit_failed": "Could not submit — please try again."
+        },
+        "buckets": {
+            "population": "Everyone",
+            "friends": "Your friends",
+            "close_friends": "Your close friends"
+        },
+        "reasons": {
+            "too_few_friends": "Available once you have 5 friends.",
+            "too_few_responders": "Available once 5 of your friends have responded.",
+            "too_few_close_friends": "Available once you have 5 close friends.",
+            "delta_too_small": "Available once you have at least 5 more friends than close friends."
         }
     }
 }

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -1138,6 +1138,8 @@
         "continue_survey": "Continue",
         "question_progress": "Question {{current}} of {{total}}",
         "question_total": "{{total}} questions",
+        "responder_count_today": "{{count}} people took this on WIT today",
+        "responder_count_today_zero": "Be the first to take this on WIT today",
         "view_results": "View results",
         "answered_view_results": "Answered — view results",
         "answer_to_view_results": "Answer to view results",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -1130,6 +1130,12 @@
     "surveys": {
         "thanks_results_tomorrow": "Thanks! Results available tomorrow.",
         "submit": "Submit",
+        "next": "Next",
+        "back": "Back",
+        "start_survey": "Start",
+        "continue_survey": "Continue",
+        "question_progress": "Question {{current}} of {{total}}",
+        "question_total": "{{total}} questions",
         "view_results": "View results",
         "answered_view_results": "Answered — view results",
         "answer_to_view_results": "Answer to view results",

--- a/src/i18n/locales/ko/translation.json
+++ b/src/i18n/locales/ko/translation.json
@@ -1120,6 +1120,7 @@
   },
   "surveys": {
     "section_title": "오늘의 설문",
+    "section_results_released": "설문 결과",
     "thanks_results_tomorrow": "감사합니다! 결과는 내일 공개돼요.",
     "submit": "제출",
     "next": "다음",

--- a/src/i18n/locales/ko/translation.json
+++ b/src/i18n/locales/ko/translation.json
@@ -1119,6 +1119,7 @@
     }
   },
   "surveys": {
+    "section_title": "오늘의 설문",
     "thanks_results_tomorrow": "감사합니다! 결과는 내일 공개돼요.",
     "submit": "제출",
     "next": "다음",

--- a/src/i18n/locales/ko/translation.json
+++ b/src/i18n/locales/ko/translation.json
@@ -1129,6 +1129,8 @@
     "continue_survey": "이어서 답하기",
     "question_progress": "{{current}} / {{total}}",
     "question_total": "총 {{total}}문항",
+    "responder_count_today": "오늘 WIT에서 {{count}}명이 응답했어요",
+    "responder_count_today_zero": "WIT에서 첫 번째로 응답해보세요",
     "view_results": "결과 보기",
     "answered_view_results": "응답 완료 — 결과 보기",
     "answer_to_view_results": "답변하면 결과를 볼 수 있어요",

--- a/src/i18n/locales/ko/translation.json
+++ b/src/i18n/locales/ko/translation.json
@@ -1150,7 +1150,19 @@
       "too_few_friends": "친구가 5명 이상일 때 공개돼요.",
       "too_few_responders": "친구 5명 이상이 응답하면 공개돼요.",
       "too_few_close_friends": "친한 친구가 5명 이상일 때 공개돼요.",
-      "delta_too_small": "친구가 친한 친구보다 5명 이상 많아야 공개돼요."
+      "delta_too_small": "친구가 친한 친구보다 5명 이상 많아야 공개돼요.",
+      "view_friend_disabled": "개인정보 보호를 위해 이 결과는 친구별 보기를 제공하지 않아요."
+    },
+    "panel_kinds": {
+      "aggregated_likert": "점수 분포",
+      "option_counts": "선택 분포",
+      "wordcloud": "자유 응답"
+    },
+    "panel_questions_count": "총 {{count}}문항 집계",
+    "free_text_placeholder": "답변을 입력해주세요…",
+    "wordcloud": {
+      "empty": "아직 충분한 응답이 모이지 않았어요.",
+      "suppressed": "{{min}}명 미만이 답한 단어 {{count}}개는 개인정보 보호를 위해 숨겼어요."
     }
   }
 }

--- a/src/i18n/locales/ko/translation.json
+++ b/src/i18n/locales/ko/translation.json
@@ -1121,6 +1121,12 @@
   "surveys": {
     "thanks_results_tomorrow": "감사합니다! 결과는 내일 공개돼요.",
     "submit": "제출",
+    "next": "다음",
+    "back": "이전",
+    "start_survey": "시작하기",
+    "continue_survey": "이어서 답하기",
+    "question_progress": "{{current}} / {{total}}",
+    "question_total": "총 {{total}}문항",
     "view_results": "결과 보기",
     "answered_view_results": "응답 완료 — 결과 보기",
     "answer_to_view_results": "답변하면 결과를 볼 수 있어요",

--- a/src/i18n/locales/ko/translation.json
+++ b/src/i18n/locales/ko/translation.json
@@ -196,6 +196,7 @@
         "explore_friends": "친구 추가",
         "questions": "전체 질문",
         "my_profile": "마이 프로필",
+        "survey_results": "설문 결과",
         "settings": "설정",
         "edit_profile": "프로필 편집",
         "inquiry": "문의 & 연락처",
@@ -1115,6 +1116,33 @@
       "step2": "위젯 옵션을 눌러주세요",
       "step3": "위젯 목록에서\nWhoAmI Today를 찾아주세요",
       "step4": "위젯을 홈 화면으로\n드래그해주세요"
+    }
+  },
+  "surveys": {
+    "thanks_results_tomorrow": "감사합니다! 결과는 내일 공개돼요.",
+    "submit": "제출",
+    "view_results": "결과 보기",
+    "answered_view_results": "응답 완료 — 결과 보기",
+    "answer_to_view_results": "답변하면 결과를 볼 수 있어요",
+    "locked_title": "결과가 아직 공개되지 않았어요",
+    "archive_title": "설문 결과",
+    "archive_empty": "아직 예정된 설문이 없습니다.",
+    "n_responders": "n = {{n}}",
+    "your_percentile": "응답자 중 상위 {{p}}%예요.",
+    "toast": {
+      "submitted": "설문이 제출되었어요!",
+      "submit_failed": "제출에 실패했어요. 다시 시도해주세요."
+    },
+    "buckets": {
+      "population": "전체",
+      "friends": "친구",
+      "close_friends": "친한 친구"
+    },
+    "reasons": {
+      "too_few_friends": "친구가 5명 이상일 때 공개돼요.",
+      "too_few_responders": "친구 5명 이상이 응답하면 공개돼요.",
+      "too_few_close_friends": "친한 친구가 5명 이상일 때 공개돼요.",
+      "delta_too_small": "친구가 친한 친구보다 5명 이상 많아야 공개돼요."
     }
   }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -73,6 +73,9 @@ import Password from './routes/sign-up/Password';
 import SignIn from './routes/SignIn';
 import SignUp from './routes/SignUp';
 import SuggestQuestions from './routes/SuggestQuestions';
+import SurveyAnswer from './routes/surveys/SurveyAnswer';
+import SurveyResults from './routes/surveys/SurveyResults';
+import SurveysIndex from './routes/surveys/SurveysIndex';
 import UpdateCheckin from './routes/update/UpdateCheckin';
 import UserPage from './routes/UserPage';
 import ViewAsPage from './routes/ViewAsPage';
@@ -188,6 +191,19 @@ const router = createBrowserRouter([
         children: [
           { path: '', element: <Share /> },
           { path: 'photo', element: <PhotoOfTheDayFlow /> },
+        ],
+      },
+      {
+        path: 'surveys',
+        element: (
+          <VersionGuard allowedVersions={[VersionType.VER_W, VersionType.VER_Q]}>
+            <Outlet />
+          </VersionGuard>
+        ),
+        children: [
+          { path: '', element: <SurveysIndex /> },
+          { path: ':slug/results', element: <SurveyResults /> },
+          { path: ':slug/answer', element: <SurveyAnswer /> },
         ],
       },
       {

--- a/src/models/discover.ts
+++ b/src/models/discover.ts
@@ -85,6 +85,14 @@ export interface MusicHighlightCardBody {
   sharedByUsername: string;
 }
 
+// SurveyResults Card Body (frontend-only injection)
+export interface SurveyResultsCardBody {
+  slug: string;
+  titleEn: string;
+  titleKo: string;
+  date: string;
+}
+
 // Discover Result Item (discriminated union)
 export type DiscoverResultItem =
   | {
@@ -121,4 +129,8 @@ export type DiscoverResultItem =
   | {
       type: 'MusicHighlight';
       body: MusicHighlightCardBody;
+    }
+  | {
+      type: 'SurveyResults';
+      body: SurveyResultsCardBody;
     };

--- a/src/models/survey.ts
+++ b/src/models/survey.ts
@@ -34,6 +34,7 @@ export interface Survey {
   interpretation_ko: string;
   questions: SurveyQuestion[];
   user_has_responded: boolean;
+  responder_count: number;
 }
 
 export interface SurveyOfTheDayResponse {

--- a/src/models/survey.ts
+++ b/src/models/survey.ts
@@ -1,4 +1,6 @@
-export type SurveyType = 'likert_5' | 'single_choice' | 'multi_choice';
+// Question types — defined per-question so a single Survey can mix them.
+// Mirror of surveys/models.py TYPE_CHOICES.
+export type QuestionType = 'likert_5' | 'single_choice' | 'multi_choice' | 'free_text';
 
 export interface SurveyOption {
   id: number;
@@ -11,6 +13,7 @@ export interface SurveyOption {
 export interface SurveyQuestion {
   id: number;
   order: number;
+  type: QuestionType;
   prompt_en: string;
   prompt_ko: string;
   low_label_en: string;
@@ -23,7 +26,6 @@ export interface SurveyQuestion {
 
 export interface Survey {
   slug: string;
-  type: SurveyType;
   title_en: string;
   title_ko: string;
   description_en: string;
@@ -41,7 +43,7 @@ export interface SurveyOfTheDayResponse {
 
 export interface SurveyAnswerInput {
   question_id: number;
-  value: number | number[];
+  value: number | number[] | string;
 }
 
 export type SuppressedReason =
@@ -49,6 +51,7 @@ export type SuppressedReason =
   | 'too_few_responders'
   | 'too_few_close_friends'
   | 'delta_too_small'
+  | 'view_friend_disabled'
   | null;
 
 export interface AggregatedLikertDistribution {
@@ -72,7 +75,18 @@ export interface OptionCountsDistribution {
   user_choice: number | number[] | null;
 }
 
-export type SurveyDistribution = AggregatedLikertDistribution | OptionCountsDistribution;
+export interface WordcloudDistribution {
+  kind: 'wordcloud';
+  tokens: { token: string; count: number }[];
+  min_token_frequency: number;
+  suppressed_token_count: number;
+  viewer_tokens: string[];
+}
+
+export type SurveyDistribution =
+  | AggregatedLikertDistribution
+  | OptionCountsDistribution
+  | WordcloudDistribution;
 
 export interface BucketResult {
   n: number;
@@ -80,8 +94,12 @@ export interface BucketResult {
   user_percentile: number | null;
 }
 
-export interface SurveyResults {
-  user_response: { id: number | null };
+export interface ResultPanel {
+  group_key: string;
+  kind: SurveyDistribution['kind'];
+  title_en: string;
+  title_ko: string;
+  question_count: number;
   population: BucketResult | null;
   population_available: boolean;
   population_suppressed_reason: SuppressedReason;
@@ -94,6 +112,11 @@ export interface SurveyResults {
   close_friends_available: boolean;
   close_friends_suppressed_reason: SuppressedReason;
   close_friends_required_n: number;
+}
+
+export interface SurveyResults {
+  user_response: { id: number | null };
+  panels: ResultPanel[];
 }
 
 export interface SurveyResultsError {

--- a/src/models/survey.ts
+++ b/src/models/survey.ts
@@ -1,0 +1,110 @@
+export type SurveyType = 'likert_5' | 'single_choice' | 'multi_choice';
+
+export interface SurveyOption {
+  id: number;
+  order: number;
+  label_en: string;
+  label_ko: string;
+  value: number;
+}
+
+export interface SurveyQuestion {
+  id: number;
+  order: number;
+  prompt_en: string;
+  prompt_ko: string;
+  low_label_en: string;
+  low_label_ko: string;
+  high_label_en: string;
+  high_label_ko: string;
+  reverse_scored: boolean;
+  options: SurveyOption[];
+}
+
+export interface Survey {
+  slug: string;
+  type: SurveyType;
+  title_en: string;
+  title_ko: string;
+  description_en: string;
+  description_ko: string;
+  interpretation_en: string;
+  interpretation_ko: string;
+  questions: SurveyQuestion[];
+  user_has_responded: boolean;
+}
+
+export interface SurveyOfTheDayResponse {
+  date?: string;
+  survey: Survey | null;
+}
+
+export interface SurveyAnswerInput {
+  question_id: number;
+  value: number | number[];
+}
+
+export type SuppressedReason =
+  | 'too_few_friends'
+  | 'too_few_responders'
+  | 'too_few_close_friends'
+  | 'delta_too_small'
+  | null;
+
+export interface AggregatedLikertDistribution {
+  kind: 'aggregated_likert';
+  bins: { score: number; count: number }[];
+  min_score: number;
+  max_score: number;
+  user_score: number | null;
+}
+
+export interface OptionCountsDistribution {
+  kind: 'option_counts';
+  question_id: number | null;
+  options: {
+    option_id: number;
+    value: number;
+    label_en: string;
+    label_ko: string;
+    count: number;
+  }[];
+  user_choice: number | number[] | null;
+}
+
+export type SurveyDistribution = AggregatedLikertDistribution | OptionCountsDistribution;
+
+export interface BucketResult {
+  n: number;
+  distribution: SurveyDistribution;
+  user_percentile: number | null;
+}
+
+export interface SurveyResults {
+  user_response: { id: number | null };
+  population: BucketResult | null;
+  population_available: boolean;
+  population_suppressed_reason: SuppressedReason;
+  population_required_n: number;
+  friends: BucketResult | null;
+  friends_available: boolean;
+  friends_suppressed_reason: SuppressedReason;
+  friends_required_n: number;
+  close_friends: BucketResult | null;
+  close_friends_available: boolean;
+  close_friends_suppressed_reason: SuppressedReason;
+  close_friends_required_n: number;
+}
+
+export interface SurveyResultsError {
+  detail: string;
+  needs_submission: boolean;
+  available_at: string | null;
+}
+
+export interface PastSurvey {
+  date: string;
+  survey: Survey;
+  user_answered: boolean;
+  results_unlocked: boolean;
+}

--- a/src/routes/discover/Discover.tsx
+++ b/src/routes/discover/Discover.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import useSWR from 'swr';
 import FilterChip from '@components/_common/filter-chip/FilterChip';
 import PullToRefresh from '@components/_common/pull-to-refresh/PullToRefresh';
 import HighlightQuestionSection from '@components/discover/HighlightQuestionSection/HighlightQuestionSection';
@@ -8,6 +9,7 @@ import MusicHighlightCard from '@components/discover/MusicHighlightCard/MusicHig
 import ProfileSuggestionCard from '@components/discover/ProfileSuggestionCard/ProfileSuggestionCard';
 import SelectInterestSection from '@components/discover/SelectInterestSection/SelectInterestSection';
 import SelectPersonaSection from '@components/discover/SelectPersonaSection/SelectPersonaSection';
+import SurveyResultsCard from '@components/discover/SurveyResultsCard/SurveyResultsCard';
 import SharedPlaylistSection, {
   SharedTrack,
 } from '@components/friends/shared-playlist/SharedPlaylistSection';
@@ -32,6 +34,7 @@ import { useBoundStore } from '@stores/useBoundStore';
 import { UserSelector } from '@stores/user';
 import { getDiscoverFeed } from '@utils/apis/discover';
 import { getMe } from '@utils/apis/my';
+import { getPastSurveys } from '@utils/apis/survey';
 import { getItemFromSessionStorage, setItemToSessionStorage } from '@utils/sessionStorage';
 import { MainScrollContainer } from 'src/routes/Root';
 import * as S from './Discover.styled';
@@ -131,6 +134,23 @@ function Discover() {
     };
   }, [musicTracks]);
 
+  const { data: pastSurveysData } = useSWR('/surveys/past/', getPastSurveys, {
+    revalidateOnFocus: false,
+  });
+  const surveyResultsCard: DiscoverResultItem | null = useMemo(() => {
+    const unlocked = pastSurveysData?.results?.find((row) => row.results_unlocked);
+    if (!unlocked) return null;
+    return {
+      type: 'SurveyResults' as const,
+      body: {
+        slug: unlocked.survey.slug,
+        titleEn: unlocked.survey.title_en,
+        titleKo: unlocked.survey.title_ko,
+        date: unlocked.date,
+      },
+    };
+  }, [pastSurveysData]);
+
   // Inject synthetic cards at specific positions in the flattened feed
   const feedWithInjections = useMemo(() => {
     if (!discoverData) return [];
@@ -142,7 +162,7 @@ function Discover() {
 
     // Pick at most 2 injected cards per day (rotate daily)
     const allCards = (
-      [missionPromptCard, profileSuggestionCard, musicHighlightCard] as const
+      [surveyResultsCard, missionPromptCard, profileSuggestionCard, musicHighlightCard] as const
     ).filter((c) => c !== null) as DiscoverResultItem[];
     const dayOfYear = getDayOfYear();
     const selectedCards =
@@ -164,7 +184,13 @@ function Discover() {
       });
 
     return result;
-  }, [discoverData, missionPromptCard, profileSuggestionCard, musicHighlightCard]);
+  }, [
+    discoverData,
+    missionPromptCard,
+    profileSuggestionCard,
+    musicHighlightCard,
+    surveyResultsCard,
+  ]);
 
   // Client-side filtering by category
   const filterItem = useCallback(
@@ -173,7 +199,8 @@ function Discover() {
       if (
         item.type === 'MissionPrompt' ||
         item.type === 'ProfileSuggestion' ||
-        item.type === 'MusicHighlight'
+        item.type === 'MusicHighlight' ||
+        item.type === 'SurveyResults'
       ) {
         return true;
       }
@@ -246,6 +273,8 @@ function Discover() {
           );
         case 'MusicHighlight':
           return <MusicHighlightCard key={`music-highlight-${index}`} highlight={item.body} />;
+        case 'SurveyResults':
+          return <SurveyResultsCard key={`survey-results-${index}`} card={item.body} />;
         default:
           return null;
       }

--- a/src/routes/share/Share.tsx
+++ b/src/routes/share/Share.tsx
@@ -7,6 +7,7 @@ import CheckInPostShareCta from '@components/share/CheckInPostShareCta';
 import MissionOfTheDay, { markMissionCompleted } from '@components/share/MissionOfTheDay';
 import NotePostInputTrigger from '@components/share/NotePostInputTrigger';
 import QuestionsOfTheDaySection from '@components/share/QuestionsOfTheDaySection';
+import SurveyOfTheDay from '@components/share/SurveyOfTheDay';
 import { DEFAULT_MARGIN } from '@constants/layout';
 import { Layout, Typo } from '@design-system';
 import { useRestoreScrollPosition } from '@hooks/useRestoreScrollPosition';
@@ -38,6 +39,7 @@ function Share() {
           <Layout.FlexCol w="100%" ph={DEFAULT_MARGIN} pv={16} gap={16} pb={100}>
             <NotePostInputTrigger />
             <CheckInPostShareCta />
+            <SurveyOfTheDay />
             <QuestionsOfTheDaySection />
           </Layout.FlexCol>
         </PullToRefresh>
@@ -105,7 +107,10 @@ function Share() {
             <MissionOfTheDay onDoMission={handleDoMission} />
           </ColorCard>
 
-          {/* Section 3: Questions of the Day */}
+          {/* Section 3: Survey of the Day */}
+          <SurveyOfTheDay />
+
+          {/* Section 4: Questions of the Day */}
           <QuestionsOfTheDaySection />
         </Layout.FlexCol>
       </PullToRefresh>

--- a/src/routes/surveys/SurveyAnswer.tsx
+++ b/src/routes/surveys/SurveyAnswer.tsx
@@ -1,10 +1,11 @@
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
 import styled from 'styled-components';
-import useSWR from 'swr';
+import useSWR, { mutate } from 'swr';
 
 import { SurveyAnswerForm } from '@components/survey/SurveyAnswerForm';
 import { Colors, Layout, Typo } from '@design-system';
+import { SURVEY_OF_THE_DAY_KEY } from '@hooks/useSurveyOfTheDay';
 import i18n from '@i18n/index';
 import { useBoundStore } from '@stores/useBoundStore';
 import { getSurveyDetail } from '@utils/apis/survey';
@@ -54,6 +55,7 @@ function SurveyAnswer() {
         <SurveyAnswerForm
           survey={survey}
           onSubmitted={() => {
+            mutate(SURVEY_OF_THE_DAY_KEY);
             openToast({ message: t('toast.submitted') });
             navigate(`/surveys/${survey.slug}/results`);
           }}

--- a/src/routes/surveys/SurveyAnswer.tsx
+++ b/src/routes/surveys/SurveyAnswer.tsx
@@ -3,7 +3,9 @@ import { useNavigate, useParams } from 'react-router-dom';
 import styled from 'styled-components';
 import useSWR, { mutate } from 'swr';
 
+import SubHeader from '@components/sub-header/SubHeader';
 import { SurveyAnswerForm } from '@components/survey/SurveyAnswerForm';
+import { TITLE_HEADER_HEIGHT } from '@constants/layout';
 import { Colors, Layout, Typo } from '@design-system';
 import { SURVEY_OF_THE_DAY_KEY } from '@hooks/useSurveyOfTheDay';
 import i18n from '@i18n/index';
@@ -13,6 +15,7 @@ import { getSurveyDetail } from '@utils/apis/survey';
 const Page = styled(Layout.FlexCol)`
   width: 100%;
   padding: 16px;
+  padding-top: ${TITLE_HEADER_HEIGHT + 16}px;
   gap: 12px;
   background: ${Colors.LIGHT};
   min-height: 100vh;
@@ -42,27 +45,27 @@ function SurveyAnswer() {
   if (!survey) return null;
 
   return (
-    <Page>
-      <Card>
-        <Typo type="title-large" color="BLACK">
-          {pickLocalized(survey.title_en, survey.title_ko)}
-        </Typo>
-        {survey.description_en && (
-          <Typo type="body-medium" color="DARK_GRAY">
-            {pickLocalized(survey.description_en, survey.description_ko)}
-          </Typo>
-        )}
-        <SurveyAnswerForm
-          survey={survey}
-          onSubmitted={() => {
-            mutate(SURVEY_OF_THE_DAY_KEY);
-            openToast({ message: t('toast.submitted') });
-            navigate(`/surveys/${survey.slug}/results`);
-          }}
-          onError={(message) => openToast({ message })}
-        />
-      </Card>
-    </Page>
+    <>
+      <SubHeader title={pickLocalized(survey.title_en, survey.title_ko)} />
+      <Page>
+        <Card>
+          {survey.description_en && (
+            <Typo type="body-medium" color="DARK_GRAY">
+              {pickLocalized(survey.description_en, survey.description_ko)}
+            </Typo>
+          )}
+          <SurveyAnswerForm
+            survey={survey}
+            onSubmitted={() => {
+              mutate(SURVEY_OF_THE_DAY_KEY);
+              openToast({ message: t('toast.submitted') });
+              navigate(`/surveys/${survey.slug}/results`);
+            }}
+            onError={(message) => openToast({ message })}
+          />
+        </Card>
+      </Page>
+    </>
   );
 }
 

--- a/src/routes/surveys/SurveyAnswer.tsx
+++ b/src/routes/surveys/SurveyAnswer.tsx
@@ -1,0 +1,67 @@
+import { useTranslation } from 'react-i18next';
+import { useNavigate, useParams } from 'react-router-dom';
+import styled from 'styled-components';
+import useSWR from 'swr';
+
+import { SurveyAnswerForm } from '@components/survey/SurveyAnswerForm';
+import { Colors, Layout, Typo } from '@design-system';
+import i18n from '@i18n/index';
+import { useBoundStore } from '@stores/useBoundStore';
+import { getSurveyDetail } from '@utils/apis/survey';
+
+const Page = styled(Layout.FlexCol)`
+  width: 100%;
+  padding: 16px;
+  gap: 12px;
+  background: ${Colors.LIGHT};
+  min-height: 100vh;
+`;
+
+const Card = styled(Layout.FlexCol)`
+  width: 100%;
+  border: 1px solid ${Colors.LIGHT_GRAY};
+  border-radius: 12px;
+  background: ${Colors.WHITE};
+  padding: 16px;
+  gap: 12px;
+`;
+
+const pickLocalized = (en: string, ko: string) => (i18n.language === 'ko' ? ko : en);
+
+function SurveyAnswer() {
+  const { slug } = useParams<{ slug: string }>();
+  const { t } = useTranslation('translation', { keyPrefix: 'surveys' });
+  const navigate = useNavigate();
+  const openToast = useBoundStore((s) => s.openToast);
+
+  const { data: survey } = useSWR(slug ? `/surveys/${slug}/` : null, () =>
+    getSurveyDetail(slug as string),
+  );
+
+  if (!survey) return null;
+
+  return (
+    <Page>
+      <Card>
+        <Typo type="title-large" color="BLACK">
+          {pickLocalized(survey.title_en, survey.title_ko)}
+        </Typo>
+        {survey.description_en && (
+          <Typo type="body-medium" color="DARK_GRAY">
+            {pickLocalized(survey.description_en, survey.description_ko)}
+          </Typo>
+        )}
+        <SurveyAnswerForm
+          survey={survey}
+          onSubmitted={() => {
+            openToast({ message: t('toast.submitted') });
+            navigate(`/surveys/${survey.slug}/results`);
+          }}
+          onError={(message) => openToast({ message })}
+        />
+      </Card>
+    </Page>
+  );
+}
+
+export default SurveyAnswer;

--- a/src/routes/surveys/SurveyResults.tsx
+++ b/src/routes/surveys/SurveyResults.tsx
@@ -3,7 +3,9 @@ import { useNavigate, useParams } from 'react-router-dom';
 import styled from 'styled-components';
 import useSWR from 'swr';
 
+import SubHeader from '@components/sub-header/SubHeader';
 import { SurveyResultsBucket } from '@components/survey/SurveyResultsBucket';
+import { TITLE_HEADER_HEIGHT } from '@constants/layout';
 import { Colors, Layout, Typo } from '@design-system';
 import i18n from '@i18n/index';
 import { Survey, SurveyResultsError } from '@models/survey';
@@ -12,6 +14,7 @@ import { getSurveyDetail, getSurveyResults } from '@utils/apis/survey';
 const Page = styled(Layout.FlexCol)`
   width: 100%;
   padding: 16px;
+  padding-top: ${TITLE_HEADER_HEIGHT + 16}px;
   gap: 16px;
   background: ${Colors.LIGHT};
   min-height: 100vh;
@@ -55,19 +58,19 @@ function SurveyResults() {
   if (axiosError?.response?.status === 403) {
     const body = axiosError.response.data;
     return (
-      <Page>
-        <Typo type="title-large" color="BLACK">
-          {t('locked_title')}
-        </Typo>
-        <Typo type="body-medium" color="DARK_GRAY">
-          {body.detail}
-        </Typo>
-        {body.needs_submission && (
-          <ActionButton type="button" onClick={() => navigate(`/surveys/${slug}/answer`)}>
-            {t('answer_to_view_results')}
-          </ActionButton>
-        )}
-      </Page>
+      <>
+        <SubHeader title={t('locked_title')} />
+        <Page>
+          <Typo type="body-medium" color="DARK_GRAY">
+            {body.detail}
+          </Typo>
+          {body.needs_submission && (
+            <ActionButton type="button" onClick={() => navigate(`/surveys/${slug}/answer`)}>
+              {t('answer_to_view_results')}
+            </ActionButton>
+          )}
+        </Page>
+      </>
     );
   }
 
@@ -76,30 +79,30 @@ function SurveyResults() {
   const interpretation = pickLocalized(survey.interpretation_en, survey.interpretation_ko);
 
   return (
-    <Page>
-      <Typo type="title-large" color="BLACK">
-        {pickLocalized(survey.title_en, survey.title_ko)}
-      </Typo>
-      <SurveyResultsBucket
-        title={t('buckets.population')}
-        available={data.population_available}
-        reason={data.population_suppressed_reason}
-        bucket={data.population}
-        interpretation={interpretation}
-      />
-      <SurveyResultsBucket
-        title={t('buckets.friends')}
-        available={data.friends_available}
-        reason={data.friends_suppressed_reason}
-        bucket={data.friends}
-      />
-      <SurveyResultsBucket
-        title={t('buckets.close_friends')}
-        available={data.close_friends_available}
-        reason={data.close_friends_suppressed_reason}
-        bucket={data.close_friends}
-      />
-    </Page>
+    <>
+      <SubHeader title={pickLocalized(survey.title_en, survey.title_ko)} />
+      <Page>
+        <SurveyResultsBucket
+          title={t('buckets.population')}
+          available={data.population_available}
+          reason={data.population_suppressed_reason}
+          bucket={data.population}
+          interpretation={interpretation}
+        />
+        <SurveyResultsBucket
+          title={t('buckets.friends')}
+          available={data.friends_available}
+          reason={data.friends_suppressed_reason}
+          bucket={data.friends}
+        />
+        <SurveyResultsBucket
+          title={t('buckets.close_friends')}
+          available={data.close_friends_available}
+          reason={data.close_friends_suppressed_reason}
+          bucket={data.close_friends}
+        />
+      </Page>
+    </>
   );
 }
 

--- a/src/routes/surveys/SurveyResults.tsx
+++ b/src/routes/surveys/SurveyResults.tsx
@@ -8,16 +8,26 @@ import { SurveyResultsBucket } from '@components/survey/SurveyResultsBucket';
 import { TITLE_HEADER_HEIGHT } from '@constants/layout';
 import { Colors, Layout, Typo } from '@design-system';
 import i18n from '@i18n/index';
-import { Survey, SurveyResultsError } from '@models/survey';
+import { ResultPanel, Survey, SurveyResultsError } from '@models/survey';
 import { getSurveyDetail, getSurveyResults } from '@utils/apis/survey';
 
 const Page = styled(Layout.FlexCol)`
   width: 100%;
   padding: 16px;
   padding-top: ${TITLE_HEADER_HEIGHT + 16}px;
-  gap: 16px;
+  gap: 24px;
   background: ${Colors.LIGHT};
   min-height: 100vh;
+`;
+
+const PanelGroup = styled(Layout.FlexCol)`
+  width: 100%;
+  gap: 12px;
+`;
+
+const PanelHeader = styled(Layout.FlexCol)`
+  width: 100%;
+  gap: 4px;
 `;
 
 const ActionButton = styled.button`
@@ -38,6 +48,51 @@ interface AxiosError {
     status: number;
     data: SurveyResultsError;
   };
+}
+
+function panelHeading(panel: ResultPanel, t: (k: string) => string) {
+  // Single-question panels carry the prompt as title; multi-question panels render
+  // a kind label as the section heading.
+  const localized = pickLocalized(panel.title_en, panel.title_ko);
+  if (localized) return localized;
+  return t(`panel_kinds.${panel.kind}`);
+}
+
+function PanelView({ panel, interpretation }: { panel: ResultPanel; interpretation?: string }) {
+  const { t } = useTranslation('translation', { keyPrefix: 'surveys' });
+  return (
+    <PanelGroup>
+      <PanelHeader>
+        <Typo type="title-medium" color="BLACK">
+          {panelHeading(panel, t)}
+        </Typo>
+        {panel.question_count > 1 && (
+          <Typo type="label-medium" color="DARK_GRAY">
+            {t('panel_questions_count', { count: panel.question_count })}
+          </Typo>
+        )}
+      </PanelHeader>
+      <SurveyResultsBucket
+        title={t('buckets.population')}
+        available={panel.population_available}
+        reason={panel.population_suppressed_reason}
+        bucket={panel.population}
+        interpretation={interpretation}
+      />
+      <SurveyResultsBucket
+        title={t('buckets.friends')}
+        available={panel.friends_available}
+        reason={panel.friends_suppressed_reason}
+        bucket={panel.friends}
+      />
+      <SurveyResultsBucket
+        title={t('buckets.close_friends')}
+        available={panel.close_friends_available}
+        reason={panel.close_friends_suppressed_reason}
+        bucket={panel.close_friends}
+      />
+    </PanelGroup>
+  );
 }
 
 function SurveyResults() {
@@ -82,25 +137,14 @@ function SurveyResults() {
     <>
       <SubHeader title={pickLocalized(survey.title_en, survey.title_ko)} />
       <Page>
-        <SurveyResultsBucket
-          title={t('buckets.population')}
-          available={data.population_available}
-          reason={data.population_suppressed_reason}
-          bucket={data.population}
-          interpretation={interpretation}
-        />
-        <SurveyResultsBucket
-          title={t('buckets.friends')}
-          available={data.friends_available}
-          reason={data.friends_suppressed_reason}
-          bucket={data.friends}
-        />
-        <SurveyResultsBucket
-          title={t('buckets.close_friends')}
-          available={data.close_friends_available}
-          reason={data.close_friends_suppressed_reason}
-          bucket={data.close_friends}
-        />
+        {data.panels.map((panel, idx) => (
+          <PanelView
+            key={panel.group_key}
+            panel={panel}
+            // Show the survey-level interpretation only on the first panel.
+            interpretation={idx === 0 ? interpretation : undefined}
+          />
+        ))}
       </Page>
     </>
   );

--- a/src/routes/surveys/SurveyResults.tsx
+++ b/src/routes/surveys/SurveyResults.tsx
@@ -1,0 +1,106 @@
+import { useTranslation } from 'react-i18next';
+import { useNavigate, useParams } from 'react-router-dom';
+import styled from 'styled-components';
+import useSWR from 'swr';
+
+import { SurveyResultsBucket } from '@components/survey/SurveyResultsBucket';
+import { Colors, Layout, Typo } from '@design-system';
+import i18n from '@i18n/index';
+import { Survey, SurveyResultsError } from '@models/survey';
+import { getSurveyDetail, getSurveyResults } from '@utils/apis/survey';
+
+const Page = styled(Layout.FlexCol)`
+  width: 100%;
+  padding: 16px;
+  gap: 16px;
+  background: ${Colors.LIGHT};
+  min-height: 100vh;
+`;
+
+const ActionButton = styled.button`
+  align-self: flex-start;
+  border: 1px solid ${Colors.PRIMARY};
+  border-radius: 8px;
+  padding: 8px 16px;
+  background: ${Colors.PRIMARY};
+  color: ${Colors.WHITE};
+  font-size: 14px;
+  cursor: pointer;
+`;
+
+const pickLocalized = (en: string, ko: string) => (i18n.language === 'ko' ? ko : en);
+
+interface AxiosError {
+  response?: {
+    status: number;
+    data: SurveyResultsError;
+  };
+}
+
+function SurveyResults() {
+  const { slug } = useParams<{ slug: string }>();
+  const { t } = useTranslation('translation', { keyPrefix: 'surveys' });
+  const navigate = useNavigate();
+
+  const { data, error } = useSWR(
+    slug ? `/surveys/${slug}/results/` : null,
+    () => getSurveyResults(slug as string),
+    { shouldRetryOnError: false },
+  );
+  const { data: survey } = useSWR<Survey>(slug ? `/surveys/${slug}/` : null, () =>
+    getSurveyDetail(slug as string),
+  );
+
+  const axiosError = error as AxiosError | undefined;
+  if (axiosError?.response?.status === 403) {
+    const body = axiosError.response.data;
+    return (
+      <Page>
+        <Typo type="title-large" color="BLACK">
+          {t('locked_title')}
+        </Typo>
+        <Typo type="body-medium" color="DARK_GRAY">
+          {body.detail}
+        </Typo>
+        {body.needs_submission && (
+          <ActionButton type="button" onClick={() => navigate(`/surveys/${slug}/answer`)}>
+            {t('answer_to_view_results')}
+          </ActionButton>
+        )}
+      </Page>
+    );
+  }
+
+  if (!data || !survey) return null;
+
+  const interpretation = pickLocalized(survey.interpretation_en, survey.interpretation_ko);
+
+  return (
+    <Page>
+      <Typo type="title-large" color="BLACK">
+        {pickLocalized(survey.title_en, survey.title_ko)}
+      </Typo>
+      <SurveyResultsBucket
+        title={t('buckets.population')}
+        available={data.population_available}
+        reason={data.population_suppressed_reason}
+        bucket={data.population}
+        interpretation={interpretation}
+      />
+      <SurveyResultsBucket
+        title={t('buckets.friends')}
+        available={data.friends_available}
+        reason={data.friends_suppressed_reason}
+        bucket={data.friends}
+      />
+      <SurveyResultsBucket
+        title={t('buckets.close_friends')}
+        available={data.close_friends_available}
+        reason={data.close_friends_suppressed_reason}
+        bucket={data.close_friends}
+      />
+    </Page>
+  );
+}
+
+export default SurveyResults;

--- a/src/routes/surveys/SurveysIndex.tsx
+++ b/src/routes/surveys/SurveysIndex.tsx
@@ -1,0 +1,86 @@
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
+import useSWR from 'swr';
+
+import { Colors, Layout, Typo } from '@design-system';
+import i18n from '@i18n/index';
+import { PastSurvey } from '@models/survey';
+import { getPastSurveys } from '@utils/apis/survey';
+
+const Page = styled(Layout.FlexCol)`
+  width: 100%;
+  padding: 16px;
+  gap: 12px;
+  background: ${Colors.LIGHT};
+  min-height: 100vh;
+`;
+
+const RowCard = styled.button`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+  border: 1px solid ${Colors.LIGHT_GRAY};
+  border-radius: 12px;
+  background: ${Colors.WHITE};
+  padding: 12px 16px;
+  text-align: left;
+  cursor: pointer;
+`;
+
+const StatusChip = styled.span<{ unanswered: boolean }>`
+  border-radius: 8px;
+  padding: 4px 8px;
+  font-size: 14px;
+  border: 1px ${({ unanswered }) => (unanswered ? 'dashed' : 'solid')} ${Colors.LIGHT_GRAY};
+  background: ${Colors.WHITE};
+  color: ${({ unanswered }) => (unanswered ? Colors.DARK_GRAY : Colors.PRIMARY)};
+`;
+
+const pickLocalized = (en: string, ko: string) => (i18n.language === 'ko' ? ko : en);
+
+function SurveysIndex() {
+  const { t } = useTranslation('translation', { keyPrefix: 'surveys' });
+  const navigate = useNavigate();
+  const { data } = useSWR('/surveys/past/', getPastSurveys);
+
+  const handleClick = (row: PastSurvey) => {
+    if (row.user_answered) {
+      navigate(`/surveys/${row.survey.slug}/results`);
+    } else {
+      navigate(`/surveys/${row.survey.slug}/answer`);
+    }
+  };
+
+  if (!data) return null;
+
+  return (
+    <Page>
+      <Typo type="title-large" color="BLACK">
+        {t('archive_title')}
+      </Typo>
+      {data.results.length === 0 && (
+        <Typo type="body-medium" color="DARK_GRAY">
+          {t('archive_empty')}
+        </Typo>
+      )}
+      {data.results.map((row) => (
+        <RowCard key={row.date} type="button" onClick={() => handleClick(row)}>
+          <Typo type="label-large" color="DARK_GRAY">
+            {row.date}
+          </Typo>
+          <Typo type="title-medium" color="BLACK">
+            {pickLocalized(row.survey.title_en, row.survey.title_ko)}
+          </Typo>
+          <StatusChip unanswered={!row.user_answered}>
+            {row.user_answered ? t('answered_view_results') : t('answer_to_view_results')}
+          </StatusChip>
+        </RowCard>
+      ))}
+    </Page>
+  );
+}
+
+export default SurveysIndex;

--- a/src/routes/surveys/SurveysIndex.tsx
+++ b/src/routes/surveys/SurveysIndex.tsx
@@ -3,6 +3,8 @@ import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import useSWR from 'swr';
 
+import SubHeader from '@components/sub-header/SubHeader';
+import { TITLE_HEADER_HEIGHT } from '@constants/layout';
 import { Colors, Layout, Typo } from '@design-system';
 import i18n from '@i18n/index';
 import { PastSurvey } from '@models/survey';
@@ -11,6 +13,7 @@ import { getPastSurveys } from '@utils/apis/survey';
 const Page = styled(Layout.FlexCol)`
   width: 100%;
   padding: 16px;
+  padding-top: ${TITLE_HEADER_HEIGHT + 16}px;
   gap: 12px;
   background: ${Colors.LIGHT};
   min-height: 100vh;
@@ -57,29 +60,29 @@ function SurveysIndex() {
   if (!data) return null;
 
   return (
-    <Page>
-      <Typo type="title-large" color="BLACK">
-        {t('archive_title')}
-      </Typo>
-      {data.results.length === 0 && (
-        <Typo type="body-medium" color="DARK_GRAY">
-          {t('archive_empty')}
-        </Typo>
-      )}
-      {data.results.map((row) => (
-        <RowCard key={row.date} type="button" onClick={() => handleClick(row)}>
-          <Typo type="label-large" color="DARK_GRAY">
-            {row.date}
+    <>
+      <SubHeader title={t('archive_title')} />
+      <Page>
+        {data.results.length === 0 && (
+          <Typo type="body-medium" color="DARK_GRAY">
+            {t('archive_empty')}
           </Typo>
-          <Typo type="title-medium" color="BLACK">
-            {pickLocalized(row.survey.title_en, row.survey.title_ko)}
-          </Typo>
-          <StatusChip unanswered={!row.user_answered}>
-            {row.user_answered ? t('answered_view_results') : t('answer_to_view_results')}
-          </StatusChip>
-        </RowCard>
-      ))}
-    </Page>
+        )}
+        {data.results.map((row) => (
+          <RowCard key={row.date} type="button" onClick={() => handleClick(row)}>
+            <Typo type="label-large" color="DARK_GRAY">
+              {row.date}
+            </Typo>
+            <Typo type="title-medium" color="BLACK">
+              {pickLocalized(row.survey.title_en, row.survey.title_ko)}
+            </Typo>
+            <StatusChip unanswered={!row.user_answered}>
+              {row.user_answered ? t('answered_view_results') : t('answer_to_view_results')}
+            </StatusChip>
+          </RowCard>
+        ))}
+      </Page>
+    </>
   );
 }
 

--- a/src/utils/apis/survey.ts
+++ b/src/utils/apis/survey.ts
@@ -1,0 +1,37 @@
+import {
+  PastSurvey,
+  Survey,
+  SurveyAnswerInput,
+  SurveyOfTheDayResponse,
+  SurveyResults,
+} from '@models/survey';
+
+import axios from './axios';
+
+export const getSurveyOfTheDay = async (): Promise<SurveyOfTheDayResponse> => {
+  const { data } = await axios.get<SurveyOfTheDayResponse>('/surveys/today/');
+  return data;
+};
+
+export const getSurveyDetail = async (slug: string): Promise<Survey> => {
+  const { data } = await axios.get<Survey>(`/surveys/${slug}/`);
+  return data;
+};
+
+export const submitSurveyResponse = async (
+  slug: string,
+  answers: SurveyAnswerInput[],
+): Promise<{ id: number }> => {
+  const { data } = await axios.post<{ id: number }>(`/surveys/${slug}/responses/`, { answers });
+  return data;
+};
+
+export const getSurveyResults = async (slug: string): Promise<SurveyResults> => {
+  const { data } = await axios.get<SurveyResults>(`/surveys/${slug}/results/`);
+  return data;
+};
+
+export const getPastSurveys = async (): Promise<{ results: PastSurvey[] }> => {
+  const { data } = await axios.get<{ results: PastSurvey[] }>('/surveys/past/');
+  return data;
+};


### PR DESCRIPTION
## Summary

Adds the Survey of the Day feature frontend:
- **Share-tab card** with blue gradient + "Survey of the Day" header, survey title, "X people took this on WIT today" responder count, Start/Continue CTA. Matches the existing \`Photo of the Day\` / \`Mission of the Day\` card aesthetic.
- **Unified answer flow** at \`/surveys/:slug/answer\` — one question at a time with Next/Back, progress bar, draft auto-saved to \`localStorage\` keyed by \`whoami_survey_draft_<userId>_<slug>\` (survives app close). On reload, jumps to the first unanswered question.
- **Per-question input dispatch** — \`LikertChips\` for \`likert_5\`, \`ChoiceChips\` for single/multi, \`FreeTextInput\` (textarea) for \`free_text\`.
- **Renderer registry** at \`src/components/survey/results/registry.ts\` — \`AggregatedLikertRenderer\` / \`OptionCountsRenderer\` / \`WordcloudRenderer\`. Adding a new view = drop a component + register the kind.
- **Results page** \`/surveys/:slug/results\` renders a stack of bucket panels, one per backend panel.
- **Discover feed** injects a \`SurveyResultsCard\` (blue gradient, "Survey results" label, "View results" white pill) for unlocked past surveys.
- **Sidebar archive** entry "Survey Results" → \`/surveys\` index of past surveys.
- **\`SubHeader\`** with back navigation on all three survey routes (results, answer, archive).
- **i18n**: copy in both \`en\` and \`ko\` for all new strings.

## Test plan
- [x] \`npx craco build\` — compiles clean (warnings are pre-existing no-console / any in unrelated files)
- [x] \`npx tsc --noEmit\` — clean
- [x] Verified visually: card renders, chips select correctly, draft persists across reload, results page shows aggregated_likert panel + wordcloud panel for mixed-type survey
- [x] 320px viewport: chips wrap, no overflow
- [ ] **After merge**: backend must be running with at least one \`DailySurvey\` for today + sufficient mock responses for privacy gates to pass — see \`seed_survey_mock_data\` command in the backend PR