### PR TITLE
feat(browse-mode): per-session vibe picker (frontend)

### DIFF
--- a/src/components/browse-mode/BrowseModeCustomizeSheet.tsx
+++ b/src/components/browse-mode/BrowseModeCustomizeSheet.tsx
@@ -1,0 +1,589 @@
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useTranslation } from 'react-i18next';
+import styled from 'styled-components';
+import BottomModal from '@components/_common/bottom-modal/BottomModal';
+import BottomModalActionButton from '@components/_common/bottom-modal/BottomModalActionButton';
+import Icon from '@components/_common/icon/Icon';
+import SocialBatteryChip from '@components/profile/social-batter-chip/SocialBatteryChip';
+import {
+  ALL_BROWSE_MODE_TABS,
+  BUILT_IN_BROWSE_MODES,
+  CUSTOMIZE_TEMPLATES,
+  TAB_DURATION_OPTIONS,
+} from '@constants/browseMode';
+import { Colors, Layout, Typo } from '@design-system';
+import {
+  BrowseModeConfig,
+  BrowseModeFilters,
+  BrowseModeTabKey,
+  CustomBrowseModePreset,
+} from '@models/browseMode';
+import { SocialBattery } from '@models/checkIn';
+import { useBoundStore } from '@stores/useBoundStore';
+
+const FILTER_KEYS: (keyof BrowseModeFilters)[] = ['friends_close_only', 'chats_close_only'];
+
+interface BrowseModeCustomizeSheetProps {
+  visible: boolean;
+  onClose: () => void;
+  onSaved: (preset: {
+    id: number;
+    name: string;
+    config: BrowseModeConfig;
+    default_battery: SocialBattery | null;
+  }) => void;
+  onApplyWithoutSaving: (snapshot: {
+    config: BrowseModeConfig;
+    name: string;
+    description: string;
+    default_battery: SocialBattery | null;
+  }) => void;
+  /**
+   * When provided, the sheet opens in EDIT mode: form prefilled with the
+   * preset's name / config / default_battery, "Save" updates instead of
+   * creating, and "Apply without saving" still works for one-off tweaks.
+   * Wishlist + quick-start templates remain available — useful for
+   * starting an edit session by replacing the tab set, etc.
+   */
+  editingPreset?: CustomBrowseModePreset | null;
+  /**
+   * "Make a custom version of a built-in" entry: prefills the form with the
+   * given seed (config, name suggestion, default battery) but Save still
+   * creates a NEW custom preset rather than mutating any built-in. Built-ins
+   * are hardcoded constants and intentionally stay immutable; this just gives
+   * users a way to fork one and tweak from there.
+   */
+  cloneSeed?: {
+    config: BrowseModeConfig;
+    name: string;
+    description?: string;
+    default_battery: SocialBattery | null;
+  } | null;
+}
+
+function defaultConfig(seed?: BrowseModeConfig): BrowseModeConfig {
+  // Prefer the user's currently active mode (so they can re-edit after
+  // "Apply without saving"), then fall back to the selectively_social built-in.
+  const base = seed ?? BUILT_IN_BROWSE_MODES.selectively_social.config;
+  return {
+    tabs: [...base.tabs],
+    filters: { ...base.filters },
+    sections: { ...base.sections },
+    // Preserve per-tab durations so toggling tabs / filters in the form
+    // doesn't silently strip a Digital-detox preset's timers.
+    tab_durations: base.tab_durations ? { ...base.tab_durations } : undefined,
+  };
+}
+
+function BrowseModeCustomizeSheet({
+  visible,
+  onClose,
+  onSaved,
+  onApplyWithoutSaving,
+  editingPreset,
+  cloneSeed,
+}: BrowseModeCustomizeSheetProps) {
+  const [t] = useTranslation('translation', { keyPrefix: 'browse_mode' });
+  const saveCustomBrowseModePreset = useBoundStore((state) => state.saveCustomBrowseModePreset);
+  const updateCustomBrowseModePreset = useBoundStore((state) => state.updateCustomBrowseModePreset);
+  const activeBrowseMode = useBoundStore((state) => state.activeBrowseMode);
+
+  const isEditing = !!editingPreset;
+
+  const [config, setConfig] = useState<BrowseModeConfig>(() =>
+    defaultConfig(activeBrowseMode?.config),
+  );
+  const [defaultBattery, setDefaultBattery] = useState<SocialBattery | null>(null);
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // When the sheet opens, seed the form. In edit mode that's the preset's
+  // current values. Otherwise, prefer the active mode (so users can tweak
+  // rather than start over). When the sheet closes, reset everything.
+  useEffect(() => {
+    if (visible) {
+      // cloneSeed wins over editingPreset on form values: when both are
+      // present (preview-bar restore of an edit-in-progress), we want the
+      // user's UNSAVED tweaks back, not the preset's saved values.
+      // editingPreset is still consulted by handleSave for update-vs-create.
+      if (cloneSeed) {
+        setConfig(defaultConfig(cloneSeed.config));
+        setDefaultBattery(cloneSeed.default_battery);
+        setName(cloneSeed.name);
+        setDescription(cloneSeed.description ?? '');
+      } else if (editingPreset) {
+        setConfig(defaultConfig(editingPreset.config));
+        setDefaultBattery(editingPreset.default_battery);
+        setName(editingPreset.name);
+        setDescription(editingPreset.description ?? '');
+      } else {
+        setConfig(defaultConfig(activeBrowseMode?.config));
+        setDefaultBattery(
+          activeBrowseMode?.kind === 'custom' ? activeBrowseMode.default_battery : null,
+        );
+        setName('');
+        setDescription('');
+      }
+      setError(null);
+    }
+  }, [visible, activeBrowseMode, editingPreset, cloneSeed]);
+
+  const tabsValid = config.tabs.length > 0;
+
+  const applyTemplate = (templateId: string) => {
+    const tpl = CUSTOMIZE_TEMPLATES.find((c) => c.id === templateId);
+    if (!tpl) return;
+    setConfig((prev) => ({
+      ...prev,
+      tabs: [...tpl.config.tabs],
+      filters: { ...tpl.config.filters },
+      // Templates fully replace per-tab durations — including clearing them
+      // when switching from Digital detox to a non-time-bounded template.
+      tab_durations: tpl.config.tab_durations ? { ...tpl.config.tab_durations } : undefined,
+    }));
+  };
+
+  const setTabDuration = (tab: BrowseModeTabKey, minutes: number | undefined) => {
+    setConfig((prev) => {
+      const next = { ...(prev.tab_durations ?? {}) };
+      if (minutes === undefined) {
+        delete next[tab];
+      } else {
+        next[tab] = minutes;
+      }
+      const cleaned = Object.keys(next).length > 0 ? next : undefined;
+      return { ...prev, tab_durations: cleaned };
+    });
+  };
+
+  const toggleTab = (tab: BrowseModeTabKey) => {
+    setConfig((prev) => {
+      const has = prev.tabs.includes(tab);
+      return {
+        ...prev,
+        tabs: has ? prev.tabs.filter((t2) => t2 !== tab) : [...prev.tabs, tab],
+      };
+    });
+  };
+
+  const toggleFilter = (key: keyof BrowseModeFilters) => {
+    setConfig((prev) => ({
+      ...prev,
+      filters: { ...prev.filters, [key]: !prev.filters[key] },
+    }));
+  };
+
+  // When the user leaves the name blank, build one from their tab choices —
+  // e.g. "Friends · Update · Share" — so they're not blocked from saving over
+  // a forgotten field. Editing keeps whatever name was there originally.
+  const generateAutoName = (): string => {
+    if (config.tabs.length === 0) return '';
+    const labels = config.tabs.slice(0, 3).map((tab) => String(t(`tabs.${tab}`)));
+    return labels.join(' · ');
+  };
+
+  const handleSave = async () => {
+    const trimmed = name.trim() || generateAutoName();
+    const trimmedDescription = description.trim();
+    if (!trimmed) {
+      // Tabs are also empty — surface the existing tab error rather than the
+      // name error so the user knows what to fix.
+      setError(t('steps.customize.errors.name_required'));
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      if (editingPreset) {
+        await updateCustomBrowseModePreset(editingPreset.id, {
+          name: trimmed,
+          description: trimmedDescription,
+          config,
+          default_battery: defaultBattery,
+        });
+        onSaved({
+          id: editingPreset.id,
+          name: trimmed,
+          config,
+          default_battery: defaultBattery,
+        });
+      } else {
+        const created = await saveCustomBrowseModePreset(
+          trimmed,
+          trimmedDescription,
+          config,
+          defaultBattery,
+        );
+        onSaved({
+          id: created.id,
+          name: created.name,
+          config: created.config,
+          default_battery: created.default_battery,
+        });
+      }
+    } catch (e) {
+      setError(t('steps.customize.errors.save_failed'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return createPortal(
+    <BottomModal visible={visible} onClose={onClose} heightMode="full">
+      <Layout.FlexCol alignItems="center" w="100%" bgColor="WHITE" pb={32}>
+        <Icon name="home_indicator" />
+        <Layout.FlexCol alignItems="center" gap={4} pt={4} ph={16}>
+          <Typo type="title-large">
+            {isEditing ? t('steps.customize.title_edit') : t('steps.customize.title')}
+          </Typo>
+          {/* No subtitle in either mode — the section labels carry the meaning
+              and a separate explanation just adds noise. */}
+        </Layout.FlexCol>
+
+        <Layout.FlexCol w="100%" ph={16} pt={16} gap={20}>
+          {/* Quick-start templates */}
+          <Layout.FlexCol w="100%" gap={6}>
+            <Typo type="title-small">{t('steps.customize.templates_section')}</Typo>
+            <Typo type="body-small" color="MEDIUM_GRAY">
+              {t('steps.customize.templates_subtitle')}
+            </Typo>
+            {/* w="100%" is needed: without it Layout.FlexCol shrinks to its
+                children's intrinsic width and the templates render half-width. */}
+            <Layout.FlexCol w="100%" gap={6} pt={4}>
+              {CUSTOMIZE_TEMPLATES.map((tpl) => (
+                <TemplateButton key={tpl.id} type="button" onClick={() => applyTemplate(tpl.id)}>
+                  <TemplateEmoji>{tpl.emoji}</TemplateEmoji>
+                  <Layout.FlexCol alignItems="flex-start" gap={2}>
+                    <Typo type="title-small">{t(`templates.${tpl.i18nKey}.name`)}</Typo>
+                    <Typo type="body-small" color="MEDIUM_GRAY">
+                      {t(`templates.${tpl.i18nKey}.description`)}
+                    </Typo>
+                  </Layout.FlexCol>
+                </TemplateButton>
+              ))}
+            </Layout.FlexCol>
+          </Layout.FlexCol>
+
+          {/* Show these tabs */}
+          <Layout.FlexCol w="100%" gap={8}>
+            <Typo type="title-small">{t('steps.customize.tabs_section')}</Typo>
+            <Typo type="body-small" color="MEDIUM_GRAY">
+              {t('steps.customize.tabs_subtitle')}
+            </Typo>
+            {ALL_BROWSE_MODE_TABS.map((tab) => {
+              const active = config.tabs.includes(tab);
+              const duration = config.tab_durations?.[tab];
+              return (
+                <Layout.FlexRow key={tab} gap={8} alignItems="center" w="100%">
+                  <TabPill type="button" $active={active} onClick={() => toggleTab(tab)}>
+                    <Typo type="label-large" color={active ? 'PRIMARY' : 'MEDIUM_GRAY'}>
+                      {t(`tabs.${tab}`)}
+                    </Typo>
+                  </TabPill>
+                  {/* Duration selector only meaningful when the tab is on.
+                      Hidden when tab is off so the form doesn't get noisy. */}
+                  {active && (
+                    <DurationSelect
+                      aria-label={String(
+                        t('steps.customize.duration_aria', { tab: t(`tabs.${tab}`) }),
+                      )}
+                      value={duration === undefined ? '' : String(duration)}
+                      onChange={(e) =>
+                        setTabDuration(
+                          tab,
+                          e.target.value === '' ? undefined : Number(e.target.value),
+                        )
+                      }
+                    >
+                      {TAB_DURATION_OPTIONS.map((opt) => (
+                        <option
+                          key={opt.i18nKey}
+                          value={opt.value === undefined ? '' : String(opt.value)}
+                        >
+                          {String(t(`steps.customize.duration_options.${opt.i18nKey}`))}
+                        </option>
+                      ))}
+                    </DurationSelect>
+                  )}
+                </Layout.FlexRow>
+              );
+            })}
+            {!tabsValid && (
+              <Typo type="label-small" color="MEDIUM_GRAY">
+                {t('steps.customize.errors.tabs_required')}
+              </Typo>
+            )}
+          </Layout.FlexCol>
+
+          {/* Apply these filters */}
+          <Layout.FlexCol w="100%" gap={8}>
+            <Typo type="title-small">{t('steps.customize.filters_section')}</Typo>
+            {FILTER_KEYS.map((key) => (
+              <ToggleRow
+                key={key}
+                label={String(t(`filters.${key}`))}
+                checked={!!config.filters[key]}
+                onToggle={() => toggleFilter(key)}
+              />
+            ))}
+          </Layout.FlexCol>
+
+          {/* Default battery (optional) — when set, the "Also set my battery"
+              sync toggle on the mode picker will apply this battery on activation. */}
+          <Layout.FlexCol w="100%" gap={6}>
+            <Typo type="title-small">{t('steps.customize.battery_section')}</Typo>
+            <Typo type="body-small" color="MEDIUM_GRAY">
+              {t('steps.customize.battery_subtitle')}
+            </Typo>
+            <Layout.FlexRow gap={6} pt={4} style={{ flexWrap: 'wrap' }}>
+              <NoneChip
+                type="button"
+                $active={defaultBattery === null}
+                onClick={() => setDefaultBattery(null)}
+              >
+                <Typo
+                  type="label-large"
+                  color={defaultBattery === null ? 'PRIMARY' : 'MEDIUM_GRAY'}
+                >
+                  {t('steps.customize.battery_none')}
+                </Typo>
+              </NoneChip>
+              {Object.values(SocialBattery).map((battery) => (
+                <SocialBatteryChip
+                  key={battery}
+                  socialBattery={battery}
+                  onSelect={() => setDefaultBattery(battery)}
+                  isSelected={defaultBattery === battery}
+                />
+              ))}
+            </Layout.FlexRow>
+          </Layout.FlexCol>
+
+          {/* Save section — name input is always visible so the path to a saved
+              mode is one continuous form, not a hidden two-step. "Apply without
+              saving" stays as the no-name escape hatch.
+              The label/input/counter use a small inline-form style instead of
+              the design-system Input (which is sized for prominent login-style
+              forms and visually overpowers this multi-section sheet). */}
+          <Layout.FlexCol w="100%" gap={12}>
+            <Layout.FlexCol w="100%" gap={4}>
+              <Typo type="title-small" color="MEDIUM_GRAY">
+                {t('steps.customize.name_label')}
+              </Typo>
+              <NameInput
+                type="text"
+                placeholder={String(t('steps.customize.name_placeholder'))}
+                value={name}
+                maxLength={40}
+                onChange={(e) => setName(e.target.value)}
+                autoCapitalize="none"
+                autoComplete="off"
+              />
+              <Layout.FlexRow w="100%" justifyContent="flex-end">
+                <Typo type="label-small" color="DARK_GRAY">
+                  {name.length} / 40
+                </Typo>
+              </Layout.FlexRow>
+
+              {/* Optional one-line description shown under the name on the
+                  picker card. Backend caps at 30 — short on purpose so the
+                  card doesn't grow unpredictably when the description has to
+                  share a row with the chevron / X. */}
+              <Typo type="title-small" color="MEDIUM_GRAY">
+                {t('steps.customize.description_label')}
+              </Typo>
+              <NameInput
+                type="text"
+                placeholder={String(t('steps.customize.description_placeholder'))}
+                value={description}
+                maxLength={30}
+                onChange={(e) => setDescription(e.target.value)}
+                autoCapitalize="none"
+                autoComplete="off"
+              />
+              <Layout.FlexRow w="100%" justifyContent="flex-end">
+                <Typo type="label-small" color="DARK_GRAY">
+                  {description.length} / 30
+                </Typo>
+              </Layout.FlexRow>
+
+              {error && (
+                <Typo type="label-small" color="WARNING">
+                  {error}
+                </Typo>
+              )}
+            </Layout.FlexCol>
+            {/* Save is enabled as soon as tabs are valid — name can be blank
+                because we auto-slug from tab choices in handleSave. */}
+            <BottomModalActionButton
+              status={tabsValid && !saving ? 'normal' : 'disabled'}
+              text={t('steps.customize.save')}
+              onClick={handleSave}
+            />
+            <ApplyWithoutSavingLink
+              type="button"
+              onClick={() =>
+                tabsValid &&
+                onApplyWithoutSaving({
+                  config,
+                  name,
+                  description,
+                  default_battery: defaultBattery,
+                })
+              }
+              disabled={!tabsValid}
+            >
+              <Typo type="label-large" color={tabsValid ? 'PRIMARY' : 'LIGHT_GRAY'}>
+                {t('steps.customize.apply_without_saving')}
+              </Typo>
+            </ApplyWithoutSavingLink>
+          </Layout.FlexCol>
+        </Layout.FlexCol>
+      </Layout.FlexCol>
+    </BottomModal>,
+    document.body,
+  );
+}
+
+interface ToggleRowProps {
+  label: string;
+  checked: boolean;
+  onToggle: () => void;
+}
+
+function ToggleRow({ label, checked, onToggle }: ToggleRowProps) {
+  return (
+    <ToggleButton type="button" onClick={onToggle} aria-pressed={checked}>
+      <CheckSquare $checked={checked} />
+      <Typo type="body-medium">{label}</Typo>
+    </ToggleButton>
+  );
+}
+
+export default BrowseModeCustomizeSheet;
+
+const TemplateButton = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  background: ${Colors.WHITE};
+  border: 1px solid ${Colors.LIGHT_GRAY};
+  border-radius: 12px;
+  padding: 10px 12px;
+  cursor: pointer;
+  text-align: left;
+  &:hover {
+    border-color: ${Colors.PRIMARY};
+  }
+`;
+
+const TemplateEmoji = styled.span`
+  font-size: 22px;
+  line-height: 1;
+`;
+
+const TabPill = styled.button<{ $active: boolean }>`
+  border-radius: 8px;
+  padding: 4px 8px;
+  border: 1px solid ${({ $active }) => ($active ? Colors.PRIMARY : Colors.LIGHT_GRAY)};
+  background: ${({ $active }) => ($active ? '#F3E8FF' : Colors.WHITE)};
+  cursor: pointer;
+  /* Pill is the wider element on the left; let it shrink before the
+     duration select if both can't fit. Min-width keeps the label readable. */
+  flex-shrink: 0;
+  min-width: 80px;
+  text-align: left;
+`;
+
+// iOS-Focus-mode-style time picker. Uses the native <select> so iOS gives
+// the system wheel UI and Android the dropdown — same UX users already
+// know from Focus / Do Not Disturb settings.
+const DurationSelect = styled.select`
+  border-radius: 8px;
+  padding: 4px 8px;
+  border: 1px solid ${Colors.LIGHT_GRAY};
+  background: ${Colors.WHITE};
+  font-size: 14px;
+  font-family: inherit;
+  color: ${Colors.DARK_GRAY};
+  cursor: pointer;
+  &:focus {
+    outline: none;
+    border-color: ${Colors.PRIMARY};
+  }
+`;
+
+const NoneChip = styled.button<{ $active: boolean }>`
+  border-radius: 8px;
+  padding: 4px 8px;
+  border: 1px solid ${({ $active }) => ($active ? Colors.PRIMARY : Colors.LIGHT_GRAY)};
+  background: ${({ $active }) => ($active ? '#F3E8FF' : Colors.WHITE)};
+  cursor: pointer;
+`;
+
+const ToggleButton = styled.button`
+  background: none;
+  border: none;
+  padding: 6px 0;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  text-align: left;
+  width: 100%;
+`;
+
+const CheckSquare = styled.span<{ $checked: boolean }>`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 4px;
+  border: 1.5px solid ${({ $checked }) => ($checked ? Colors.PRIMARY : Colors.MEDIUM_GRAY)};
+  background: ${({ $checked }) => ($checked ? Colors.PRIMARY : 'transparent')};
+  position: relative;
+  flex-shrink: 0;
+  &::after {
+    content: '';
+    display: ${({ $checked }) => ($checked ? 'block' : 'none')};
+    width: 4px;
+    height: 8px;
+    border-right: 2px solid white;
+    border-bottom: 2px solid white;
+    transform: translateY(-1px) rotate(45deg);
+  }
+`;
+
+const ApplyWithoutSavingLink = styled.button`
+  background: none;
+  border: none;
+  padding: 8px 0;
+  cursor: ${({ disabled }) => (disabled ? 'default' : 'pointer')};
+  align-self: center;
+`;
+
+// Inline-form input. Same look as the design-system Input (underline that
+// thickens + tints PRIMARY on focus) but with tighter vertical padding so
+// the field doesn't dwarf the surrounding 14px body text on this sheet.
+const NameInput = styled.input`
+  width: 100%;
+  outline: none;
+  padding: 6px 0;
+  font-size: 14px;
+  font-family: inherit;
+  border-width: 0 0 1px;
+  border-color: ${Colors.MEDIUM_GRAY};
+  &:focus {
+    border-bottom-width: 2px;
+    border-bottom-color: ${Colors.PRIMARY};
+    padding-bottom: 5px;
+  }
+  &::placeholder {
+    color: ${Colors.MEDIUM_GRAY};
+  }
+`;

--- a/src/components/browse-mode/BrowseModePreviewBar.tsx
+++ b/src/components/browse-mode/BrowseModePreviewBar.tsx
@@ -1,0 +1,158 @@
+import { useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import styled, { createGlobalStyle } from 'styled-components';
+import { Colors, SvgIcon, Typo } from '@design-system';
+import { useBoundStore } from '@stores/useBoundStore';
+
+/**
+ * Top-of-app bar that shows when the user activated a transient "Apply
+ * without saving" custom mode. Acts like the "View as" preview pattern —
+ * makes it visually obvious the current view is hypothetical, and gives
+ * one tap to exit and return to the picker.
+ *
+ * Renders nothing when no mode is active or the active mode is a real
+ * built-in / saved preset. The transient mode is identified by
+ * `id === -1` (the sentinel set in BrowseModeSessionPrompt's
+ * "Apply without saving" handler).
+ */
+const PREVIEW_BODY_CLASS = 'browse-mode-preview-active';
+
+/**
+ * Global style applied while preview is active: every interactive element
+ * (button / link / input / etc.) gets `pointer-events: none` so the user
+ * can SEE the app under their hypothetical mode but can't actually act on
+ * it. The preview bar itself opts back in via `data-preview-exempt`.
+ *
+ * Scrolling is unaffected because we don't blanket the whole body — only
+ * named interactive elements.
+ */
+const PreviewGlobalStyle = createGlobalStyle`
+  body.${PREVIEW_BODY_CLASS} button:not([data-preview-exempt]):not([data-preview-exempt] *),
+  body.${PREVIEW_BODY_CLASS} a:not([data-preview-exempt]):not([data-preview-exempt] *),
+  body.${PREVIEW_BODY_CLASS} input,
+  body.${PREVIEW_BODY_CLASS} textarea,
+  body.${PREVIEW_BODY_CLASS} select,
+  body.${PREVIEW_BODY_CLASS} [role="button"]:not([data-preview-exempt]):not([data-preview-exempt] *),
+  body.${PREVIEW_BODY_CLASS} [role="link"]:not([data-preview-exempt]):not([data-preview-exempt] *),
+  body.${PREVIEW_BODY_CLASS} [role="checkbox"]:not([data-preview-exempt]):not([data-preview-exempt] *) {
+    pointer-events: none !important;
+    cursor: default !important;
+  }
+  body.${PREVIEW_BODY_CLASS} [data-preview-exempt],
+  body.${PREVIEW_BODY_CLASS} [data-preview-exempt] * {
+    pointer-events: auto !important;
+    cursor: pointer !important;
+  }
+`;
+
+function BrowseModePreviewBar() {
+  const [t] = useTranslation('translation', { keyPrefix: 'browse_mode' });
+  const activeBrowseMode = useBoundStore((state) => state.activeBrowseMode);
+  const clearActiveBrowseMode = useBoundStore((state) => state.clearActiveBrowseMode);
+  const openBrowseModePicker = useBoundStore((state) => state.openBrowseModePicker);
+  const openToast = useBoundStore((state) => state.openToast);
+
+  const isPreview = activeBrowseMode?.kind === 'custom' && activeBrowseMode.id === -1;
+  // Throttle "blocked click" toasts: rapid taps would otherwise spam the
+  // toast queue. Stored as a ref because we don't want re-renders for
+  // this debounce timestamp.
+  const lastBlockedToastAt = useRef(0);
+
+  // Toggle the body class so the global style above kicks in. Done as an
+  // effect (not direct render) so we clean up reliably on unmount /
+  // mode-change — no risk of leaving the app in a "frozen" state.
+  useEffect(() => {
+    if (isPreview) {
+      document.body.classList.add(PREVIEW_BODY_CLASS);
+      return () => document.body.classList.remove(PREVIEW_BODY_CLASS);
+    }
+    return undefined;
+  }, [isPreview]);
+
+  // Belt and braces over the body-class CSS: lots of interactive things in
+  // this app aren't `<button>` / `[role="button"]` (e.g. ping pills, like
+  // hearts, `<div onClick>` cards) so a CSS-selector approach misses them.
+  // A capture-phase event listener catches every click/touch/key activation
+  // before it reaches its handler, then short-circuits unless the target is
+  // inside an element marked `data-preview-exempt` (the bar itself).
+  useEffect(() => {
+    if (!isPreview) return undefined;
+    const block = (e: Event) => {
+      const { target } = e;
+      if (target instanceof Element && target.closest('[data-preview-exempt]')) return;
+      e.preventDefault();
+      e.stopPropagation();
+      // Some component libraries register handlers via React's synthetic
+      // system AND a native handler — stopImmediatePropagation kills both.
+      e.stopImmediatePropagation();
+      // Surface a toast so the user understands WHY their tap had no
+      // effect, instead of just silently doing nothing. Throttled to one
+      // per ~1.5 s so a flurry of taps doesn't queue a stack of toasts.
+      const now = Date.now();
+      if (now - lastBlockedToastAt.current > 1500) {
+        lastBlockedToastAt.current = now;
+        openToast({ message: String(t('preview_bar.blocked_toast')) });
+      }
+    };
+    // `click` covers tap / mouse / Enter+Space activations on buttons.
+    // We intentionally do NOT block touchstart/touchmove — that'd kill
+    // body scroll on touch screens and the user wouldn't be able to see
+    // how the rest of the page LOOKS in the preview.
+    const events: ('click' | 'submit')[] = ['click', 'submit'];
+    events.forEach((evt) => document.addEventListener(evt, block, true));
+    return () => {
+      events.forEach((evt) => document.removeEventListener(evt, block, true));
+    };
+  }, [isPreview, openToast, t]);
+
+  if (!isPreview) return null;
+
+  const handleExit = () => {
+    clearActiveBrowseMode();
+    openBrowseModePicker();
+  };
+
+  return (
+    <>
+      <PreviewGlobalStyle />
+      <Bar role="status" aria-live="polite" data-preview-exempt>
+        <Typo type="label-large" color="PRIMARY">
+          {t('preview_bar.label')}
+        </Typo>
+        <ExitButton
+          type="button"
+          onClick={handleExit}
+          aria-label={String(t('preview_bar.exit_aria'))}
+          data-preview-exempt
+        >
+          <SvgIcon name="close" size={16} />
+        </ExitButton>
+      </Bar>
+    </>
+  );
+}
+
+export default BrowseModePreviewBar;
+
+const Bar = styled.div`
+  position: sticky;
+  top: 0;
+  z-index: 1100;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 16px;
+  background: #f3e8ff;
+  border-bottom: 1px solid ${Colors.PRIMARY};
+`;
+
+const ExitButton = styled.button`
+  background: none;
+  border: none;
+  padding: 4px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+`;

--- a/src/components/browse-mode/BrowseModeSessionPrompt.tsx
+++ b/src/components/browse-mode/BrowseModeSessionPrompt.tsx
@@ -1,0 +1,475 @@
+import { useCallback, useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
+import CommonDialog from '@components/_common/alert-dialog/common-dialog/CommonDialog';
+import BottomModal from '@components/_common/bottom-modal/BottomModal';
+import { SocialBatteryChipAssets } from '@components/profile/social-batter-chip/SocialBatteryChip.contants';
+import { BUILT_IN_BROWSE_MODES } from '@constants/browseMode';
+import { Colors, SvgIcon, Typo } from '@design-system';
+import { usePreventScroll } from '@hooks/usePreventScroll';
+import {
+  ActiveBrowseMode,
+  BrowseModeConfig,
+  BuiltInBrowseModeId,
+  CustomBrowseModePreset,
+} from '@models/browseMode';
+import { SocialBattery } from '@models/checkIn';
+import { useBoundStore } from '@stores/useBoundStore';
+import { postCheckIn } from '@utils/apis/checkIn';
+import { HiddenModeKey, readHiddenModes, writeHiddenModes } from '@utils/browseModeHiddenModes';
+import { saveLastPickedMode } from '@utils/browseModeLastPick';
+import BrowseModeCustomizeSheet from './BrowseModeCustomizeSheet';
+import BrowseModeStepMode, { ModeChoice } from './BrowseModeStepMode';
+import BrowseModeWishlistSheet from './BrowseModeWishlistSheet';
+
+const SYNC_PREF_KEY = 'browse_mode_sync_battery_pref';
+
+interface BrowseModeSessionPromptProps {
+  visible: boolean;
+  onDismiss: () => void;
+  onFinish: () => void;
+  /**
+   * When true, render as a full-screen takeover (opaque, blocks all underlying UI)
+   * instead of the bottom-sheet style. Used for the auto-prompt at session start so
+   * the user picks their vibe BEFORE being flooded with the app's content.
+   */
+  fullScreen?: boolean;
+}
+
+function readSyncPref(): boolean {
+  const stored = localStorage.getItem(SYNC_PREF_KEY);
+  if (stored === null) return true; // default ON
+  return stored === 'true';
+}
+
+function writeSyncPref(value: boolean) {
+  localStorage.setItem(SYNC_PREF_KEY, value ? 'true' : 'false');
+}
+
+function BrowseModeSessionPrompt({
+  visible,
+  onDismiss,
+  onFinish,
+  fullScreen = false,
+}: BrowseModeSessionPromptProps) {
+  const [t] = useTranslation('translation', { keyPrefix: 'browse_mode' });
+  // Battery labels are top-level (`social_battery.<key>`) — separate `t` without a keyPrefix.
+  const [tRoot] = useTranslation('translation');
+  const navigate = useNavigate();
+  usePreventScroll(fullScreen && visible);
+
+  const [syncBattery, setSyncBattery] = useState<boolean>(readSyncPref);
+  const [customizeOpen, setCustomizeOpen] = useState(false);
+  // When set, BrowseModeCustomizeSheet opens in EDIT mode prefilled with this
+  // preset's values. Cleared on close so the next "Add a new browsing mode"
+  // tap starts from the active mode again.
+  const [editingPreset, setEditingPreset] = useState<CustomBrowseModePreset | null>(null);
+  // When set, the customize sheet opens prefilled with these values but Save
+  // creates a NEW custom preset (used for "fork a built-in" via the chevron).
+  const [cloneSeed, setCloneSeed] = useState<{
+    config: BrowseModeConfig;
+    name: string;
+    description?: string;
+    default_battery: SocialBattery | null;
+  } | null>(null);
+  const [pendingDeletePreset, setPendingDeletePreset] = useState<CustomBrowseModePreset | null>(
+    null,
+  );
+  const [hiddenModeKeys, setHiddenModeKeys] = useState<HiddenModeKey[]>([]);
+  const [wishlistOpen, setWishlistOpen] = useState(false);
+
+  const checkIn = useBoundStore((state) => state.checkIn);
+  const fetchCheckIn = useBoundStore((state) => state.fetchCheckIn);
+  const customPresets = useBoundStore((state) => state.customBrowseModePresets);
+  const activeBrowseMode = useBoundStore((state) => state.activeBrowseMode);
+  const myProfile = useBoundStore((state) => state.myProfile);
+  const setActiveBuiltIn = useBoundStore((state) => state.setActiveBuiltInBrowseMode);
+  const setActiveCustom = useBoundStore((state) => state.setActiveCustomBrowseMode);
+  const deleteCustomBrowseModePreset = useBoundStore((state) => state.deleteCustomBrowseModePreset);
+  const openToast = useBoundStore((state) => state.openToast);
+
+  const handleSyncToggle = useCallback((next: boolean) => {
+    setSyncBattery(next);
+    writeSyncPref(next);
+  }, []);
+
+  // Hydrate hidden mode keys from localStorage every time the picker opens —
+  // captures changes made elsewhere (e.g. another tab) without requiring us
+  // to thread the value through the store.
+  useEffect(() => {
+    if (visible && myProfile?.id) {
+      setHiddenModeKeys(readHiddenModes(myProfile.id));
+    }
+  }, [visible, myProfile?.id]);
+
+  // When the picker opens with a customize-restore snapshot in the store
+  // (the preview bar's exit-X path), re-enter the customize sheet with the
+  // same form state the user had before applying without saving.
+  const customizeRestoreSnapshot = useBoundStore((state) => state.customizeRestoreSnapshot);
+  const setCustomizeRestoreSnapshot = useBoundStore((state) => state.setCustomizeRestoreSnapshot);
+  useEffect(() => {
+    if (!visible || !customizeRestoreSnapshot) return;
+    const { editingPresetId, config, name, description, default_battery } =
+      customizeRestoreSnapshot;
+    const editingMatch = editingPresetId
+      ? customPresets.find((p) => p.id === editingPresetId) ?? null
+      : null;
+    setEditingPreset(editingMatch);
+    setCloneSeed({ config, name, description, default_battery });
+    setCustomizeOpen(true);
+    setCustomizeRestoreSnapshot(null);
+  }, [visible, customizeRestoreSnapshot, customPresets, setCustomizeRestoreSnapshot]);
+
+  const persistHiddenModes = useCallback(
+    (next: HiddenModeKey[]) => {
+      setHiddenModeKeys(next);
+      if (myProfile?.id) writeHiddenModes(myProfile.id, next);
+    },
+    [myProfile?.id],
+  );
+
+  const handleHideMode = useCallback(
+    (modeKey: HiddenModeKey) => {
+      persistHiddenModes(
+        hiddenModeKeys.includes(modeKey) ? hiddenModeKeys : [...hiddenModeKeys, modeKey],
+      );
+    },
+    [hiddenModeKeys, persistHiddenModes],
+  );
+
+  const handleShowMode = useCallback(
+    (modeKey: HiddenModeKey) => {
+      persistHiddenModes(hiddenModeKeys.filter((x) => x !== modeKey));
+    },
+    [hiddenModeKeys, persistHiddenModes],
+  );
+
+  const handleCloneBuiltIn = useCallback(
+    (id: BuiltInBrowseModeId) => {
+      const built = BUILT_IN_BROWSE_MODES[id];
+      const baseName = String(t(`modes.${built.i18nKey}.name`));
+      setCloneSeed({
+        config: built.config,
+        // Suffix nudges users that this is THEIR copy — they can rename freely.
+        name: String(t('steps.mode.clone_name_suffix', { name: baseName })),
+        default_battery: built.suggestedBattery,
+      });
+      setEditingPreset(null);
+      setCustomizeOpen(true);
+    },
+    [t],
+  );
+
+  const applyMode = useCallback(
+    async (
+      mode: ActiveBrowseMode,
+      suggestedBattery: SocialBattery | null,
+      // `keepPickerOpen` is the post-Save flow's pivot: we activate the new
+      // preset (so it shows as "Current" in the picker list) but leave the
+      // picker mounted instead of closing it. The battery-adjust toast is
+      // also suppressed because tapping the toast's "Adjust" link would
+      // navigate AWAY while the picker is still open — confusing.
+      { keepPickerOpen = false }: { keepPickerOpen?: boolean } = {},
+    ) => {
+      if (mode.kind === 'built_in') {
+        setActiveBuiltIn(mode.id);
+      } else {
+        await setActiveCustom({
+          kind: 'custom',
+          id: mode.id,
+          name: mode.name,
+          // Description is metadata for the picker card; the active-mode
+          // store slice doesn't read it. Empty string is the safe default
+          // since ActiveBrowseMode doesn't carry description.
+          description: '',
+          config: mode.config,
+          default_battery: mode.default_battery,
+          last_used_at: null,
+          created_at: '',
+          updated_at: '',
+        });
+      }
+      if (myProfile?.id) saveLastPickedMode(myProfile.id, mode);
+
+      let batteryApplied: SocialBattery | null = null;
+      if (syncBattery && suggestedBattery) {
+        try {
+          await postCheckIn({
+            ...(checkIn ?? {}),
+            social_battery: suggestedBattery,
+            mood: checkIn?.mood ?? [],
+            thought: checkIn?.thought ?? '',
+            track_id: checkIn?.track_id ?? '',
+          });
+          await fetchCheckIn();
+          batteryApplied = suggestedBattery;
+        } catch {
+          // Sync is best-effort — don't block mode activation on a battery write failure.
+        }
+      }
+
+      if (!keepPickerOpen) onFinish();
+
+      // Confirm the mode change with a toast — "Browsing in <name> mode".
+      // When the battery sync also fired, fold the battery into the same
+      // toast so we don't queue two notifications back-to-back; the
+      // "Adjust" action stays in the keepPickerOpen=false flow only,
+      // since navigating away while the picker's still open is jarring.
+      const modeName =
+        mode.kind === 'built_in'
+          ? String(t(`modes.${BUILT_IN_BROWSE_MODES[mode.id].i18nKey}.name`))
+          : mode.name;
+      if (batteryApplied) {
+        const emoji = SocialBatteryChipAssets[batteryApplied].emoji ?? '';
+        openToast({
+          message: String(
+            t('toasts.browsing_in_with_battery', {
+              name: modeName,
+              emoji,
+              label: tRoot(`social_battery.${batteryApplied}`),
+            }),
+          ),
+          ...(keepPickerOpen
+            ? {}
+            : {
+                actionText: String(t('toasts.adjust')),
+                action: () => navigate('/update'),
+              }),
+        });
+      } else {
+        openToast({
+          message: String(t('toasts.browsing_in', { name: modeName })),
+        });
+      }
+    },
+    [
+      checkIn,
+      fetchCheckIn,
+      myProfile?.id,
+      navigate,
+      onFinish,
+      openToast,
+      setActiveBuiltIn,
+      setActiveCustom,
+      syncBattery,
+      t,
+      tRoot,
+    ],
+  );
+
+  const handleModePick = useCallback(
+    async (choice: ModeChoice) => {
+      if (choice.kind === 'built_in') {
+        const built = BUILT_IN_BROWSE_MODES[choice.id];
+        await applyMode(
+          { kind: 'built_in', id: built.id, config: built.config },
+          built.suggestedBattery,
+        );
+      } else if (choice.kind === 'custom') {
+        await applyMode(
+          {
+            kind: 'custom',
+            id: choice.preset.id,
+            name: choice.preset.name,
+            config: choice.preset.config,
+            default_battery: choice.preset.default_battery,
+          },
+          choice.preset.default_battery,
+        );
+      }
+    },
+    [applyMode],
+  );
+
+  const closeCustomize = useCallback(() => {
+    setCustomizeOpen(false);
+    setEditingPreset(null);
+    setCloneSeed(null);
+  }, []);
+
+  const handleEditPreset = useCallback((preset: CustomBrowseModePreset) => {
+    setCloneSeed(null);
+    setEditingPreset(preset);
+    setCustomizeOpen(true);
+  }, []);
+
+  const handleDeletePreset = useCallback((preset: CustomBrowseModePreset) => {
+    setPendingDeletePreset(preset);
+  }, []);
+
+  const handleCustomizeSaved = useCallback(async () => {
+    // Save just persists the preset — no auto-activation. The picker stays
+    // open and the new / edited preset appears in the saved-modes list;
+    // the user explicitly picks it to start browsing in it. Keeps the
+    // "create" flow distinct from the "switch" flow so we don't surprise
+    // them with a mode change they didn't ask for.
+    closeCustomize();
+  }, [closeCustomize]);
+
+  const handleCustomizeApplyWithoutSaving = useCallback(
+    async (snapshot: {
+      config: BrowseModeConfig;
+      name: string;
+      description: string;
+      default_battery: SocialBattery | null;
+    }) => {
+      // Capture the customize-sheet form state BEFORE closing — so the preview
+      // bar's exit X can drop the user back into the same edit/create flow
+      // they were in (with their tweaks intact) instead of the picker root.
+      useBoundStore.getState().setCustomizeRestoreSnapshot({
+        editingPresetId: editingPreset?.id ?? null,
+        config: snapshot.config,
+        name: snapshot.name,
+        description: snapshot.description,
+        default_battery: snapshot.default_battery,
+      });
+      closeCustomize();
+      // Ad-hoc mode: write directly to the store (no backend persistence, no
+      // last_used_at bump). The id `-1` flags it as transient — store actions
+      // refuse to mark it used / mutate it server-side.
+      useBoundStore.setState({
+        activeBrowseMode: {
+          kind: 'custom',
+          id: -1,
+          name: 'Custom',
+          config: snapshot.config,
+          default_battery: snapshot.default_battery,
+        },
+      });
+      onFinish();
+    },
+    [closeCustomize, editingPreset?.id, onFinish],
+  );
+
+  const handleConfirmDelete = useCallback(async () => {
+    if (!pendingDeletePreset) return;
+    try {
+      await deleteCustomBrowseModePreset(pendingDeletePreset.id);
+    } catch {
+      // Best-effort: the store will still re-fetch on next open. Surface a toast
+      // so the user knows it didn't stick rather than silently failing.
+      openToast({ message: String(t('toasts.delete_failed')) });
+    } finally {
+      setPendingDeletePreset(null);
+    }
+  }, [deleteCustomBrowseModePreset, openToast, pendingDeletePreset, t]);
+
+  const stepContent = (
+    <BrowseModeStepMode
+      presets={customPresets}
+      lastActive={activeBrowseMode}
+      syncBattery={syncBattery}
+      hiddenModeKeys={hiddenModeKeys}
+      onSyncToggle={handleSyncToggle}
+      onPick={handleModePick}
+      onOpenCustomize={() => {
+        setCloneSeed(null);
+        setEditingPreset(null);
+        setCustomizeOpen(true);
+      }}
+      onOpenWishlist={() => setWishlistOpen(true)}
+      onCloneBuiltIn={handleCloneBuiltIn}
+      onEditPreset={handleEditPreset}
+      onHideMode={handleHideMode}
+      onShowMode={handleShowMode}
+      onDeleteMode={handleDeletePreset}
+    />
+  );
+
+  return (
+    <>
+      {fullScreen
+        ? createPortal(
+            visible && !customizeOpen && !wishlistOpen ? (
+              <FullScreenOverlay role="dialog" aria-modal="true">
+                <SkipBar>
+                  <SkipButton
+                    type="button"
+                    onClick={onDismiss}
+                    aria-label={String(t('full_screen.skip'))}
+                  >
+                    <Typo type="label-large" color="MEDIUM_GRAY">
+                      {t('full_screen.skip')}
+                    </Typo>
+                    <SvgIcon name="close" size={20} />
+                  </SkipButton>
+                </SkipBar>
+                <FullScreenBody>{stepContent}</FullScreenBody>
+              </FullScreenOverlay>
+            ) : null,
+            document.body,
+          )
+        : createPortal(
+            <BottomModal visible={visible && !customizeOpen && !wishlistOpen} onClose={onDismiss}>
+              {stepContent}
+            </BottomModal>,
+            document.body,
+          )}
+      <BrowseModeCustomizeSheet
+        visible={visible && customizeOpen}
+        onClose={closeCustomize}
+        onSaved={handleCustomizeSaved}
+        onApplyWithoutSaving={handleCustomizeApplyWithoutSaving}
+        editingPreset={editingPreset}
+        cloneSeed={cloneSeed}
+      />
+      <BrowseModeWishlistSheet
+        visible={visible && wishlistOpen}
+        onClose={() => setWishlistOpen(false)}
+      />
+      <CommonDialog
+        visible={!!pendingDeletePreset}
+        title={String(t('steps.mode.delete_confirm_title'))}
+        content={
+          pendingDeletePreset
+            ? String(t('steps.mode.delete_confirm_content', { name: pendingDeletePreset.name }))
+            : null
+        }
+        cancelText={String(t('steps.mode.delete_confirm_cancel'))}
+        confirmText={String(t('steps.mode.delete_confirm_confirm'))}
+        confirmTextColor="WARNING"
+        onClickConfirm={handleConfirmDelete}
+        onClickClose={() => setPendingDeletePreset(null)}
+      />
+    </>
+  );
+}
+
+export default BrowseModeSessionPrompt;
+
+const FullScreenOverlay = styled.div`
+  position: fixed;
+  inset: 0;
+  background: ${Colors.WHITE};
+  z-index: 2500;
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+`;
+
+const SkipBar = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  padding: 12px 16px;
+`;
+
+const SkipButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: none;
+  border: none;
+  padding: 8px;
+  cursor: pointer;
+`;
+
+const FullScreenBody = styled.div`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 0 8px 24px;
+`;

--- a/src/components/browse-mode/BrowseModeStepMode.tsx
+++ b/src/components/browse-mode/BrowseModeStepMode.tsx
@@ -136,7 +136,7 @@ function BrowseModeStepMode({
           return (
             <ModeCard
               key={mode.id}
-              type="button"
+              role={editListMode ? undefined : 'button'}
               $selected={selected}
               $editing={editListMode}
               onClick={handleCardClick}
@@ -225,7 +225,7 @@ function BrowseModeStepMode({
               return (
                 <ModeCard
                   key={preset.id}
-                  type="button"
+                  role={editListMode ? undefined : 'button'}
                   $selected={selected}
                   $editing={editListMode}
                   onClick={handleCardClick}
@@ -400,7 +400,12 @@ function BrowseModeStepMode({
 
 export default BrowseModeStepMode;
 
-const ModeCard = styled.button<{ $selected: boolean; $editing: boolean }>`
+// ModeCard is a div (not a <button>) because it nests inner <button> icons
+// for the chevron / X — <button> inside <button> is invalid HTML.
+// role="button" + tabIndex give it the same a11y semantics. Click is the
+// only activation we surface; keyboard activation isn't critical here
+// because the inner chevron / X covers that path.
+const ModeCard = styled.div<{ $selected: boolean; $editing: boolean }>`
   background: ${({ $selected }) => ($selected ? '#F3E8FF' : Colors.WHITE)};
   border: 1px solid ${({ $selected }) => ($selected ? Colors.PRIMARY : Colors.LIGHT_GRAY)};
   border-radius: 12px;

--- a/src/components/browse-mode/BrowseModeStepMode.tsx
+++ b/src/components/browse-mode/BrowseModeStepMode.tsx
@@ -1,0 +1,523 @@
+import { MouseEvent, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import styled from 'styled-components';
+import Icon from '@components/_common/icon/Icon';
+import { SocialBatteryChipAssets } from '@components/profile/social-batter-chip/SocialBatteryChip.contants';
+import { BUILT_IN_BROWSE_MODE_LIST } from '@constants/browseMode';
+import { Colors, Layout, SvgIcon, Typo } from '@design-system';
+import { ActiveBrowseMode, BuiltInBrowseModeId, CustomBrowseModePreset } from '@models/browseMode';
+import { useBoundStore } from '@stores/useBoundStore';
+import { builtInKey, customKey, HiddenModeKey } from '@utils/browseModeHiddenModes';
+import { isBuiltInPicked, isCustomPicked, readLastPickedMode } from '@utils/browseModeLastPick';
+
+export type ModeChoice =
+  | { kind: 'built_in'; id: BuiltInBrowseModeId }
+  | { kind: 'custom'; preset: CustomBrowseModePreset };
+
+interface BrowseModeStepModeProps {
+  presets: CustomBrowseModePreset[];
+  /** Currently active mode in this session (used as a fallback for pre-selection). */
+  lastActive: ActiveBrowseMode | null;
+  syncBattery: boolean;
+  /**
+   * Modes the user has chosen to hide from the picker. Covers both built-ins
+   * and custom presets — same hide affordance for both, since the user just
+   * wants a clean list either way. See {@link HiddenModeKey}.
+   */
+  hiddenModeKeys: HiddenModeKey[];
+  onSyncToggle: (next: boolean) => void;
+  onPick: (choice: ModeChoice) => void;
+  onOpenCustomize: () => void;
+  /** Open the "tell us what you wish the picker did" sheet. */
+  onOpenWishlist: () => void;
+  /** Tap the `>` chevron on a built-in: opens customize as a "fork & save". */
+  onCloneBuiltIn: (id: BuiltInBrowseModeId) => void;
+  onEditPreset: (preset: CustomBrowseModePreset) => void;
+  /** Soft-hide (recoverable) a mode from the picker; works for either kind. */
+  onHideMode: (key: HiddenModeKey) => void;
+  /** Restore a hidden mode back to the picker. */
+  onShowMode: (key: HiddenModeKey) => void;
+  /** Permanently delete a saved preset (offered only via the Hidden section). */
+  onDeleteMode: (preset: CustomBrowseModePreset) => void;
+}
+
+function BrowseModeStepMode({
+  presets,
+  lastActive,
+  syncBattery,
+  hiddenModeKeys,
+  onSyncToggle,
+  onPick,
+  onOpenCustomize,
+  onOpenWishlist,
+  onCloneBuiltIn,
+  onEditPreset,
+  onHideMode,
+  onShowMode,
+  onDeleteMode,
+}: BrowseModeStepModeProps) {
+  const [t] = useTranslation('translation', { keyPrefix: 'browse_mode' });
+  // Battery labels live at the top level (`social_battery.<key>`) — outside our keyPrefix.
+  const [tRoot] = useTranslation('translation');
+  const userId = useBoundStore((state) => state.myProfile?.id);
+
+  // Edit-list mode: cards swap their `>` chevron for an `✕` remove. Built-in
+  // X = hide (per-user localStorage); custom X = delete (with confirm). In
+  // edit mode the card body is non-interactive — you're managing, not picking.
+  const [editListMode, setEditListMode] = useState(false);
+
+  // Hidden modes never appear in the main list — even in edit mode they
+  // surface only via the "Hidden" section below (so the same item never
+  // shows twice). Same treatment for built-ins and custom presets.
+  const isBuiltInHidden = (id: BuiltInBrowseModeId) => hiddenModeKeys.includes(builtInKey(id));
+  const isCustomHidden = (id: number) => hiddenModeKeys.includes(customKey(id));
+  const visibleBuiltIns = BUILT_IN_BROWSE_MODE_LIST.filter((m) => !isBuiltInHidden(m.id));
+  const visiblePresets = presets.filter((p) => !isCustomHidden(p.id));
+  const hiddenBuiltIns = BUILT_IN_BROWSE_MODE_LIST.filter((m) => isBuiltInHidden(m.id));
+  const hiddenPresets = presets.filter((p) => isCustomHidden(p.id));
+  const hasHidden = hiddenBuiltIns.length > 0 || hiddenPresets.length > 0;
+
+  // Selection precedence: in-session active mode wins (so the user can see
+  // "what am I currently in" when they re-open the picker mid-session). When
+  // there's no active mode, fall back to the persisted "last picked" hint —
+  // and if THAT points to a custom preset that's since been deleted, drop it.
+  // If we still have nothing, highlight Full social as the implicit baseline
+  // because no-mode-set is functionally identical to Full social (all tabs).
+  // Two sources so the badge label can differ: active → "Current",
+  // last_picked → "Last used".
+  type SelectionSource = 'active' | 'last_picked' | null;
+  const rawStored = userId ? readLastPickedMode(userId) : null;
+  const storedOrphan = (() => {
+    if (!rawStored?.startsWith('custom:')) return false;
+    const id = Number(rawStored.slice('custom:'.length));
+    return !presets.some((p) => p.id === id);
+  })();
+  const stored = storedOrphan ? null : rawStored;
+  const showImplicitBaseline = !lastActive && !stored;
+  const builtInSource = (id: BuiltInBrowseModeId): SelectionSource => {
+    if (lastActive?.kind === 'built_in' && (lastActive.id as BuiltInBrowseModeId) === id) {
+      return 'active';
+    }
+    if (lastActive) return null;
+    if (stored && isBuiltInPicked(stored, id)) return 'last_picked';
+    if (showImplicitBaseline && id === 'very_social') return 'active';
+    return null;
+  };
+  const customSource = (id: number): SelectionSource => {
+    if (lastActive?.kind === 'custom' && lastActive.id === id) return 'active';
+    if (lastActive) return null;
+    if (stored && isCustomPicked(stored, id)) return 'last_picked';
+    return null;
+  };
+
+  const stopCardClick = (e: MouseEvent) => e.stopPropagation();
+
+  return (
+    <Layout.FlexCol alignItems="center" w="100%" bgColor="WHITE">
+      <Icon name="home_indicator" />
+      <Layout.FlexCol alignItems="center" gap={4} pt={4} ph={16}>
+        <Typo type="title-large">{t('steps.mode.title')}</Typo>
+        <EditListToggle type="button" onClick={() => setEditListMode((v) => !v)}>
+          <Typo type="label-large" color="PRIMARY">
+            {editListMode ? t('steps.mode.edit_done') : t('steps.mode.edit_list')}
+          </Typo>
+        </EditListToggle>
+      </Layout.FlexCol>
+
+      <Layout.FlexCol w="100%" gap={8} pt={16} ph={16}>
+        {visibleBuiltIns.map((mode) => {
+          const source = builtInSource(mode.id);
+          const selected = source !== null && !editListMode;
+          const batteryEmoji = SocialBatteryChipAssets[mode.suggestedBattery].emoji ?? '';
+          const batteryLabel = tRoot(`social_battery.${mode.suggestedBattery}`);
+          const handleCardClick = editListMode
+            ? undefined
+            : () => onPick({ kind: 'built_in', id: mode.id });
+          return (
+            <ModeCard
+              key={mode.id}
+              type="button"
+              $selected={selected}
+              $editing={editListMode}
+              onClick={handleCardClick}
+            >
+              <Layout.FlexRow gap={12} alignItems="center" w="100%">
+                <ModeEmoji>{mode.emoji}</ModeEmoji>
+                <Layout.FlexCol alignItems="flex-start" gap={2} flex={1}>
+                  <Layout.FlexRow gap={6} alignItems="center" style={{ flexWrap: 'wrap' }}>
+                    <Typo type="title-small">{t(`modes.${mode.i18nKey}.name`)}</Typo>
+                    {!editListMode && source && (
+                      <SelectedBadge>
+                        <Typo type="label-small" color="PRIMARY">
+                          {t(
+                            source === 'active'
+                              ? 'steps.mode.current_badge'
+                              : 'steps.mode.last_used_badge',
+                          )}
+                        </Typo>
+                      </SelectedBadge>
+                    )}
+                  </Layout.FlexRow>
+                  <Typo type="body-small" color="MEDIUM_GRAY">
+                    {t(`modes.${mode.i18nKey}.description`)}
+                  </Typo>
+                  <BatteryHint>
+                    <Typo type="label-small" color={syncBattery ? 'DARK_GRAY' : 'MEDIUM_GRAY'}>
+                      {t('steps.mode.battery_hint', {
+                        emoji: batteryEmoji,
+                        label: String(batteryLabel),
+                      })}
+                    </Typo>
+                  </BatteryHint>
+                </Layout.FlexCol>
+                <CardActions onClick={stopCardClick}>
+                  {editListMode ? (
+                    <CardIconButton
+                      type="button"
+                      aria-label={String(
+                        t('steps.mode.hide_builtin_aria', {
+                          name: t(`modes.${mode.i18nKey}.name`),
+                        }),
+                      )}
+                      onClick={(e) => {
+                        stopCardClick(e);
+                        onHideMode(builtInKey(mode.id));
+                      }}
+                    >
+                      <SvgIcon name="close" size={18} />
+                    </CardIconButton>
+                  ) : (
+                    <CardIconButton
+                      type="button"
+                      aria-label={String(
+                        t('steps.mode.clone_builtin_aria', {
+                          name: t(`modes.${mode.i18nKey}.name`),
+                        }),
+                      )}
+                      onClick={(e) => {
+                        stopCardClick(e);
+                        onCloneBuiltIn(mode.id);
+                      }}
+                    >
+                      <SvgIcon name="chevron_right" size={18} />
+                    </CardIconButton>
+                  )}
+                </CardActions>
+              </Layout.FlexRow>
+            </ModeCard>
+          );
+        })}
+
+        {visiblePresets.length > 0 && (
+          <Layout.FlexCol w="100%" gap={6} pt={4}>
+            <Typo type="label-medium" color="DARK_GRAY">
+              {t('steps.mode.saved_label')}
+            </Typo>
+            {visiblePresets.map((preset) => {
+              const source = customSource(preset.id);
+              const selected = source !== null && !editListMode;
+              const battery = preset.default_battery;
+              const batteryEmoji = battery ? SocialBatteryChipAssets[battery].emoji ?? '' : '';
+              const batteryLabel = battery ? tRoot(`social_battery.${battery}`) : '';
+              const handleCardClick = editListMode
+                ? undefined
+                : () => onPick({ kind: 'custom', preset });
+              return (
+                <ModeCard
+                  key={preset.id}
+                  type="button"
+                  $selected={selected}
+                  $editing={editListMode}
+                  onClick={handleCardClick}
+                >
+                  <Layout.FlexRow gap={12} alignItems="center" w="100%">
+                    <ModeEmoji>✨</ModeEmoji>
+                    <Layout.FlexCol alignItems="flex-start" gap={2} flex={1}>
+                      <Layout.FlexRow gap={6} alignItems="center" style={{ flexWrap: 'wrap' }}>
+                        <Typo type="title-small">{preset.name}</Typo>
+                        {!editListMode && source && (
+                          <SelectedBadge>
+                            <Typo type="label-small" color="PRIMARY">
+                              {t(
+                                source === 'active'
+                                  ? 'steps.mode.current_badge'
+                                  : 'steps.mode.last_used_badge',
+                              )}
+                            </Typo>
+                          </SelectedBadge>
+                        )}
+                      </Layout.FlexRow>
+                      <Typo type="body-small" color="MEDIUM_GRAY">
+                        {/* The user-provided description wins; we only fall back
+                            to the auto tab-list when they haven't written one,
+                            so saved cards aren't redundant ("Friends · Update"
+                            under a name like "Friends Update mode"). */}
+                        {preset.description?.trim()
+                          ? preset.description
+                          : preset.config.tabs.map((tab) => t(`tabs.${tab}`)).join(' · ')}
+                      </Typo>
+                      {battery && (
+                        <BatteryHint>
+                          <Typo
+                            type="label-small"
+                            color={syncBattery ? 'DARK_GRAY' : 'MEDIUM_GRAY'}
+                          >
+                            {t('steps.mode.battery_hint', {
+                              emoji: batteryEmoji,
+                              label: String(batteryLabel),
+                            })}
+                          </Typo>
+                        </BatteryHint>
+                      )}
+                    </Layout.FlexCol>
+                    <CardActions onClick={stopCardClick}>
+                      {editListMode ? (
+                        <CardIconButton
+                          type="button"
+                          aria-label={String(
+                            t('steps.mode.hide_preset_aria', { name: preset.name }),
+                          )}
+                          onClick={(e) => {
+                            stopCardClick(e);
+                            onHideMode(customKey(preset.id));
+                          }}
+                        >
+                          <SvgIcon name="close" size={18} />
+                        </CardIconButton>
+                      ) : (
+                        <CardIconButton
+                          type="button"
+                          aria-label={String(
+                            t('steps.mode.edit_preset_aria', { name: preset.name }),
+                          )}
+                          onClick={(e) => {
+                            stopCardClick(e);
+                            onEditPreset(preset);
+                          }}
+                        >
+                          <SvgIcon name="chevron_right" size={18} />
+                        </CardIconButton>
+                      )}
+                    </CardActions>
+                  </Layout.FlexRow>
+                </ModeCard>
+              );
+            })}
+          </Layout.FlexCol>
+        )}
+
+        {/* Restore section: only visible in edit-list mode and only when something
+            has actually been hidden — keeps the surface clean otherwise. Both
+            kinds of mode (built-in and custom preset) appear here together so
+            the user has one place to look for "where did my mode go?". Saved
+            presets get an extra "Delete forever" link — the actual delete is
+            kept behind this two-step (hide first, then delete) so a stray X
+            tap can't permanently destroy the user's work. */}
+        {editListMode && hasHidden && (
+          <Layout.FlexCol w="100%" gap={6} pt={8}>
+            <Typo type="label-medium" color="DARK_GRAY">
+              {t('steps.mode.hidden_label')}
+            </Typo>
+            {hiddenBuiltIns.map((mode) => (
+              <HiddenRow key={mode.id}>
+                <ModeEmoji>{mode.emoji}</ModeEmoji>
+                <Layout.FlexCol alignItems="flex-start" flex={1}>
+                  <Typo type="title-small" color="MEDIUM_GRAY">
+                    {t(`modes.${mode.i18nKey}.name`)}
+                  </Typo>
+                </Layout.FlexCol>
+                <RestoreButton type="button" onClick={() => onShowMode(builtInKey(mode.id))}>
+                  <Typo type="label-large" color="PRIMARY">
+                    {t('steps.mode.show_again')}
+                  </Typo>
+                </RestoreButton>
+              </HiddenRow>
+            ))}
+            {hiddenPresets.map((preset) => (
+              <HiddenRow key={preset.id}>
+                <ModeEmoji>✨</ModeEmoji>
+                <Layout.FlexCol alignItems="flex-start" flex={1}>
+                  <Typo type="title-small" color="MEDIUM_GRAY">
+                    {preset.name}
+                  </Typo>
+                </Layout.FlexCol>
+                <RestoreButton type="button" onClick={() => onShowMode(customKey(preset.id))}>
+                  <Typo type="label-large" color="PRIMARY">
+                    {t('steps.mode.show_again')}
+                  </Typo>
+                </RestoreButton>
+                <RestoreButton type="button" onClick={() => onDeleteMode(preset)}>
+                  <Typo type="label-large" color="WARNING">
+                    {t('steps.mode.delete_forever')}
+                  </Typo>
+                </RestoreButton>
+              </HiddenRow>
+            ))}
+          </Layout.FlexCol>
+        )}
+
+        {!editListMode && (
+          <Layout.FlexCol w="100%" alignItems="flex-start">
+            <CustomizeLink type="button" onClick={onOpenCustomize}>
+              <Typo type="title-small" color="PRIMARY">
+                {t('steps.mode.customize')}
+              </Typo>
+            </CustomizeLink>
+            {/* Wishlist entry — separate from customize because "send feedback"
+                is a different intent than "make a saved mode", and pairing them
+                inside the customize sheet conflated the two. */}
+            <CustomizeLink type="button" onClick={onOpenWishlist}>
+              <Typo type="title-small" color="PRIMARY">
+                {t('steps.mode.wishlist_link')}
+              </Typo>
+            </CustomizeLink>
+          </Layout.FlexCol>
+        )}
+      </Layout.FlexCol>
+
+      {!editListMode && (
+        <SyncToggleRow w="100%" ph={16} pv={12} mt={8}>
+          <SyncCheckbox
+            type="button"
+            aria-pressed={syncBattery}
+            onClick={() => onSyncToggle(!syncBattery)}
+          >
+            <CheckSquare $checked={syncBattery} />
+            <Layout.FlexCol alignItems="flex-start" gap={2}>
+              <Typo type="body-medium">{t('steps.mode.sync_toggle')}</Typo>
+              <Typo type="label-small" color="DARK_GRAY">
+                {t('steps.mode.sync_subtitle')}
+              </Typo>
+            </Layout.FlexCol>
+          </SyncCheckbox>
+        </SyncToggleRow>
+      )}
+
+      <Layout.FlexRow w="100%" pb={20} />
+    </Layout.FlexCol>
+  );
+}
+
+export default BrowseModeStepMode;
+
+const ModeCard = styled.button<{ $selected: boolean; $editing: boolean }>`
+  background: ${({ $selected }) => ($selected ? '#F3E8FF' : Colors.WHITE)};
+  border: 1px solid ${({ $selected }) => ($selected ? Colors.PRIMARY : Colors.LIGHT_GRAY)};
+  border-radius: 12px;
+  padding: 12px 14px;
+  width: 100%;
+  cursor: ${({ $editing }) => ($editing ? 'default' : 'pointer')};
+  text-align: left;
+  &:hover {
+    border-color: ${({ $editing }) => ($editing ? Colors.LIGHT_GRAY : Colors.PRIMARY)};
+  }
+`;
+
+const ModeEmoji = styled.span`
+  font-size: 28px;
+  line-height: 1;
+`;
+
+const SelectedBadge = styled.span`
+  display: inline-flex;
+  align-items: center;
+  background: ${Colors.WHITE};
+  border: 1px solid ${Colors.PRIMARY};
+  border-radius: 8px;
+  padding: 0 6px;
+`;
+
+const BatteryHint = styled.span`
+  display: inline-flex;
+  align-items: center;
+  margin-top: 2px;
+`;
+
+const CardActions = styled.div`
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+`;
+
+const CardIconButton = styled.button`
+  background: none;
+  border: none;
+  padding: 6px;
+  border-radius: 6px;
+  cursor: pointer;
+  &:hover {
+    background: ${Colors.LIGHT};
+  }
+`;
+
+const EditListToggle = styled.button`
+  background: none;
+  border: none;
+  padding: 4px 8px;
+  cursor: pointer;
+`;
+
+const HiddenRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: ${Colors.WHITE};
+  border: 1px dashed ${Colors.LIGHT_GRAY};
+  border-radius: 12px;
+  padding: 8px 12px;
+`;
+
+const RestoreButton = styled.button`
+  background: none;
+  border: none;
+  padding: 6px 10px;
+  cursor: pointer;
+`;
+
+const CustomizeLink = styled.button`
+  background: none;
+  border: none;
+  padding: 8px 0;
+  cursor: pointer;
+  align-self: flex-start;
+`;
+
+const SyncToggleRow = styled(Layout.FlexRow)`
+  border-top: 1px solid ${Colors.LIGHT};
+  background: ${Colors.WHITE};
+`;
+
+const SyncCheckbox = styled.button`
+  background: none;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 0;
+  text-align: left;
+`;
+
+const CheckSquare = styled.span<{ $checked: boolean }>`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 4px;
+  border: 1.5px solid ${({ $checked }) => ($checked ? Colors.PRIMARY : Colors.MEDIUM_GRAY)};
+  background: ${({ $checked }) => ($checked ? Colors.PRIMARY : 'transparent')};
+  position: relative;
+  flex-shrink: 0;
+  margin-top: 2px;
+  &::after {
+    content: '';
+    display: ${({ $checked }) => ($checked ? 'block' : 'none')};
+    width: 4px;
+    height: 8px;
+    border-right: 2px solid white;
+    border-bottom: 2px solid white;
+    transform: translateY(-1px) rotate(45deg);
+  }
+`;

--- a/src/components/browse-mode/BrowseModeWishlistSheet.tsx
+++ b/src/components/browse-mode/BrowseModeWishlistSheet.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useTranslation } from 'react-i18next';
+import styled from 'styled-components';
+import BottomModal from '@components/_common/bottom-modal/BottomModal';
+import BottomModalActionButton from '@components/_common/bottom-modal/BottomModalActionButton';
+import Icon from '@components/_common/icon/Icon';
+import { Colors, Layout, Typo } from '@design-system';
+import { useBoundStore } from '@stores/useBoundStore';
+import { submitBrowseModeWishlist } from '@utils/apis/browseMode';
+
+interface BrowseModeWishlistSheetProps {
+  visible: boolean;
+  onClose: () => void;
+}
+
+/**
+ * Small standalone sheet for "ideas the user wishes the picker did".
+ * Was originally embedded in the customize sheet, but that conflated
+ * "make a saved mode" with "send feedback" — two unrelated tasks. Now
+ * it has its own entry point ("Not satisfied yet?") on the picker, so
+ * users can drop a note even without saving anything.
+ *
+ * On successful send the sheet closes and surfaces a toast — the user
+ * lands back on the picker so they can keep doing whatever they were doing.
+ */
+function BrowseModeWishlistSheet({ visible, onClose }: BrowseModeWishlistSheetProps) {
+  const [t] = useTranslation('translation', { keyPrefix: 'browse_mode' });
+  const openToast = useBoundStore((state) => state.openToast);
+  const [text, setText] = useState('');
+  const [state, setState] = useState<'idle' | 'sending' | 'error'>('idle');
+
+  useEffect(() => {
+    if (visible) {
+      setText('');
+      setState('idle');
+    }
+  }, [visible]);
+
+  const handleSend = async () => {
+    const trimmed = text.trim();
+    if (!trimmed) return;
+    setState('sending');
+    try {
+      await submitBrowseModeWishlist(trimmed);
+      openToast({ message: String(t('wishlist.sent_toast')) });
+      onClose();
+    } catch {
+      setState('error');
+    }
+  };
+
+  return createPortal(
+    <BottomModal visible={visible} onClose={onClose} heightMode="content">
+      <Layout.FlexCol alignItems="center" w="100%" bgColor="WHITE" pb={32}>
+        <Icon name="home_indicator" />
+        <Layout.FlexCol alignItems="center" gap={4} pt={4} ph={16}>
+          <Typo type="title-large">{t('wishlist.title')}</Typo>
+          <Typo type="body-medium" color="MEDIUM_GRAY" textAlign="center">
+            {t('wishlist.subtitle')}
+          </Typo>
+        </Layout.FlexCol>
+
+        <Layout.FlexCol w="100%" ph={16} pt={16} gap={8}>
+          <WishlistTextarea
+            value={text}
+            onChange={(e) => {
+              setText(e.target.value);
+              if (state === 'error') setState('idle');
+            }}
+            maxLength={2000}
+            placeholder={String(t('wishlist.placeholder'))}
+            rows={4}
+          />
+          {state === 'error' && (
+            <Typo type="label-small" color="WARNING">
+              {t('wishlist.error')}
+            </Typo>
+          )}
+          <BottomModalActionButton
+            status={text.trim() && state !== 'sending' ? 'normal' : 'disabled'}
+            text={t('wishlist.send')}
+            onClick={handleSend}
+          />
+        </Layout.FlexCol>
+      </Layout.FlexCol>
+    </BottomModal>,
+    document.body,
+  );
+}
+
+export default BrowseModeWishlistSheet;
+
+const WishlistTextarea = styled.textarea`
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid ${Colors.LIGHT_GRAY};
+  padding: 10px 12px;
+  font-family: inherit;
+  font-size: 14px;
+  resize: vertical;
+  &:focus {
+    outline: none;
+    border-color: ${Colors.PRIMARY};
+  }
+`;

--- a/src/components/check-in/check-in-freshness-prompt/CheckInFreshnessPrompt.tsx
+++ b/src/components/check-in/check-in-freshness-prompt/CheckInFreshnessPrompt.tsx
@@ -34,7 +34,9 @@ function CheckInFreshnessPrompt({ visible, onDismiss, checkIn }: CheckInFreshnes
 
   const handleUpdate = useCallback(() => {
     onDismiss();
-    navigate('/check-in/edit');
+    // Send users to the Check-In tab (`/update`) — the standalone
+    // `/check-in/edit` page is deprecated and shouldn't be linked.
+    navigate('/update');
   }, [onDismiss, navigate]);
 
   const handleClear = useCallback(async () => {

--- a/src/components/header/side-menu/SideMenu.tsx
+++ b/src/components/header/side-menu/SideMenu.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import useSWR from 'swr';
 
 import EmojiItem from '@components/_common/emoji-item/EmojiItem';
+import { FeatureFlagKey } from '@constants/featureFlag';
 import { Z_INDEX } from '@constants/layout';
 import { ONBOARDING_VIDEO_URL } from '@constants/url';
 import { Button, Layout, SvgIcon, Typo } from '@design-system';
@@ -13,10 +14,20 @@ import { VersionType } from '@models/api/user';
 import { useBoundStore } from '@stores/useBoundStore';
 import { getMyPendingVersionSwapRequest } from '@utils/apis/user';
 
-const SIDE_MENU_LIST = [
-  { key: 'my_profile', path: '/my' },
-  { key: 'survey_results', path: '/surveys' },
-  { key: 'settings', path: '/settings' },
+type SideMenuItem =
+  | { key: string; emoji: string; kind: 'route'; path: string; flag?: FeatureFlagKey }
+  | { key: string; emoji: string; kind: 'browse_mode'; flag: FeatureFlagKey };
+
+const SIDE_MENU_LIST: SideMenuItem[] = [
+  { key: 'my_profile', emoji: '👤', kind: 'route', path: '/my' },
+  {
+    key: 'browsing_mode',
+    emoji: '✨',
+    kind: 'browse_mode',
+    flag: FeatureFlagKey.BROWSE_MODE,
+  },
+  { key: 'survey_results', emoji: '📊', kind: 'route', path: '/surveys' },
+  { key: 'settings', emoji: '⚙️', kind: 'route', path: '/settings' },
 ];
 
 const VERSION_LABEL: Record<VersionType, string> = {
@@ -33,6 +44,8 @@ function SideMenu({ closeSideMenu }: Props) {
   const [t] = useTranslation('translation', { keyPrefix: 'home.header.side_menu' });
   const navigate = useNavigate();
   const postMessage = usePostAppMessage();
+  const featureFlags = useBoundStore((state) => state.featureFlags);
+  const openBrowseModePicker = useBoundStore((state) => state.openBrowseModePicker);
 
   const myProfile = useBoundStore((state) => state.myProfile);
   const { data: pendingResp } = useSWR(
@@ -41,8 +54,14 @@ function SideMenu({ closeSideMenu }: Props) {
   );
   const isPending = !!pendingResp?.pending;
 
-  const handleClickMenu = (path: string) => () => {
-    navigate(path);
+  const visibleItems = SIDE_MENU_LIST.filter((menu) => !menu.flag || featureFlags?.[menu.flag]);
+
+  const handleClickMenu = (menu: SideMenuItem) => () => {
+    if (menu.kind === 'route') {
+      navigate(menu.path);
+    } else if (menu.kind === 'browse_mode') {
+      openBrowseModePicker();
+    }
     closeSideMenu();
   };
 
@@ -73,9 +92,17 @@ function SideMenu({ closeSideMenu }: Props) {
         <Layout.FlexCol pt={20} pl={24}>
           <SvgIcon name="close" color="BLACK" size={24} onClick={handleClickDimmed} />
           <Layout.FlexCol gap={12} pt={30}>
-            {SIDE_MENU_LIST.map((menu) => (
-              <button type="button" key={menu.key} onClick={handleClickMenu(menu.path)}>
-                <Typo type="head-line">{t(menu.key)}</Typo>
+            {visibleItems.map((menu) => (
+              <button type="button" key={menu.key} onClick={handleClickMenu(menu)}>
+                <Layout.FlexRow gap={6} alignItems="center">
+                  <EmojiItem
+                    emojiString={menu.emoji}
+                    size={20}
+                    bgColor="TRANSPARENT"
+                    outline="TRANSPARENT"
+                  />
+                  <Typo type="head-line">{t(menu.key)}</Typo>
+                </Layout.FlexRow>
               </button>
             ))}
             <Layout.FlexCol mt={52}>
@@ -88,7 +115,7 @@ function SideMenu({ closeSideMenu }: Props) {
                   handleClickOnboardingVideo();
                 }}
               >
-                <Layout.FlexRow gap={4} alignItems="center">
+                <Layout.FlexRow gap={6} alignItems="center">
                   <EmojiItem
                     emojiString="📺"
                     size={20}

--- a/src/components/tab/Tab.tsx
+++ b/src/components/tab/Tab.tsx
@@ -4,6 +4,7 @@ import { useMatch } from 'react-router-dom';
 import { MAIN_SCROLL_CONTAINER_ID } from '@constants/scroll';
 import { Layout, SvgIcon, Typo } from '@design-system';
 import { resetScrollPosition } from '@hooks/useRestoreScrollPosition';
+import { BrowseModeTabKey } from '@models/browseMode';
 import { useBoundStore } from '@stores/useBoundStore';
 import { UserSelector } from '@stores/user';
 import {
@@ -84,36 +85,52 @@ function TabItem({ to, type, size = 48, end = false }: TabItemProps) {
 
 export default function Tab() {
   const { featureFlags } = useBoundStore(UserSelector);
+  const activeBrowseMode = useBoundStore((state) => state.activeBrowseMode);
+
+  // When a browse mode is active, only render tabs whose key is in the mode's allowlist.
+  // `my` and `questions` are intentionally exempt — profile lives in the hamburger menu
+  // and questions is feature-flag-gated, so users always want them when those flags allow.
+  const allowedTabs = activeBrowseMode?.config.tabs;
+  const ALWAYS_SHOWN: BrowseModeTabKey[] = ['my', 'questions'];
+  const isTabAllowed = (key: BrowseModeTabKey) => {
+    if (ALWAYS_SHOWN.includes(key)) return true;
+    return !allowedTabs || allowedTabs.includes(key);
+  };
 
   if (featureFlags?.checkInPosts) {
     return (
-      <TabWrapper>
+      <TabWrapper data-preview-exempt>
         <Layout.FlexRow w="100%" justifyContent="space-evenly" alignItems="center" pt={4}>
-          <TabItem to="/feed" type="feed" size={28} />
-          <TabItem to="/share" type="share" size={28} />
-          <TabItem to="/discover" type="discover" size={28} />
-          <TabItem to="/chats" type="chats" size={28} />
-          <TabItem to="/my" type="my" size={28} />
+          {/* Ver. Q has a "feed" tab that maps to the friends slot conceptually; treat it as 'friends'. */}
+          {isTabAllowed('friends') && <TabItem to="/feed" type="feed" size={28} />}
+          {isTabAllowed('share') && <TabItem to="/share" type="share" size={28} />}
+          {isTabAllowed('discover') && <TabItem to="/discover" type="discover" size={28} />}
+          {isTabAllowed('chats') && <TabItem to="/chats" type="chats" size={28} />}
+          {isTabAllowed('my') && <TabItem to="/my" type="my" size={28} />}
         </Layout.FlexRow>
       </TabWrapper>
     );
   }
 
   return (
-    <TabWrapper>
+    <TabWrapper data-preview-exempt>
       <Layout.FlexRow w="100%" h="100%" justifyContent="space-evenly" alignItems="center">
         {featureFlags?.friendList ? (
           <>
-            <TabItem to="/friends" type="friends" size={28} />
-            <TabItem to="/update" type="update" size={28} />
-            <TabItem to="/share" type="share" size={28} />
-            <TabItem to="/discover" type="discover" size={28} />
+            {isTabAllowed('friends') && <TabItem to="/friends" type="friends" size={28} />}
+            {isTabAllowed('update') && <TabItem to="/update" type="update" size={28} />}
+            {isTabAllowed('share') && <TabItem to="/share" type="share" size={28} />}
+            {isTabAllowed('discover') && <TabItem to="/discover" type="discover" size={28} />}
           </>
         ) : featureFlags?.friendFeed ? (
-          <TabItem to="/feed" type="friends" size={28} />
+          isTabAllowed('friends') && <TabItem to="/feed" type="friends" size={28} />
         ) : null}
-        {featureFlags?.questionsTab && <TabItem to="/questions" type="questions" size={28} />}
-        {featureFlags?.chatTab && <TabItem to="/chats" type="chats" size={28} />}
+        {featureFlags?.questionsTab && isTabAllowed('questions') && (
+          <TabItem to="/questions" type="questions" size={28} />
+        )}
+        {featureFlags?.chatTab && isTabAllowed('chats') && (
+          <TabItem to="/chats" type="chats" size={28} />
+        )}
       </Layout.FlexRow>
     </TabWrapper>
   );

--- a/src/constants/browseMode.ts
+++ b/src/constants/browseMode.ts
@@ -1,0 +1,151 @@
+import { BrowseModeTabKey, BuiltInBrowseMode, BuiltInBrowseModeId } from '@models/browseMode';
+import { SocialBattery } from '@models/checkIn';
+
+/**
+ * Tab keys the user can toggle in the customize sheet — limited to the bottom-tab
+ * tabs they actually see on Ver. W. `my` (profile) lives in the hamburger menu and
+ * `questions` is feature-flag-gated, so neither needs a per-mode toggle.
+ *
+ * The wider {@link BrowseModeTabKey} union still includes those keys so we don't
+ * break any built-in modes referencing them.
+ */
+export const ALL_BROWSE_MODE_TABS: BrowseModeTabKey[] = [
+  'friends',
+  'update',
+  'share',
+  'discover',
+  'chats',
+];
+
+export const BUILT_IN_BROWSE_MODES: Record<BuiltInBrowseModeId, BuiltInBrowseMode> = {
+  very_social: {
+    kind: 'built_in',
+    id: 'very_social',
+    i18nKey: 'very_social',
+    emoji: '🤩',
+    suggestedBattery: SocialBattery.fully_charged,
+    config: {
+      tabs: ['friends', 'update', 'share', 'discover', 'chats'],
+      filters: {},
+      sections: {},
+    },
+  },
+  selectively_social: {
+    kind: 'built_in',
+    id: 'selectively_social',
+    i18nKey: 'selectively_social',
+    emoji: '💜',
+    suggestedBattery: SocialBattery.moderately_social,
+    config: {
+      tabs: ['friends', 'update', 'share', 'chats'],
+      filters: { friends_close_only: true },
+      sections: { hide_synthetic_discover_cards: true },
+    },
+  },
+  quiet: {
+    kind: 'built_in',
+    id: 'quiet',
+    i18nKey: 'quiet',
+    emoji: '🌙',
+    suggestedBattery: SocialBattery.low,
+    config: {
+      tabs: ['share'],
+      filters: {},
+      sections: { hide_ping_buttons: true, hide_new_post_badge: true },
+    },
+  },
+};
+
+export const BUILT_IN_BROWSE_MODE_LIST: BuiltInBrowseMode[] = [
+  BUILT_IN_BROWSE_MODES.very_social,
+  BUILT_IN_BROWSE_MODES.selectively_social,
+  BUILT_IN_BROWSE_MODES.quiet,
+];
+
+/**
+ * Quick-start templates surfaced inside the customize sheet. Tapping one
+ * prefills the form so users can save it (with their own name) instead of
+ * starting from a blank slate. Distinct from the 3 built-in modes — these
+ * are starting points for the user's OWN saved presets.
+ */
+export type CustomizeTemplate = {
+  id: string;
+  /** i18n key under `browse_mode.templates` */
+  i18nKey: string;
+  emoji: string;
+  config: {
+    tabs: BrowseModeTabKey[];
+    filters: NonNullable<BuiltInBrowseMode['config']['filters']>;
+    /** Per-tab fade-out timers — see BrowseModeConfig.tab_durations. */
+    tab_durations?: Partial<Record<BrowseModeTabKey, number>>;
+  };
+};
+
+/**
+ * Default "fade-out" duration in minutes for tabs marked transient by the
+ * Digital detox template. Editable per-tab in the customize sheet.
+ */
+export const DIGITAL_DETOX_DEFAULT_MINUTES = 15;
+
+/**
+ * Duration options surfaced next to each active tab in the customize sheet
+ * (à la Apple's Focus-mode time pickers). `undefined` value = persistent
+ * (no timer); numeric values are minutes.
+ */
+export const TAB_DURATION_OPTIONS: { value: number | undefined; i18nKey: string }[] = [
+  { value: undefined, i18nKey: 'always' },
+  { value: 5, i18nKey: 'minutes_5' },
+  { value: 15, i18nKey: 'minutes_15' },
+  { value: 30, i18nKey: 'minutes_30' },
+  { value: 60, i18nKey: 'minutes_60' },
+];
+
+export const CUSTOMIZE_TEMPLATES: CustomizeTemplate[] = [
+  {
+    id: 'no_discover',
+    i18nKey: 'no_discover',
+    emoji: '👯',
+    config: {
+      tabs: ['friends', 'update', 'share', 'chats'],
+      filters: {},
+    },
+  },
+  {
+    id: 'just_chat',
+    i18nKey: 'just_chat',
+    emoji: '💬',
+    config: {
+      tabs: ['chats'],
+      filters: {},
+    },
+  },
+  {
+    id: 'just_discover',
+    i18nKey: 'just_discover',
+    emoji: '🔭',
+    config: {
+      tabs: ['discover'],
+      filters: {},
+    },
+  },
+  {
+    // Time-based fade-out: surfaces ALL tabs initially so the user can wrap
+    // up whatever they were doing, but every scroll-y / chat tab gets a
+    // 15-minute timer. Share has no duration so it persists — once the
+    // timers fire, all that's left is the post-something surface, which
+    // is the spirit of detox. Editable per-tab in the customize sheet.
+    id: 'digital_detox',
+    i18nKey: 'digital_detox',
+    emoji: '🌿',
+    config: {
+      tabs: ['friends', 'update', 'share', 'discover', 'chats'],
+      filters: {},
+      tab_durations: {
+        friends: DIGITAL_DETOX_DEFAULT_MINUTES,
+        update: DIGITAL_DETOX_DEFAULT_MINUTES,
+        discover: DIGITAL_DETOX_DEFAULT_MINUTES,
+        chats: DIGITAL_DETOX_DEFAULT_MINUTES,
+      },
+    },
+  },
+];

--- a/src/constants/featureFlag.ts
+++ b/src/constants/featureFlag.ts
@@ -35,6 +35,8 @@ export enum FeatureFlagKey {
   SUBSCRIPTION_POPUP = 'subscriptionPopup',
   /** 채팅 목록에서 Close Friends Only 필터 토글 노출 */
   CHAT_CLOSE_FRIENDS_FILTER = 'chatCloseFriendsFilter',
+  /** 세션 시작 시 social battery + browse mode 프롬프트 (Ver. W 전용) */
+  BROWSE_MODE = 'browseMode',
 }
 
 export type FeatureFlagMap = { [feature in FeatureFlagKey]: boolean };
@@ -61,6 +63,7 @@ const DEFAULT_FLAGS = {
   [FeatureFlagKey.SHARE_TAB_VISIBLE]: false,
   [FeatureFlagKey.SUBSCRIPTION_POPUP]: false,
   [FeatureFlagKey.CHAT_CLOSE_FRIENDS_FILTER]: false,
+  [FeatureFlagKey.BROWSE_MODE]: false,
 };
 
 export const FEATURE_FLAG_MAP_COLLECTION: FeatureFlagMapCollection = {
@@ -94,5 +97,6 @@ export const FEATURE_FLAG_MAP_COLLECTION: FeatureFlagMapCollection = {
     [FeatureFlagKey.CHAT_TAB]: true,
     [FeatureFlagKey.SUBSCRIPTION_POPUP]: true,
     [FeatureFlagKey.CHAT_CLOSE_FRIENDS_FILTER]: true,
+    [FeatureFlagKey.BROWSE_MODE]: true,
   },
 };

--- a/src/hooks/useBrowseModeSessionPrompt.ts
+++ b/src/hooks/useBrowseModeSessionPrompt.ts
@@ -1,0 +1,142 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { FeatureFlagKey } from '@constants/featureFlag';
+import { useGetAppMessage } from '@hooks/useAppMessage';
+import { SetAppStateData } from '@models/app';
+import { useBoundStore } from '@stores/useBoundStore';
+
+const AWAY_THRESHOLD_MS = 30 * 60 * 1000; // 30 min — anything shorter is "same session"
+const COOLDOWN_MS = 60 * 60 * 1000; // 1 hour cooldown after the user dismisses the prompt
+
+function getStorageKey(userId: number, suffix: string) {
+  return `browse_mode_${suffix}_${userId}`;
+}
+
+function isCooldownActive(userId: number): boolean {
+  const ts = localStorage.getItem(getStorageKey(userId, 'dismissed'));
+  if (!ts) return false;
+  return Date.now() - Number(ts) < COOLDOWN_MS;
+}
+
+function saveLastSessionTimestamp(userId: number) {
+  localStorage.setItem(getStorageKey(userId, 'last_session'), String(Date.now()));
+}
+
+function getLastSessionTimestamp(userId: number): number | null {
+  const ts = localStorage.getItem(getStorageKey(userId, 'last_session'));
+  return ts ? Number(ts) : null;
+}
+
+function saveDismissTimestamp(userId: number) {
+  localStorage.setItem(getStorageKey(userId, 'dismissed'), String(Date.now()));
+}
+
+/**
+ * On a new session — meaning the user has been away for at least 30 minutes —
+ * surface the two-step Browse Mode prompt. Quick re-opens (close → reopen
+ * within 30 min) are intentionally treated as the same session and skipped.
+ *
+ * Mirrors the structure of `useCheckInFreshnessPrompt`: visibilitychange
+ * listener + native SET_APP_STATE bridge + per-user localStorage timestamps.
+ */
+export function useBrowseModeSessionPrompt() {
+  const [shouldShow, setShouldShow] = useState(false);
+
+  const myProfile = useBoundStore((state) => state.myProfile);
+  const featureFlags = useBoundStore((state) => state.featureFlags);
+  const fetchPresets = useBoundStore((state) => state.fetchCustomBrowseModePresets);
+
+  const userId = myProfile?.id;
+  const browseModeEnabled = featureFlags?.[FeatureFlagKey.BROWSE_MODE] ?? false;
+
+  const tryTrigger = useCallback(() => {
+    if (!userId || !browseModeEnabled) return;
+    if (isCooldownActive(userId)) return;
+    setShouldShow(true);
+  }, [userId, browseModeEnabled]);
+
+  // Stable refs so the SET_APP_STATE callback doesn't re-bind every render.
+  const handleBecomeActive = useCallback(() => {
+    if (!userId) return;
+    const lastTs = getLastSessionTimestamp(userId);
+    if (lastTs && Date.now() - lastTs >= AWAY_THRESHOLD_MS) {
+      tryTrigger();
+    }
+  }, [userId, tryTrigger]);
+
+  const handleBecomeInactive = useCallback(() => {
+    if (!userId) return;
+    saveLastSessionTimestamp(userId);
+  }, [userId]);
+
+  const handleBecomeActiveRef = useRef(handleBecomeActive);
+  const handleBecomeInactiveRef = useRef(handleBecomeInactive);
+  useEffect(() => {
+    handleBecomeActiveRef.current = handleBecomeActive;
+    handleBecomeInactiveRef.current = handleBecomeInactive;
+  }, [handleBecomeActive, handleBecomeInactive]);
+
+  const handleAppState = useCallback((data: SetAppStateData) => {
+    if (!data) return;
+    if (data.value === 'active') {
+      handleBecomeActiveRef.current();
+    } else if (data.value === 'inactive' || data.value === 'background') {
+      handleBecomeInactiveRef.current();
+    }
+  }, []);
+
+  useGetAppMessage({ key: 'SET_APP_STATE', cb: handleAppState });
+
+  useEffect(() => {
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        handleBecomeActive();
+      } else {
+        handleBecomeInactive();
+      }
+    };
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    return () => document.removeEventListener('visibilitychange', onVisibilityChange);
+  }, [handleBecomeActive, handleBecomeInactive]);
+
+  // Cold start: if we have a stored "last session" from before, decide whether to prompt.
+  // Also load saved presets so they're ready when the prompt opens.
+  useEffect(() => {
+    if (!userId || !browseModeEnabled) return;
+
+    const lastTs = getLastSessionTimestamp(userId);
+    if (lastTs === null) {
+      // First time we've ever seen this user on this device — record now and skip prompting.
+      saveLastSessionTimestamp(userId);
+    } else if (Date.now() - lastTs >= AWAY_THRESHOLD_MS) {
+      tryTrigger();
+    }
+    fetchPresets();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [userId, browseModeEnabled]);
+
+  const dismiss = useCallback(() => {
+    setShouldShow(false);
+    if (userId) {
+      saveDismissTimestamp(userId);
+      saveLastSessionTimestamp(userId);
+    }
+  }, [userId]);
+
+  /**
+   * Like `dismiss`, but called after the user actively chose a mode.
+   * Skips the dismiss-cooldown so the next 30-min-away gap re-prompts as expected.
+   */
+  const finish = useCallback(() => {
+    setShouldShow(false);
+    if (userId) {
+      saveLastSessionTimestamp(userId);
+    }
+  }, [userId]);
+
+  /** Manually open the prompt (e.g., from the header indicator chip). */
+  const open = useCallback(() => {
+    setShouldShow(true);
+  }, []);
+
+  return { shouldShow, dismiss, finish, open };
+}

--- a/src/hooks/useBrowseModeTabDurations.ts
+++ b/src/hooks/useBrowseModeTabDurations.ts
@@ -1,0 +1,103 @@
+import { useEffect } from 'react';
+import { BrowseModeTabKey } from '@models/browseMode';
+import { useBoundStore } from '@stores/useBoundStore';
+
+const STORAGE_KEY_PREFIX = 'browse_mode_tab_durations_started_at_';
+
+function key(userId: number, modeKey: string) {
+  return `${STORAGE_KEY_PREFIX}${userId}_${modeKey}`;
+}
+
+/**
+ * Per-tab "auto-fade" timers — Apple-Focus-mode style.
+ *
+ * For each tab in the active mode that has a `tab_durations[tab]` minute
+ * value, schedule a one-shot timer; when it fires, that tab is removed
+ * from `activeBrowseMode.config.tabs`. Tabs without a duration entry stay
+ * forever.
+ *
+ * Activation timestamp is persisted per-user/per-mode in localStorage so
+ * the timers survive reloads. Switching to a different mode clears the
+ * persisted timestamp so the next activation starts fresh.
+ *
+ * Implementation note: a single shared timestamp is the source of truth.
+ * Each tab's deadline = timestamp + its duration. We don't track per-tab
+ * timestamps — they all start when the user activates the mode.
+ */
+export function useBrowseModeTabDurations() {
+  const activeBrowseMode = useBoundStore((state) => state.activeBrowseMode);
+  const userId = useBoundStore((state) => state.myProfile?.id);
+
+  // Combine kind+id so built-in 'very_social' and a hypothetical custom id
+  // 'very_social' don't collide in storage (also custom id 1 vs the string
+  // 'very_social' built-in).
+  const modeKey = activeBrowseMode ? `${activeBrowseMode.kind}:${activeBrowseMode.id}` : null;
+  // Stable JSON for the deps array — passing the object directly would
+  // re-fire the effect every render (object identity changes).
+  const durationsJson = JSON.stringify(activeBrowseMode?.config.tab_durations ?? {});
+
+  useEffect(() => {
+    if (!userId || !modeKey) return undefined;
+    const durations = JSON.parse(durationsJson) as Partial<Record<BrowseModeTabKey, number>>;
+    type DurationEntry = [BrowseModeTabKey, number];
+    const entries = Object.entries(durations).filter(
+      ([, m]) => typeof m === 'number' && m > 0,
+    ) as DurationEntry[];
+    if (entries.length === 0) return undefined;
+
+    const storageKey = key(userId, modeKey);
+    const existing = localStorage.getItem(storageKey);
+    const now = Date.now();
+    const startedAt = existing ? Number(existing) : now;
+    if (!existing) localStorage.setItem(storageKey, String(now));
+
+    const timers: number[] = [];
+
+    const removeTab = (tab: BrowseModeTabKey) => {
+      // Always re-read state at fire time — the user could have toggled
+      // the tab off in the customize sheet between schedule and fire.
+      const current = useBoundStore.getState().activeBrowseMode;
+      if (!current) return;
+      if (`${current.kind}:${current.id}` !== modeKey) return;
+      if (!current.config.tabs.includes(tab)) return;
+      useBoundStore.setState({
+        activeBrowseMode: {
+          ...current,
+          config: { ...current.config, tabs: current.config.tabs.filter((x) => x !== tab) },
+        },
+      });
+    };
+
+    entries.forEach(([tab, minutes]) => {
+      const deadline = startedAt + minutes * 60 * 1000;
+      const remainingMs = deadline - now;
+      if (remainingMs <= 0) {
+        removeTab(tab);
+        return;
+      }
+      timers.push(window.setTimeout(() => removeTab(tab), remainingMs));
+    });
+
+    return () => {
+      timers.forEach((t) => window.clearTimeout(t));
+    };
+    // We deliberately don't depend on the full activeBrowseMode object —
+    // re-running on every config edit would reset all timers. modeKey
+    // (kind:id) is the right granularity: timers reset on mode switch only.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [modeKey, durationsJson, userId]);
+
+  // Clear the persisted timestamp when the user actually switches to a
+  // different mode. Using cleanup on modeKey-keyed effect.
+  useEffect(() => {
+    return () => {
+      if (!userId || !modeKey) return;
+      const next = useBoundStore.getState().activeBrowseMode;
+      const stillSame = next && `${next.kind}:${next.id}` === modeKey;
+      if (!stillSame) {
+        localStorage.removeItem(key(userId, modeKey));
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [modeKey]);
+}

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -233,6 +233,7 @@
                 "explore_friends": "Add Friends",
                 "questions": "Questions",
                 "my_profile": "My Profile",
+                "browsing_mode": "Browsing Mode",
                 "survey_results": "Survey Results",
                 "settings": "Settings",
                 "edit_profile": "Edit Profile",
@@ -1239,5 +1240,142 @@
         "ok": "OK",
         "already_pending": "You already have a pending version swap request.",
         "submit_failed": "Could not submit your request. Please try again."
+    },
+    "browse_mode": {
+        "full_screen": {
+            "skip": "Skip"
+        },
+        "preview_bar": {
+            "label": "✨ Previewing a custom mode",
+            "exit_aria": "Exit preview and return to browsing modes",
+            "blocked_toast": "Action not allowed in preview mode"
+        },
+        "toasts": {
+            "battery_set": "Battery set to {{emoji}} {{label}}",
+            "browsing_in": "Browsing in {{name}} mode",
+            "browsing_in_with_battery": "Browsing in {{name}} mode · {{emoji}} {{label}}",
+            "adjust": "Adjust",
+            "delete_failed": "Couldn't delete that mode — try again?"
+        },
+        "steps": {
+            "mode": {
+                "title": "What are you in the mood for?",
+                "saved_label": "Your saved modes",
+                "customize": "✨ Add a new browsing mode",
+                "wishlist_link": "💭 Not seeing what you're looking for?",
+                "last_used_badge": "Last used",
+                "current_badge": "Current",
+                "battery_hint": "Battery → {{emoji}} {{label}}",
+                "sync_toggle": "Also set my battery",
+                "sync_subtitle": "We'll match it to the mode you pick — you can adjust afterwards",
+                "edit_preset_aria": "Edit {{name}}",
+                "delete_preset_aria": "Delete {{name}}",
+                "hide_preset_aria": "Hide {{name}} from this list",
+                "clone_builtin_aria": "Make my own version of {{name}}",
+                "hide_builtin_aria": "Hide {{name}} from this list",
+                "clone_name_suffix": "{{name}} (mine)",
+                "edit_list": "Edit list",
+                "edit_done": "Done",
+                "hidden_label": "Hidden",
+                "show_again": "Show again",
+                "delete_forever": "Delete forever",
+                "delete_confirm_title": "Delete this mode?",
+                "delete_confirm_content": "\"{{name}}\" will be removed from your saved modes.",
+                "delete_confirm_cancel": "Cancel",
+                "delete_confirm_confirm": "Delete"
+            },
+            "customize": {
+                "title": "Create Custom Mode",
+                "title_edit": "Edit Mode",
+                "subtitle": "",
+                "subtitle_edit": "Tweak the bits you want to change — Save updates your saved version",
+                "templates_section": "Quick start",
+                "templates_subtitle": "Tap one to fill in the form — tweak before saving",
+                "tabs_section": "Show these tabs",
+                "tabs_subtitle": "Pick a time limit per tab — they'll fade out after that. \"Always\" stays.",
+                "duration_aria": "Time limit for {{tab}}",
+                "duration_options": {
+                    "always": "Always",
+                    "minutes_5": "5 min",
+                    "minutes_15": "15 min",
+                    "minutes_30": "30 min",
+                    "minutes_60": "1 hour"
+                },
+                "filters_section": "Apply these filters",
+                "battery_section": "Default battery",
+                "battery_subtitle": "When 'Also set my battery' is on, this is what we'll set when you pick this mode. Optional.",
+                "battery_none": "Skip",
+                "save_as": "Save as a mode",
+                "name_label": "Mode name",
+                "name_placeholder": "e.g. Hangout, Late chill",
+                "description_label": "Description (optional)",
+                "description_placeholder": "e.g. exam week, limited chatting",
+                "save": "Save",
+                "apply_without_saving": "Apply without saving",
+                "errors": {
+                    "name_required": "Give your mode a name",
+                    "save_failed": "Couldn't save. Try again?",
+                    "tabs_required": "Pick at least one tab"
+                }
+            }
+        },
+        "wishlist": {
+            "title": "Not seeing what you're looking for?",
+            "subtitle": "What other options would you like to be able to customize for your browsing mode?",
+            "placeholder": "e.g. auto-switch to Soft mode at night, hide check-ins from specific people, save my filters per tab…",
+            "send": "Send",
+            "sent_toast": "Sent to WIT admins. Thank you for your input!",
+            "error": "Couldn't send — try again?"
+        },
+        "modes": {
+            "very_social": {
+                "name": "Full social",
+                "description": "Show me everything — I'm here for it"
+            },
+            "selectively_social": {
+                "name": "Just my people",
+                "description": "Close friends only, no random discovery"
+            },
+            "quiet": {
+                "name": "Soft mode",
+                "description": "Just here to share — keep it quiet"
+            }
+        },
+        "tabs": {
+            "friends": "Friends",
+            "update": "Update",
+            "share": "Share",
+            "discover": "Discover",
+            "chats": "Chats",
+            "my": "My",
+            "questions": "Questions"
+        },
+        "filters": {
+            "friends_close_only": "Show close friends only on Friends",
+            "chats_close_only": "Show close friends only on Chats"
+        },
+        "sections": {
+            "hide_synthetic_discover_cards": "Hide discovery suggestions",
+            "hide_ping_buttons": "Hide ping buttons",
+            "hide_new_post_badge": "Hide \"New post\" badges"
+        },
+        "templates": {
+            "no_discover": {
+                "name": "All friends, no discover",
+                "description": "Stay with people you know — no new friends today"
+            },
+            "just_chat": {
+                "name": "Just chat",
+                "description": "Replying to messages, nothing else"
+            },
+            "just_discover": {
+                "name": "Just discover",
+                "description": "Find new connections and content only"
+            },
+            "digital_detox": {
+                "name": "Digital detox",
+                "description": "Step away from the scroll — keep replies open"
+            }
+        }
     }
 }

--- a/src/i18n/locales/ko/translation.json
+++ b/src/i18n/locales/ko/translation.json
@@ -233,6 +233,7 @@
         "explore_friends": "친구 추가",
         "questions": "전체 질문",
         "my_profile": "마이 프로필",
+        "browsing_mode": "브라우즈 모드",
         "survey_results": "설문 결과",
         "settings": "설정",
         "edit_profile": "프로필 편집",
@@ -1230,5 +1231,142 @@
     "ok": "확인",
     "already_pending": "이미 진행 중인 버전 변경 신청이 있어.",
     "submit_failed": "신청에 실패했어. 다시 시도해줘."
+  },
+  "browse_mode": {
+    "full_screen": {
+      "skip": "건너뛰기"
+    },
+    "preview_bar": {
+      "label": "✨ 미리보기 모드",
+      "exit_aria": "미리보기 종료하고 브라우즈 모드 목록으로 돌아가기",
+      "blocked_toast": "미리보기 모드에서는 사용할 수 없어"
+    },
+    "toasts": {
+      "battery_set": "배터리를 {{emoji}} {{label}}(으)로 설정했어",
+      "browsing_in": "{{name}} 모드로 둘러보는 중",
+      "browsing_in_with_battery": "{{name}} 모드로 둘러보는 중 · {{emoji}} {{label}}",
+      "adjust": "조정",
+      "delete_failed": "삭제하지 못했어 — 다시 해볼까?"
+    },
+    "steps": {
+      "mode": {
+        "title": "오늘은 뭐가 끌려?",
+        "saved_label": "저장한 모드",
+        "customize": "✨ 새 브라우즈 모드 만들기",
+        "wishlist_link": "💭 원하는 게 안 보여?",
+        "last_used_badge": "마지막 사용",
+        "current_badge": "현재",
+        "battery_hint": "배터리 → {{emoji}} {{label}}",
+        "sync_toggle": "배터리도 같이 설정",
+        "sync_subtitle": "이 모드에 맞춰 자동으로 — 들어가서 조정할 수 있어",
+        "edit_preset_aria": "{{name}} 수정",
+        "delete_preset_aria": "{{name}} 삭제",
+        "hide_preset_aria": "{{name}} 목록에서 숨기기",
+        "clone_builtin_aria": "{{name}} 내 스타일로 만들기",
+        "hide_builtin_aria": "{{name}} 목록에서 숨기기",
+        "clone_name_suffix": "내 {{name}}",
+        "edit_list": "목록 편집",
+        "edit_done": "완료",
+        "hidden_label": "숨긴 모드",
+        "show_again": "다시 보기",
+        "delete_forever": "완전 삭제",
+        "delete_confirm_title": "이 모드를 삭제할까?",
+        "delete_confirm_content": "\"{{name}}\"이(가) 저장한 모드 목록에서 사라질 거야.",
+        "delete_confirm_cancel": "취소",
+        "delete_confirm_confirm": "삭제"
+      },
+      "customize": {
+        "title": "커스텀 모드 만들기",
+        "title_edit": "모드 수정",
+        "subtitle": "",
+        "subtitle_edit": "바꾸고 싶은 부분만 손봐 — 저장하면 기존 모드가 갱신돼",
+        "templates_section": "빠른 시작",
+        "templates_subtitle": "하나 골라서 편집해보고 저장해봐",
+        "tabs_section": "보여줄 탭",
+        "tabs_subtitle": "탭마다 시간 제한을 골라봐 — 시간이 지나면 사라져. \"항상\"은 그대로 유지돼.",
+        "duration_aria": "{{tab}} 시간 제한",
+        "duration_options": {
+          "always": "항상",
+          "minutes_5": "5분",
+          "minutes_15": "15분",
+          "minutes_30": "30분",
+          "minutes_60": "1시간"
+        },
+        "filters_section": "필터 기본값",
+        "battery_section": "기본 배터리",
+        "battery_subtitle": "'배터리도 같이 설정' 토글이 켜진 상태에서 이 모드를 고르면 적용될 배터리야. 선택사항.",
+        "battery_none": "안 정함",
+        "save_as": "모드로 저장하기",
+        "name_label": "모드 이름",
+        "name_placeholder": "예: 가벼운 모드, 야간 모드",
+        "description_label": "설명 (선택)",
+        "description_placeholder": "예: 시험 기간, 채팅 최소화",
+        "save": "저장",
+        "apply_without_saving": "저장 안 하고 적용",
+        "errors": {
+          "name_required": "모드 이름을 입력해줘",
+          "save_failed": "저장에 실패했어. 다시 해볼까?",
+          "tabs_required": "탭을 하나 이상 골라줘"
+        }
+      }
+    },
+    "wishlist": {
+      "title": "원하는 게 안 보여?",
+      "subtitle": "브라우즈 모드에서 또 어떤 옵션을 커스텀할 수 있으면 좋겠어?",
+      "placeholder": "예: 밤에 자동으로 Soft 모드, 특정 사람 체크인 숨기기, 탭별로 필터 저장하기…",
+      "send": "보내기",
+      "sent_toast": "WIT 관리자에게 전송됐어. 의견 고마워!",
+      "error": "보내지 못했어 — 다시 해볼까?"
+    },
+    "modes": {
+      "very_social": {
+        "name": "Full social",
+        "description": "오늘은 다 보여줘 — 다 즐길 준비됐어"
+      },
+      "selectively_social": {
+        "name": "Just my people",
+        "description": "친한 친구들만, 랜덤 추천은 빼줘"
+      },
+      "quiet": {
+        "name": "Soft mode",
+        "description": "오늘은 그냥 공유만 — 조용히 갈게"
+      }
+    },
+    "tabs": {
+      "friends": "친구",
+      "update": "업데이트",
+      "share": "공유",
+      "discover": "둘러보기",
+      "chats": "채팅",
+      "my": "마이",
+      "questions": "질문"
+    },
+    "filters": {
+      "friends_close_only": "친구 탭에서 친한 친구만 보기",
+      "chats_close_only": "채팅 탭에서 친한 친구만 보기"
+    },
+    "sections": {
+      "hide_synthetic_discover_cards": "둘러보기 추천 숨기기",
+      "hide_ping_buttons": "Ping 버튼 숨기기",
+      "hide_new_post_badge": "\"New post\" 배지 숨기기"
+    },
+    "templates": {
+      "no_discover": {
+        "name": "친구는 보고, 둘러보기는 빼고",
+        "description": "아는 친구들과만 — 오늘은 새 친구는 패스"
+      },
+      "just_chat": {
+        "name": "채팅만",
+        "description": "메시지 답장만, 다른 건 패스"
+      },
+      "just_discover": {
+        "name": "둘러보기만",
+        "description": "새로운 사람과 콘텐츠만 보기"
+      },
+      "digital_detox": {
+        "name": "디지털 디톡스",
+        "description": "스크롤은 잠시 쉬고, 답장만 열어두기"
+      }
+    }
   }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -282,6 +282,9 @@ const router = createBrowserRouter([
       {
         path: 'check-in',
         children: [
+          // DEPRECATED: /check-in/edit is no longer linked from anywhere in the
+          // app. The Check-In bottom tab (`/update`) is the supported flow.
+          // Route kept only for any legacy bookmarks; do NOT navigate here.
           { path: 'edit', element: <CheckInEdit /> },
           { path: 'archive', element: <Archive /> },
         ],

--- a/src/models/browseMode.ts
+++ b/src/models/browseMode.ts
@@ -1,0 +1,101 @@
+import { SocialBattery } from '@models/checkIn';
+
+/** Built-in mode ids are stable strings; custom presets use numeric ids from the backend. */
+export type BuiltInBrowseModeId = 'very_social' | 'selectively_social' | 'quiet';
+
+export type BrowseModeTabKey =
+  | 'friends'
+  | 'update'
+  | 'share'
+  | 'discover'
+  | 'chats'
+  | 'my'
+  | 'questions';
+
+export type BrowseModeFilters = {
+  /**
+   * When true, the FriendsList close-friends-only checkbox starts checked.
+   * Wired in `routes/friends/FriendsList.tsx`.
+   */
+  friends_close_only?: boolean;
+  /**
+   * When true, the ChatList close-friends-only filter starts on.
+   * Wired in `routes/chat/ChatList.tsx`.
+   */
+  chats_close_only?: boolean;
+};
+
+export type BrowseModeSections = {
+  /** Hide synthetic Discover-style cards from the friends feed (mission prompts, profile suggestions, etc.). */
+  hide_synthetic_discover_cards?: boolean;
+  /** Hide ping/poke buttons on friend cards. */
+  hide_ping_buttons?: boolean;
+  /** Hide the "New post" badges. */
+  hide_new_post_badge?: boolean;
+};
+
+export type BrowseModeConfig = {
+  tabs: BrowseModeTabKey[];
+  filters: BrowseModeFilters;
+  sections: BrowseModeSections;
+  /**
+   * Per-tab time limits (minutes). When a tab has a duration set, the
+   * frontend's `useBrowseModeTabDurations` hook removes that tab from the
+   * active mode N minutes after activation. Persists activation time in
+   * localStorage so the timer survives reloads. Tabs missing from this map
+   * are persistent — they stay until the user changes mode.
+   *
+   * This is how Digital-detox-style modes work: start with the broad set
+   * of tabs, mark the scroll-y ones with a duration, and they'll fade out
+   * automatically after the user's chosen window.
+   */
+  tab_durations?: Partial<Record<BrowseModeTabKey, number>>;
+};
+
+export type BuiltInBrowseMode = {
+  kind: 'built_in';
+  id: BuiltInBrowseModeId;
+  emoji: string;
+  /** i18n key suffix under `browse_mode.modes` (e.g., `very_social.name`, `very_social.description`). */
+  i18nKey: BuiltInBrowseModeId;
+  /** Battery level we suggest writing if the user keeps the sync toggle on. */
+  suggestedBattery: SocialBattery;
+  config: BrowseModeConfig;
+};
+
+export type CustomBrowseModePreset = {
+  kind: 'custom';
+  id: number;
+  name: string;
+  /**
+   * Short user-written blurb shown under the preset name on picker cards.
+   * Empty string = no description; the picker falls back to an auto-generated
+   * tab-list summary in that case. Backend caps at 30 characters.
+   */
+  description: string;
+  config: BrowseModeConfig;
+  /** Battery level the sync toggle should apply when this preset activates. Null = no sync. */
+  default_battery: SocialBattery | null;
+  last_used_at: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+/** Anything currently active in the session — built-in OR a custom preset. */
+export type ActiveBrowseMode =
+  | { kind: 'built_in'; id: BuiltInBrowseModeId; config: BrowseModeConfig }
+  | {
+      kind: 'custom';
+      id: number;
+      name: string;
+      config: BrowseModeConfig;
+      default_battery: SocialBattery | null;
+    };
+
+/** Server payload shape for create/update. */
+export type BrowseModePresetPayload = {
+  name: string;
+  description?: string;
+  config: BrowseModeConfig;
+  default_battery?: SocialBattery | null;
+};

--- a/src/routes/Root.tsx
+++ b/src/routes/Root.tsx
@@ -12,6 +12,8 @@ import { SWRConfig } from 'swr';
 import NotiPermissionBanner, {
   NOTI_PERMISSION_BANNER_HEIGHT,
 } from '@components/_common/noti-permission-banner/NotiPermissionBanner';
+import BrowseModePreviewBar from '@components/browse-mode/BrowseModePreviewBar';
+import BrowseModeSessionPrompt from '@components/browse-mode/BrowseModeSessionPrompt';
 import CheckInFreshnessPrompt from '@components/check-in/check-in-freshness-prompt/CheckInFreshnessPrompt';
 import Header from '@components/header/Header';
 import Tab from '@components/tab/Tab';
@@ -19,6 +21,8 @@ import { MAIN_SCROLL_CONTAINER_ID } from '@constants/scroll';
 import { Layout } from '@design-system';
 import { useGetAppMessage, usePostAppMessage } from '@hooks/useAppMessage';
 import useAsyncEffect from '@hooks/useAsyncEffect';
+import { useBrowseModeSessionPrompt } from '@hooks/useBrowseModeSessionPrompt';
+import { useBrowseModeTabDurations } from '@hooks/useBrowseModeTabDurations';
 import { useCheckInFreshnessPrompt } from '@hooks/useCheckInFreshnessPrompt';
 import useFcm from '@hooks/useFcm';
 import { SetAppStateData } from '@models/app';
@@ -55,6 +59,13 @@ function Root() {
     myProfile: state.myProfile,
   }));
   const { shouldShow, dismiss, checkIn } = useCheckInFreshnessPrompt();
+  const browseModePrompt = useBrowseModeSessionPrompt();
+  // Honour per-tab fade-out timers on the active mode (Digital detox-style).
+  // Mounted here so it spans the entire app session, not just while the
+  // picker is open.
+  useBrowseModeTabDurations();
+  const isBrowseModePickerOpen = useBoundStore((state) => state.isBrowseModePickerOpen);
+  const closeBrowseModePicker = useBoundStore((state) => state.closeBrowseModePicker);
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -197,9 +208,28 @@ function Root() {
     <SWRConfig value={{ provider: () => new Map() }}>
       <Layout.FlexRow justifyContent="center" bgColor="BLACK" w="100%">
         <RootContainer w="100%" bgColor="WHITE" id="root-container">
+          {/* Sticky bar: only renders during a transient "Apply without saving"
+              preview. Sits above the header so it's clear the current view is
+              hypothetical and one tap exits back to the picker. */}
+          <BrowseModePreviewBar />
           <Header />
           <Outlet />
           <CheckInFreshnessPrompt visible={shouldShow} onDismiss={dismiss} checkIn={checkIn} />
+          {/* Single picker instance — auto-prompt OR manual open, never both.
+              Mounting two instances caused the customize/wishlist sheets to
+              double up: clicking a link in one instance could open the OTHER
+              instance's sheet, which then refused to close from this one's
+              orchestrator. Consolidating fixes that.
+              Auto-prompt wins when both could fire (it's the one that knows
+              the user is in a fresh session and hasn't picked yet). */}
+          <BrowseModeSessionPrompt
+            visible={browseModePrompt.shouldShow || isBrowseModePickerOpen}
+            fullScreen={browseModePrompt.shouldShow}
+            onDismiss={
+              browseModePrompt.shouldShow ? browseModePrompt.dismiss : closeBrowseModePicker
+            }
+            onFinish={browseModePrompt.shouldShow ? browseModePrompt.finish : closeBrowseModePicker}
+          />
         </RootContainer>
         <Tab />
       </Layout.FlexRow>

--- a/src/routes/chat/ChatList.tsx
+++ b/src/routes/chat/ChatList.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import { Loader } from '@components/_common/loader/Loader.styled';
@@ -28,7 +28,17 @@ function ChatList() {
   const [loading, setLoading] = useState(true);
   const [typingUsers, setTypingUsers] = useState<Record<number, string>>({});
   const [unreadOnly, setUnreadOnly] = useState(false);
-  const [closeFriendsOnly, setCloseFriendsOnly] = useState(false);
+  // Browse mode can prefill the close-friends-only chat filter when a custom
+  // mode (or "Just my people") sets `chats_close_only`. Mirrors how
+  // FriendsList does this — derive the initial state from the active mode and
+  // bump it on if the active mode changes mid-session.
+  const browseModeForcesCloseFriends = useBoundStore(
+    (state) => !!state.activeBrowseMode?.config.filters.chats_close_only,
+  );
+  const [closeFriendsOnly, setCloseFriendsOnly] = useState(browseModeForcesCloseFriends);
+  useEffect(() => {
+    if (browseModeForcesCloseFriends) setCloseFriendsOnly(true);
+  }, [browseModeForcesCloseFriends]);
   const typingTimers = useRef<Record<number, ReturnType<typeof setTimeout>>>({});
 
   const passesCloseFriend = (r: ChatRoom) => {
@@ -134,7 +144,9 @@ function ChatList() {
             </Typo>
           </Layout.FlexRow>
           {featureFlags?.chatCloseFriendsFilter && (
-            <Layout.FlexRow gap={10} alignItems="center">
+            // Close-friends toggle is a viewing affordance — preview-exempt
+            // so the user can flip it while previewing a custom mode.
+            <Layout.FlexRow gap={10} alignItems="center" data-preview-exempt>
               <PurpleToggleWrapper>
                 <ToggleSwitch
                   type="small"

--- a/src/routes/check-in/CheckInEdit.tsx
+++ b/src/routes/check-in/CheckInEdit.tsx
@@ -1,3 +1,10 @@
+/**
+ * @deprecated The standalone "/check-in/edit" page is no longer used. The
+ * Check-In bottom tab (`/update` → `UpdateCheckin`) is the supported entry
+ * point for editing the user's check-in. This component is kept only to
+ * satisfy the existing route registration; do NOT link, navigate, or
+ * import this anywhere else. See plan: "the-previous-version-of-frolicking-sutton".
+ */
 import { Track } from '@spotify/web-api-ts-sdk';
 import { EmojiClickData } from 'emoji-picker-react';
 import { RefObject, useEffect, useRef, useState } from 'react';

--- a/src/routes/discover/Discover.tsx
+++ b/src/routes/discover/Discover.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Navigate } from 'react-router-dom';
 import useSWR from 'swr';
 import FilterChip from '@components/_common/filter-chip/FilterChip';
 import PullToRefresh from '@components/_common/pull-to-refresh/PullToRefresh';
@@ -66,6 +67,16 @@ function Discover() {
   const myProfile = useBoundStore((state) => state.myProfile);
   const { featureFlags } = useBoundStore(UserSelector);
   const isVerQ = !!featureFlags?.postsVerQ;
+
+  // If a browse mode is active and it hides Discover, redirect to the first allowed tab.
+  // Prevents the user landing here via direct URL while their session preferences hide it.
+  // Computed early so we can decide before rendering, but we must still call every hook
+  // below unconditionally to satisfy the Rules of Hooks — the `Navigate` is returned at
+  // the end of this component's body, after all hooks have run.
+  const activeBrowseMode = useBoundStore((state) => state.activeBrowseMode);
+  const allowedTabs = activeBrowseMode?.config.tabs;
+  const discoverHidden = !!allowedTabs && !allowedTabs.includes('discover');
+  const fallbackPath = allowedTabs && allowedTabs.length > 0 ? `/${allowedTabs[0]}` : '/friends';
 
   const { missions } = useMissions();
   const discoverFilterList = [DiscoverFilter.MUTUAL_FRIENDS, DiscoverFilter.MUTUAL_TRAITS];
@@ -192,24 +203,27 @@ function Discover() {
     surveyResultsCard,
   ]);
 
+  // If the active browse mode says to hide synthetic discover cards, drop them here.
+  const hideSyntheticCards = !!activeBrowseMode?.config.sections.hide_synthetic_discover_cards;
+
   // Client-side filtering by category
   const filterItem = useCallback(
     (item: DiscoverResultItem): boolean => {
-      // Always show injected synthetic cards
+      // Synthetic cards: shown by default, hidden when the active browse mode says so.
       if (
         item.type === 'MissionPrompt' ||
         item.type === 'ProfileSuggestion' ||
         item.type === 'MusicHighlight' ||
         item.type === 'SurveyResults'
       ) {
-        return true;
+        return !hideSyntheticCards;
       }
       if (selectedFilter.length === 0) return true;
       // When a filter is active, only show Response/Note items matching the category
       if (item.type !== 'Response' && item.type !== 'Note') return false;
       return selectedFilter.includes(item.category as DiscoverFilter);
     },
-    [selectedFilter],
+    [selectedFilter, hideSyntheticCards],
   );
 
   const handleRefresh = useCallback(async () => {
@@ -299,6 +313,10 @@ function Discover() {
       (item) => filterItem(item) && renderDiscoverItem(item, 0) !== null,
     );
   }, [feedWithInjections, filterItem, renderDiscoverItem]);
+
+  if (discoverHidden) {
+    return <Navigate to={fallbackPath} replace />;
+  }
 
   return (
     <>

--- a/src/routes/friends/FriendsList.tsx
+++ b/src/routes/friends/FriendsList.tsx
@@ -24,7 +24,15 @@ function FriendsList() {
   const [t] = useTranslation('translation');
   const navigate = useNavigate();
   const [selectedTab, setSelectedTab] = useState<TabType>('check-in');
-  const [closeFriendsOnly, setCloseFriendsOnly] = useState(false);
+  // Browse mode can prefill the close-friends-only filter when "Just my people" is active.
+  const browseModeForcesCloseFriends = useBoundStore(
+    (state) => !!state.activeBrowseMode?.config.filters.friends_close_only,
+  );
+  const [closeFriendsOnly, setCloseFriendsOnly] = useState(browseModeForcesCloseFriends);
+  // Reflect mode flips after the screen mounts (e.g., user opens picker from header).
+  useEffect(() => {
+    if (browseModeForcesCloseFriends) setCloseFriendsOnly(true);
+  }, [browseModeForcesCloseFriends]);
   const friendType: FriendType = closeFriendsOnly ? 'close_friends' : 'all';
 
   const {
@@ -155,11 +163,14 @@ function FriendsList() {
               </TabButton>
             </Layout.FlexRow>
 
-            {/* Close friends filter */}
+            {/* Close friends filter — preview-exempt: the user IS allowed to
+                tweak the filter while previewing a custom mode, since it's
+                a viewing affordance (not a write). */}
             <Layout.FlexRow
               gap={6}
               alignItems="center"
               style={{ cursor: 'pointer' }}
+              data-preview-exempt
               onClick={() => setCloseFriendsOnly((prev) => !prev)}
             >
               <CheckboxIcon checked={closeFriendsOnly} />

--- a/src/stores/browseMode.ts
+++ b/src/stores/browseMode.ts
@@ -1,0 +1,223 @@
+import { BUILT_IN_BROWSE_MODES } from '@constants/browseMode';
+import {
+  ActiveBrowseMode,
+  BrowseModeConfig,
+  BuiltInBrowseModeId,
+  CustomBrowseModePreset,
+} from '@models/browseMode';
+import { SocialBattery } from '@models/checkIn';
+import {
+  createBrowseModePreset,
+  deleteBrowseModePreset,
+  getBrowseModePresets,
+  markBrowseModePresetUsed,
+  updateBrowseModePreset,
+} from '@utils/apis/browseMode';
+import { sliceResetFns } from './resetSlices';
+import { SliceStateCreator } from './useBoundStore';
+
+interface BrowseModeState {
+  /** Currently-active browse mode for this session. Null = no mode selected (show everything). */
+  activeBrowseMode: ActiveBrowseMode | null;
+  /** User's saved custom presets, fetched from the backend. */
+  customBrowseModePresets: CustomBrowseModePreset[];
+  /** True while the initial fetch is in flight (and we haven't seen a response yet). */
+  customBrowseModePresetsLoading: boolean;
+  /**
+   * True when something (typically the SideMenu's "Browsing Mode" item)
+   * has requested the manual picker. Distinct from the auto-prompt at
+   * session start, which uses the fullScreen takeover from
+   * useBrowseModeSessionPrompt.
+   */
+  isBrowseModePickerOpen: boolean;
+  /**
+   * Captures the customize-sheet form state at the moment the user picked
+   * "Apply without saving". When set, the SessionPrompt re-opens the
+   * customize sheet with these values on its next mount — used by the
+   * preview bar's exit X so the user lands back where they were instead
+   * of at the picker's mode list. Cleared after restoration.
+   */
+  customizeRestoreSnapshot: {
+    editingPresetId: number | null;
+    config: BrowseModeConfig;
+    name: string;
+    description: string;
+    default_battery: SocialBattery | null;
+  } | null;
+}
+
+interface BrowseModeAction {
+  setActiveBuiltInBrowseMode: (id: BuiltInBrowseModeId) => void;
+  setActiveCustomBrowseMode: (preset: CustomBrowseModePreset) => Promise<void>;
+  clearActiveBrowseMode: () => void;
+  fetchCustomBrowseModePresets: () => Promise<void>;
+  saveCustomBrowseModePreset: (
+    name: string,
+    description: string,
+    config: BrowseModeConfig,
+    defaultBattery: SocialBattery | null,
+  ) => Promise<CustomBrowseModePreset>;
+  updateCustomBrowseModePreset: (
+    id: number,
+    patch: {
+      name?: string;
+      description?: string;
+      config?: BrowseModeConfig;
+      default_battery?: SocialBattery | null;
+    },
+  ) => Promise<void>;
+  deleteCustomBrowseModePreset: (id: number) => Promise<void>;
+  openBrowseModePicker: () => void;
+  closeBrowseModePicker: () => void;
+  setCustomizeRestoreSnapshot: (snap: BrowseModeState['customizeRestoreSnapshot']) => void;
+}
+
+const initialState: BrowseModeState = {
+  activeBrowseMode: null,
+  customBrowseModePresets: [],
+  customBrowseModePresetsLoading: false,
+  isBrowseModePickerOpen: false,
+  customizeRestoreSnapshot: null,
+};
+
+export type BrowseModeSlice = BrowseModeState & BrowseModeAction;
+
+export const createBrowseModeSlice: SliceStateCreator<BrowseModeSlice> = (set) => {
+  sliceResetFns.add(() => set(initialState));
+
+  return {
+    ...initialState,
+
+    setActiveBuiltInBrowseMode: (id) => {
+      const built = BUILT_IN_BROWSE_MODES[id];
+      set(
+        () => ({
+          activeBrowseMode: { kind: 'built_in', id: built.id, config: built.config },
+        }),
+        false,
+        'browseMode/setActiveBuiltIn',
+      );
+    },
+
+    setActiveCustomBrowseMode: async (preset) => {
+      set(
+        () => ({
+          activeBrowseMode: {
+            kind: 'custom',
+            id: preset.id,
+            name: preset.name,
+            config: preset.config,
+            default_battery: preset.default_battery,
+          },
+        }),
+        false,
+        'browseMode/setActiveCustom',
+      );
+      try {
+        const updated = await markBrowseModePresetUsed(preset.id);
+        set(
+          (state) => ({
+            customBrowseModePresets: state.customBrowseModePresets
+              .map((p) => (p.id === updated.id ? updated : p))
+              .sort(sortByLastUsed),
+          }),
+          false,
+          'browseMode/markUsed',
+        );
+      } catch {
+        // last_used_at bump is best-effort; don't block activation on a network blip.
+      }
+    },
+
+    clearActiveBrowseMode: () => set(() => ({ activeBrowseMode: null }), false, 'browseMode/clear'),
+
+    fetchCustomBrowseModePresets: async () => {
+      set(() => ({ customBrowseModePresetsLoading: true }), false, 'browseMode/fetchStart');
+      try {
+        const presets = await getBrowseModePresets();
+        set(
+          () => ({
+            customBrowseModePresets: presets.slice().sort(sortByLastUsed),
+            customBrowseModePresetsLoading: false,
+          }),
+          false,
+          'browseMode/fetchSuccess',
+        );
+      } catch {
+        set(() => ({ customBrowseModePresetsLoading: false }), false, 'browseMode/fetchError');
+      }
+    },
+
+    saveCustomBrowseModePreset: async (name, description, config, defaultBattery) => {
+      const created = await createBrowseModePreset({
+        name,
+        description,
+        config,
+        default_battery: defaultBattery,
+      });
+      set(
+        (state) => ({
+          customBrowseModePresets: [...state.customBrowseModePresets, created].sort(sortByLastUsed),
+        }),
+        false,
+        'browseMode/savePreset',
+      );
+      return created;
+    },
+
+    updateCustomBrowseModePreset: async (id, patch) => {
+      const updated = await updateBrowseModePreset(id, patch);
+      set(
+        (state) => ({
+          customBrowseModePresets: state.customBrowseModePresets
+            .map((p) => (p.id === id ? updated : p))
+            .sort(sortByLastUsed),
+          // Also keep the active mode in sync if it's the one being edited.
+          activeBrowseMode:
+            state.activeBrowseMode?.kind === 'custom' && state.activeBrowseMode.id === id
+              ? {
+                  kind: 'custom',
+                  id: updated.id,
+                  name: updated.name,
+                  config: updated.config,
+                  default_battery: updated.default_battery,
+                }
+              : state.activeBrowseMode,
+        }),
+        false,
+        'browseMode/updatePreset',
+      );
+    },
+
+    deleteCustomBrowseModePreset: async (id) => {
+      await deleteBrowseModePreset(id);
+      set(
+        (state) => ({
+          customBrowseModePresets: state.customBrowseModePresets.filter((p) => p.id !== id),
+          activeBrowseMode:
+            state.activeBrowseMode?.kind === 'custom' && state.activeBrowseMode.id === id
+              ? null
+              : state.activeBrowseMode,
+        }),
+        false,
+        'browseMode/deletePreset',
+      );
+    },
+
+    openBrowseModePicker: () =>
+      set(() => ({ isBrowseModePickerOpen: true }), false, 'browseMode/openPicker'),
+
+    closeBrowseModePicker: () =>
+      set(() => ({ isBrowseModePickerOpen: false }), false, 'browseMode/closePicker'),
+
+    setCustomizeRestoreSnapshot: (snap) =>
+      set(() => ({ customizeRestoreSnapshot: snap }), false, 'browseMode/setRestoreSnapshot'),
+  };
+
+  function sortByLastUsed(a: CustomBrowseModePreset, b: CustomBrowseModePreset) {
+    const ta = a.last_used_at ? new Date(a.last_used_at).getTime() : 0;
+    const tb = b.last_used_at ? new Date(b.last_used_at).getTime() : 0;
+    if (ta !== tb) return tb - ta;
+    return new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime();
+  }
+};

--- a/src/stores/useBoundStore.ts
+++ b/src/stores/useBoundStore.ts
@@ -1,6 +1,7 @@
 import { create, StateCreator } from 'zustand';
 import { devtools } from 'zustand/middleware';
 import { immer } from 'zustand/middleware/immer';
+import { BrowseModeSlice, createBrowseModeSlice } from './browseMode';
 import { CheckInSlice, createCheckInSlice } from './checkIn';
 import { createEmojiPickerSlice, EmojiPickerSlice } from './emojiPicker';
 import { createMomentSlice, MomentSlice } from './moment';
@@ -19,7 +20,8 @@ export type BoundState = MomentSlice &
   NotificationSlice &
   CheckInSlice &
   ToastSlice &
-  EmojiPickerSlice;
+  EmojiPickerSlice &
+  BrowseModeSlice;
 
 export type SliceStateCreator<Slice> = StateCreator<
   BoundState,
@@ -47,5 +49,6 @@ export const useBoundStore = create<BoundState>()(
     ...createCheckInSlice(...a),
     ...createToastSlice(...a),
     ...createEmojiPickerSlice(...a),
+    ...createBrowseModeSlice(...a),
   })),
 );

--- a/src/utils/apis/browseMode.ts
+++ b/src/utils/apis/browseMode.ts
@@ -1,0 +1,50 @@
+import { PaginationResponse } from '@models/api/common';
+import { BrowseModePresetPayload, CustomBrowseModePreset } from '@models/browseMode';
+import axios from './axios';
+
+type ServerPreset = Omit<CustomBrowseModePreset, 'kind'>;
+
+const fromServer = (p: ServerPreset): CustomBrowseModePreset => ({ kind: 'custom', ...p });
+
+export const getBrowseModePresets = async (): Promise<CustomBrowseModePreset[]> => {
+  const { data } = await axios.get<PaginationResponse<ServerPreset[]> | ServerPreset[]>(
+    `/browse_mode/presets/`,
+  );
+  // The backend uses DRF pagination ({ results: [...] }) but flat-array fallbacks exist elsewhere.
+  if (Array.isArray(data)) return data.map(fromServer);
+  const pag = data as PaginationResponse<ServerPreset[]> | undefined;
+  if (pag?.results && Array.isArray(pag.results)) return pag.results.map(fromServer);
+  return [];
+};
+
+export const createBrowseModePreset = async (
+  payload: BrowseModePresetPayload,
+): Promise<CustomBrowseModePreset> => {
+  const { data } = await axios.post<ServerPreset>(`/browse_mode/presets/`, payload);
+  return fromServer(data);
+};
+
+export const updateBrowseModePreset = async (
+  id: number,
+  payload: Partial<BrowseModePresetPayload>,
+): Promise<CustomBrowseModePreset> => {
+  const { data } = await axios.patch<ServerPreset>(`/browse_mode/presets/${id}/`, payload);
+  return fromServer(data);
+};
+
+export const deleteBrowseModePreset = async (id: number): Promise<void> => {
+  await axios.delete(`/browse_mode/presets/${id}/`);
+};
+
+export const markBrowseModePresetUsed = async (id: number): Promise<CustomBrowseModePreset> => {
+  const { data } = await axios.post<ServerPreset>(`/browse_mode/presets/${id}/used/`);
+  return fromServer(data);
+};
+
+/**
+ * Submit a free-text feature request from the customize sheet — "what other
+ * granular changes would you like?". Write-only; users never read each others'.
+ */
+export const submitBrowseModeWishlist = async (content: string): Promise<void> => {
+  await axios.post(`/browse_mode/wishlist/`, { content });
+};

--- a/src/utils/browseModeHiddenModes.ts
+++ b/src/utils/browseModeHiddenModes.ts
@@ -1,0 +1,65 @@
+/**
+ * Per-user persistence of which browsing modes the user has chosen to
+ * hide from the picker. Covers both:
+ *
+ * - built-in modes (hardcoded constants — no other "delete" exists for
+ *   them, so this is the only way the user can declutter the list)
+ * - custom saved presets (user can also fully delete via the API, but
+ *   most of the time they'd rather hide-and-restore than lose work)
+ *
+ * Storage shape: JSON array of mode keys in the form `built_in:<id>` or
+ * `custom:<numeric-id>`, e.g. `["built_in:very_social", "custom:5"]`.
+ * Malformed / unknown entries are filtered on read so a renamed built-in
+ * or deleted custom preset doesn't leave a phantom in the user's list.
+ *
+ * Storage key carries the legacy `browse_mode_hidden_builtins_` prefix
+ * so users with previously-hidden built-ins keep them hidden after this
+ * extension to custom presets — no migration needed.
+ */
+
+import { BuiltInBrowseModeId } from '@models/browseMode';
+
+const STORAGE_KEY_PREFIX = 'browse_mode_hidden_builtins_';
+const BUILT_IN_IDS: BuiltInBrowseModeId[] = ['very_social', 'selectively_social', 'quiet'];
+
+export type HiddenModeKey = `built_in:${BuiltInBrowseModeId}` | `custom:${number}`;
+
+export function builtInKey(id: BuiltInBrowseModeId): HiddenModeKey {
+  return `built_in:${id}`;
+}
+
+export function customKey(id: number): HiddenModeKey {
+  return `custom:${id}`;
+}
+
+function isValidKey(value: unknown): value is HiddenModeKey {
+  if (typeof value !== 'string') return false;
+  if (value.startsWith('built_in:')) {
+    return BUILT_IN_IDS.includes(value.slice('built_in:'.length) as BuiltInBrowseModeId);
+  }
+  if (value.startsWith('custom:')) {
+    const id = Number(value.slice('custom:'.length));
+    return Number.isInteger(id) && id > 0;
+  }
+  return false;
+}
+
+function key(userId: number): string {
+  return `${STORAGE_KEY_PREFIX}${userId}`;
+}
+
+export function readHiddenModes(userId: number): HiddenModeKey[] {
+  const raw = localStorage.getItem(key(userId));
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(isValidKey);
+  } catch {
+    return [];
+  }
+}
+
+export function writeHiddenModes(userId: number, keys: HiddenModeKey[]): void {
+  localStorage.setItem(key(userId), JSON.stringify(keys));
+}

--- a/src/utils/browseModeLastPick.ts
+++ b/src/utils/browseModeLastPick.ts
@@ -1,0 +1,34 @@
+/**
+ * Per-user persistence of the user's most recently activated browse mode.
+ * Used to PRE-SELECT the last-used card in the session-start prompt rather
+ * than rendering a separate "Use my last mode" row above the list.
+ *
+ * Stores either `built_in:<id>` (for one of the 3 built-in modes) or
+ * `custom:<id>` (for a saved custom preset). Returned untouched —
+ * downstream code parses the prefix.
+ */
+
+import { ActiveBrowseMode } from '@models/browseMode';
+
+const STORAGE_KEY_PREFIX = 'browse_mode_last_picked_';
+
+function key(userId: number): string {
+  return `${STORAGE_KEY_PREFIX}${userId}`;
+}
+
+export function saveLastPickedMode(userId: number, mode: ActiveBrowseMode): void {
+  const value = mode.kind === 'built_in' ? `built_in:${mode.id}` : `custom:${mode.id}`;
+  localStorage.setItem(key(userId), value);
+}
+
+export function readLastPickedMode(userId: number): string | null {
+  return localStorage.getItem(key(userId));
+}
+
+export function isBuiltInPicked(stored: string | null, builtInId: string): boolean {
+  return stored === `built_in:${builtInId}`;
+}
+
+export function isCustomPicked(stored: string | null, customId: number): boolean {
+  return stored === `custom:${customId}`;
+}


### PR DESCRIPTION
## Summary
- Adds a 'Browsing Mode' picker (sidebar + auto-prompt) that lets users hide / time-limit tabs to match their vibe
- 3 built-in modes (Full social / Just my people / Soft mode) + saveable custom presets with editable description
- Per-tab durations (Apple Focus-style — Always / 5 / 15 / 30 / 60 min); Digital detox template uses these
- Apply-without-saving preview mode with sticky exit bar; nav + close-friends filters stay tappable, everything else is blocked with a 'Action not allowed in preview mode' toast
- Hide / restore / delete-forever flow on saved presets via 'Edit list'
- Wishlist sheet ('Not seeing what you're looking for?') for free-text feedback

Gated behind \`FeatureFlagKey.BROWSE_MODE\` (Ver.W only).

Backend PR: https://github.com/ssm0318/WhoamI-Today-backend/pull/new/feat/browse-mode-backend-rebased

## Test plan
- [ ] Sidebar → 'Browsing Mode' opens picker
- [ ] Pick a built-in / saved preset → toast 'Browsing in <name> mode' + tabs filter
- [ ] '✨ Add a new browsing mode' → save → picker stays open with new preset listed
- [ ] Edit list → X hides; Hidden section shows it with 'Show again' / 'Delete forever'
- [ ] Apply without saving → preview bar appears; tap actions blocked except nav / close-friends filter; exit X restores customize sheet
- [ ] Digital detox template → tabs collapse to Share after the configured minutes (timer survives reload via localStorage)