### PR TITLE
fix(signin): 안드로이드 WebView 키보드 인풋 점프 fix

### DIFF
--- a/src/routes/SignIn.tsx
+++ b/src/routes/SignIn.tsx
@@ -1,8 +1,10 @@
 import { ChangeEvent, KeyboardEvent, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
 import ValidatedInput from '@components/_common/validated-input/ValidatedInput';
 import ValidatedPasswordInput from '@components/_common/validated-input/ValidatedPasswordInput';
+import { MAX_WINDOW_WIDTH } from '@constants/layout';
 import {
   FRIEND_DEFAULT_REDIRECTION_PATH,
   FRIENDS_Q_DEFAULT_REDIRECTION_PATH,
@@ -59,7 +61,7 @@ function SignIn() {
   };
 
   return (
-    <>
+    <FixedViewport>
       <Layout.FlexCol w="100%" alignItems="center" mt={100}>
         <img width="75px" src="/whoami-logo.svg" alt="who_am_i" />
       </Layout.FlexCol>
@@ -101,8 +103,23 @@ function SignIn() {
           </a>
         </Layout.FlexRow>
       </Layout.FlexCol>
-    </>
+    </FixedViewport>
   );
 }
+
+const FixedViewport = styled.div`
+  position: fixed;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 100%;
+  max-width: ${MAX_WINDOW_WIDTH}px;
+  height: 100vh;
+  height: 100dvh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  background-color: ${({ theme }) => theme.WHITE};
+`;
 
 export default SignIn;


### PR DESCRIPTION
## Summary

- 안드로이드 WebView 에서 SignIn 인풋 탭 시 인풋들이 화면 위쪽으로 끌려 올라가고 인풋 아래에 키보드 높이만큼의 빈 공간이 생기는 버그 fix
- SignIn 컨텐츠를 `position: fixed` 컨테이너로 wrapping 해 viewport 에 고정 — 글로벌 키보드 핸들러가 body padding/scroll 을 변경해도 영향받지 않음

## 원인

`WhoAmI-Today-app/src/screens/AppScreen/AppScreen.tsx` 의 글로벌 `keyboardDidShow` 핸들러가 모든 페이지 body 에 `paddingBottom` 추가 + `activeElement.scrollIntoView` 를 주입함. SignIn 의 부모 `RootContainer` 가 `position: relative` 라 body 스크롤에 종속되어 인풋이 끌려 올라감.

이 보정은 CheckIn / 댓글 같은 다른 페이지에 필요해 글로벌 핸들러는 손댈 수 없음 (#94 회귀 위험). SignIn 만 자체 fixed wrapper 로 격리.

## 변경

- `src/routes/SignIn.tsx`: 기존 fragment → `<FixedViewport>` styled wrapper 로 wrapping (`position: fixed; top:0; left:50%; transform: translateX(-50%); max-width: ${MAX_WINDOW_WIDTH}px; height: 100vh/100dvh; overflow: hidden`)
- 내부 마진/JSX 구조는 그대로 유지

## Test plan

- [ ] 안드로이드 에뮬레이터 320 / 375 / 393 디바이스에서:
  - [ ] SignIn 진입 → 키보드 OFF 디자인 회귀 없음
  - [ ] username 인풋 탭 → 인풋 아래 빈 공간 사라짐, 인풋 가시 영역 안
  - [ ] password 인풋 탭 → 동일
  - [ ] 키보드 dismiss → 원위치 복귀
  - [ ] 인풋 입력 → sign in 버튼 활성화 / 클릭
  - [ ] password 에서 Enter → submit 정상
- [ ] 회귀 검증: SignUp Email/Info/Password, ForgotPassword, CheckInEdit, NewNote, 댓글 입력 — 키보드 동작 변화 없음
- [ ] iOS 시뮬레이터 → SignIn 시각적 회귀 없음
- [ ] 데스크탑 Chrome 1280 / 320px → SignIn 가운데 정렬 정상