### PR TITLE
fix(browse-mode): persist active mode across page refresh

### DIFF
--- a/src/hooks/useBrowseModeActivePersistence.ts
+++ b/src/hooks/useBrowseModeActivePersistence.ts
@@ -1,0 +1,51 @@
+import { useEffect, useRef } from 'react';
+import { useBoundStore } from '@stores/useBoundStore';
+import { readActiveSession, writeActiveSession } from '@utils/browseModeActiveSession';
+
+/**
+ * Glue between the in-memory active-mode Zustand state and per-tab
+ * sessionStorage. Mount once at Root.
+ *
+ * - On user-load, if sessionStorage has an active mode for this user, push
+ *   it back into the store so the page reflects the same mode the user had
+ *   before refreshing. Only does this when the store is empty — never
+ *   stomps on a mode the user has already picked in this fresh mount.
+ * - On every change to activeBrowseMode (subscription), write through to
+ *   sessionStorage so the next refresh has fresh data. clearActiveBrowseMode
+ *   writes null (which removes the key) so a real "exit preview" actually
+ *   clears the persisted mode.
+ */
+export function useBrowseModeActivePersistence() {
+  const userId = useBoundStore((state) => state.myProfile?.id);
+  // Track whether we've already hydrated for this user so we don't
+  // overwrite the user's later picks every time the effect re-fires.
+  const hydratedFor = useRef<number | null>(null);
+
+  // Hydrate from sessionStorage on user-load.
+  useEffect(() => {
+    if (!userId) return;
+    if (hydratedFor.current === userId) return;
+    hydratedFor.current = userId;
+    const current = useBoundStore.getState().activeBrowseMode;
+    // Don't stomp on a mode the user already picked in this mount —
+    // can happen if the picker auto-prompt fires before the rehydration
+    // effect runs, or in a re-render race.
+    if (current) return;
+    const stored = readActiveSession(userId);
+    if (stored) {
+      useBoundStore.setState({ activeBrowseMode: stored });
+    }
+  }, [userId]);
+
+  // Subscribe to activeBrowseMode changes and mirror them to sessionStorage.
+  // useBoundStore.subscribe gives us the raw zustand subscribe; we ignore
+  // changes when there's no userId (anonymous shouldn't persist anything).
+  useEffect(() => {
+    if (!userId) return undefined;
+    const unsub = useBoundStore.subscribe((state, prev) => {
+      if (state.activeBrowseMode === prev.activeBrowseMode) return;
+      writeActiveSession(userId, state.activeBrowseMode);
+    });
+    return unsub;
+  }, [userId]);
+}

--- a/src/routes/Root.tsx
+++ b/src/routes/Root.tsx
@@ -21,6 +21,7 @@ import { MAIN_SCROLL_CONTAINER_ID } from '@constants/scroll';
 import { Layout } from '@design-system';
 import { useGetAppMessage, usePostAppMessage } from '@hooks/useAppMessage';
 import useAsyncEffect from '@hooks/useAsyncEffect';
+import { useBrowseModeActivePersistence } from '@hooks/useBrowseModeActivePersistence';
 import { useBrowseModeSessionPrompt } from '@hooks/useBrowseModeSessionPrompt';
 import { useBrowseModeTabDurations } from '@hooks/useBrowseModeTabDurations';
 import { useCheckInFreshnessPrompt } from '@hooks/useCheckInFreshnessPrompt';
@@ -64,6 +65,10 @@ function Root() {
   // Mounted here so it spans the entire app session, not just while the
   // picker is open.
   useBrowseModeTabDurations();
+  // Persist activeBrowseMode in sessionStorage so a page refresh keeps the
+  // user's pick within the same tab. Cleared on tab close (next visit
+  // starts fresh and the auto-prompt logic decides whether to ask again).
+  useBrowseModeActivePersistence();
   const isBrowseModePickerOpen = useBoundStore((state) => state.isBrowseModePickerOpen);
   const closeBrowseModePicker = useBoundStore((state) => state.closeBrowseModePicker);
   const location = useLocation();

--- a/src/utils/browseModeActiveSession.ts
+++ b/src/utils/browseModeActiveSession.ts
@@ -1,0 +1,49 @@
+/**
+ * Per-user, per-tab persistence of the currently active browse mode.
+ *
+ * Lives in sessionStorage (NOT localStorage) so it survives page refreshes
+ * within a single tab but resets on tab close. That matches the user's
+ * mental model of "I picked Soft mode for THIS session" — refresh shouldn't
+ * forget it, but coming back tomorrow is a fresh decision.
+ *
+ * Cross-tab and cross-day "do you want to re-pick" prompting stays the
+ * responsibility of `useBrowseModeSessionPrompt` — this util only handles
+ * the within-tab survival of an already-chosen mode.
+ */
+
+import { ActiveBrowseMode } from '@models/browseMode';
+
+const STORAGE_KEY_PREFIX = 'browse_mode_active_session_';
+
+function key(userId: number): string {
+  return `${STORAGE_KEY_PREFIX}${userId}`;
+}
+
+export function readActiveSession(userId: number): ActiveBrowseMode | null {
+  try {
+    const raw = sessionStorage.getItem(key(userId));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== 'object') return null;
+    const mode = parsed as { kind?: unknown };
+    // Defensive shape check — corrupt entries (schema change, manual
+    // tampering) shouldn't blow up rehydration.
+    if (mode.kind !== 'built_in' && mode.kind !== 'custom') return null;
+    return parsed as ActiveBrowseMode;
+  } catch {
+    return null;
+  }
+}
+
+export function writeActiveSession(userId: number, mode: ActiveBrowseMode | null): void {
+  try {
+    if (mode === null) {
+      sessionStorage.removeItem(key(userId));
+    } else {
+      sessionStorage.setItem(key(userId), JSON.stringify(mode));
+    }
+  } catch {
+    // sessionStorage can throw in private mode / if quota exceeded —
+    // best-effort persistence, not worth crashing the app over.
+  }
+}


### PR DESCRIPTION
## Summary
- \`activeBrowseMode\` lived only in the Zustand store (memory-only) so a refresh wiped it. User's pick (e.g. 'Just my people') would silently revert to 'no mode' and Discover etc. would reappear.
- Persist per-user, per-tab in **sessionStorage** so refresh keeps the mode but tab close starts fresh.

## Implementation
- \`src/utils/browseModeActiveSession.ts\` — read/write helpers keyed per user, defensive shape check on read.
- \`src/hooks/useBrowseModeActivePersistence.ts\` — mounted at Root.
  - Hydrate the store from sessionStorage on user-load (only when store is empty, so we never stomp on a mode the user picked in this mount).
  - Subscribe to \`activeBrowseMode\` changes and mirror them to sessionStorage. Clearing the mode removes the key.
- Cross-tab and cross-day re-prompting stays the responsibility of \`useBrowseModeSessionPrompt\` — this only covers within-tab refresh.

## Test plan
- [x] Pick 'Just my people' → reload → bottom nav still has only 4 tabs (Discover hidden) ✓
- [x] sessionStorage shows \`browse_mode_active_session_<userId>\` with the picked mode JSON ✓
- [ ] Open new tab → no mode active (sessionStorage is per-tab) ✓
- [ ] Pick a custom preset → reload → preset still active and marked Current
- [ ] Apply without saving → reload → preview bar still showing
- [ ] Close tab and reopen → mode cleared (auto-prompt logic decides whether to ask again)