### PR TITLE
fix(browse-mode): don't create check-in from scratch on battery sync

### DIFF
--- a/src/components/browse-mode/BrowseModeSessionPrompt.tsx
+++ b/src/components/browse-mode/BrowseModeSessionPrompt.tsx
@@ -194,14 +194,18 @@ function BrowseModeSessionPrompt({
       if (myProfile?.id) saveLastPickedMode(myProfile.id, mode);
 
       let batteryApplied: SocialBattery | null = null;
-      if (syncBattery && suggestedBattery) {
+      // Only patch an EXISTING check-in's battery — don't create one from
+      // scratch just because the user picked a browse mode. The backend
+      // requires `visibility` (and other per-component visibilities) on
+      // create; we don't know the user's preferred values, and silently
+      // creating a new check-in with defaults isn't what they asked for.
+      // Users without a check-in yet just don't get the battery sync —
+      // they can run a real check-in later and adjust then.
+      if (syncBattery && suggestedBattery && checkIn) {
         try {
           await postCheckIn({
-            ...(checkIn ?? {}),
+            ...checkIn,
             social_battery: suggestedBattery,
-            mood: checkIn?.mood ?? [],
-            thought: checkIn?.thought ?? '',
-            track_id: checkIn?.track_id ?? '',
           });
           await fetchCheckIn();
           batteryApplied = suggestedBattery;


### PR DESCRIPTION
## Summary
The 'Also set my battery' sync was calling \`postCheckIn\` with a sparse payload (\`social_battery / mood / thought / track_id\`) when the user had no existing check-in yet. The backend's CheckIn serializer requires \`visibility\` on create, so the call returned 400:

\`\`\`
{'visibility': [ErrorDetail(string='이 필드는 필수 항목입니다.', code='required')]}
Body: {\"social_battery\": \"moderately_social\", \"mood\": [], \"thought\": \"\", \"track_id\": \"\"}
\`\`\`

Repro: adoor_2 (ID 3) on Android, no prior check-in, picked a mode with sync-battery on.

## Fix
Two paths:
- **Existing check-in** → spread it whole and override only \`social_battery\` (preserves visibility, per-component visibilities, mood, thought, track_id from the user's actual prior check-in).
- **No check-in yet** → skip the sync entirely. We don't know the user's preferred visibility defaults; fabricating a check-in with arbitrary values isn't what the user asked for when they just picked a browse mode. They can run a real check-in later and adjust then.

## Test plan
- [ ] User with no check-in → pick mode with sync on → no 400, no toast about battery, mode activates fine
- [ ] User with existing check-in → pick mode with sync on → battery updates, other fields preserved (visibility, mood, etc.)
- [ ] Backend logs no 'visibility required' validation errors from /api/check_in/ originating from BrowseModeSessionPrompt