### PR TITLE
feat(friends): ver.Q my friends 리스트에서 close friend 토글

### DIFF
--- a/src/components/friends/updated-friend-item/UpdatedFriendItemDefault.tsx
+++ b/src/components/friends/updated-friend-item/UpdatedFriendItemDefault.tsx
@@ -2,9 +2,10 @@ import { MouseEvent, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Icon from '@components/_common/icon/Icon';
 import ProfileImage from '@components/_common/profile-image/ProfileImage';
+import EditConnectionsBottomSheet from '@components/profile/edit-connections/EditConnectionsBottomSheet';
 import UserMoreModal from '@components/user-page/UserMoreModal';
-import { Layout, Typo } from '@design-system';
-import { UpdatedProfile } from '@models/api/friends';
+import { Layout, SvgIcon, Typo } from '@design-system';
+import { Connection, UpdatedProfile } from '@models/api/friends';
 import { UserProfile } from '@models/user';
 import { useBoundStore } from '@stores/useBoundStore';
 import { UserSelector } from '@stores/user';
@@ -23,12 +24,15 @@ function UpdatedFriendItemDefault({
   showMoreButton,
   onAfterUserMoreAction,
 }: Props) {
-  const { id, profile_image, username, unread_chat_count, description } = user;
+  const { id, profile_image, username, unread_chat_count, description, connection_status } = user;
 
   const { featureFlags } = useBoundStore(UserSelector);
   const isVerQ = !!featureFlags?.postsVerQ;
+  const showConnectionToggle = isMyPage && isVerQ;
 
   const [showMoreModal, setShowMoreModal] = useState(false);
+  const [isEditConnectionsBottomSheetVisible, setIsEditConnectionsBottomSheetVisible] =
+    useState(false);
 
   const navigate = useNavigate();
   const handleClickProfile = () => {
@@ -45,6 +49,11 @@ function UpdatedFriendItemDefault({
     setShowMoreModal(true);
   };
 
+  const handleClickConnectionBadge = (e: MouseEvent) => {
+    e.stopPropagation();
+    setIsEditConnectionsBottomSheetVisible(true);
+  };
+
   return (
     <Layout.FlexRow w="100%" ph={16} gap={16}>
       <StyledUpdatedFriendItem
@@ -57,10 +66,21 @@ function UpdatedFriendItemDefault({
           <Layout.FlexRow alignItems="center" gap={7}>
             <ProfileImage imageUrl={profile_image} username={username} size={44} />
             <Layout.FlexCol>
-              <Layout.FlexRow gap={4} alignItems="center">
+              <Layout.FlexRow gap={8} alignItems="center">
                 <Typo type="label-large" ellipsis={{ enabled: true, maxWidth: 100 }}>
                   {username}
                 </Typo>
+                {showConnectionToggle && connection_status && (
+                  <SvgIcon
+                    name={
+                      connection_status === Connection.CLOSE_FRIEND
+                        ? 'close_friend'
+                        : 'default_friend'
+                    }
+                    size={20}
+                    onClick={handleClickConnectionBadge}
+                  />
+                )}
               </Layout.FlexRow>
               {description && (
                 <Typo type="label-medium" color="MEDIUM_GRAY" numberOfLines={1}>
@@ -104,6 +124,16 @@ function UpdatedFriendItemDefault({
           setIsVisible={setShowMoreModal}
           user={user as unknown as UserProfile}
           callback={onAfterUserMoreAction}
+        />
+      )}
+      {showConnectionToggle && (
+        <EditConnectionsBottomSheet
+          user={user as unknown as UserProfile}
+          visible={isEditConnectionsBottomSheetVisible}
+          closeBottomSheet={() => setIsEditConnectionsBottomSheetVisible(false)}
+          onConnectionChanged={() => {
+            onAfterUserMoreAction?.();
+          }}
         />
       )}
     </Layout.FlexRow>


### PR DESCRIPTION
## Summary
- ver.Q 내 친구 리스트(`/my/friends/list`)의 각 친구 row에 close-friend 토글 아이콘 추가
- UserPage username 옆에 이미 있는 토글 패턴(`SvgIcon close_friend / default_friend` → `EditConnectionsBottomSheet`)을 그대로 이식. 기존 `changeConnection` API 재사용, 백엔드 변경 없음
- `isMyPage && postsVerQ` 일 때만 노출 (다른 사람의 친구 리스트 `DefaultUserFriendsList`는 `isMyPage={false}`라 자동 가려짐)
- 변경 후 `onAfterUserMoreAction`으로 리스트 refetch → 아이콘 즉시 갱신

## Test plan
- [ ] `npx craco build` 클린 (확인됨)
- [ ] dev server webpack overlay 없음
- [ ] ver.Q 시드 계정으로 my profile → "N friends" → 친구 row에 아이콘 노출 확인
- [ ] 아이콘 탭 → bottom sheet → close friend 선택 → save → 토스트 + 즉시 아이콘 변경
- [ ] reload 후 close-friend 상태 유지 (백엔드 round-trip)
- [ ] \`PATCH /api/user/connections/{id}/\` 호출 확인
- [ ] 320px / 393px viewport에서 username row 레이아웃 깨짐 없음
- [ ] ver.W 계정에서는 라우트 진입해도 아이콘 미노출