### PR TITLE
chore(version): rename version swap -> version switch

### DIFF
--- a/src/components/friends/explore-friends/friend-search-list/FriendSearchList.tsx
+++ b/src/components/friends/explore-friends/friend-search-list/FriendSearchList.tsx
@@ -147,9 +147,9 @@ export default function FriendSearchList({ query }: Props) {
             </Typo>
             <Button.Primary
               status="normal"
-              text={t('friends.explore_friends.search.request_version_swap')}
+              text={t('friends.explore_friends.search.request_version_switch')}
               sizing="stretch"
-              onClick={() => navigate('/settings/version-swap-request')}
+              onClick={() => navigate('/settings/version-switch-request')}
             />
           </Layout.FlexCol>
         </Layout.FlexCol>

--- a/src/components/header/side-menu/SideMenu.tsx
+++ b/src/components/header/side-menu/SideMenu.tsx
@@ -12,7 +12,7 @@ import { Button, Layout, SvgIcon, Typo } from '@design-system';
 import { usePostAppMessage } from '@hooks/useAppMessage';
 import { VersionType } from '@models/api/user';
 import { useBoundStore } from '@stores/useBoundStore';
-import { getMyPendingVersionSwapRequest } from '@utils/apis/user';
+import { getMyPendingVersionSwitchRequest } from '@utils/apis/user';
 
 type SideMenuItem =
   | { key: string; emoji: string; kind: 'route'; path: string; flag?: FeatureFlagKey }
@@ -49,8 +49,8 @@ function SideMenu({ closeSideMenu }: Props) {
 
   const myProfile = useBoundStore((state) => state.myProfile);
   const { data: pendingResp } = useSWR(
-    '/user/version-swap-request/me/',
-    getMyPendingVersionSwapRequest,
+    '/user/version-switch-request/me/',
+    getMyPendingVersionSwitchRequest,
   );
   const isPending = !!pendingResp?.pending;
 
@@ -69,9 +69,9 @@ function SideMenu({ closeSideMenu }: Props) {
     closeSideMenu();
   };
 
-  const handleClickVersionSwap = () => {
+  const handleClickVersionSwitch = () => {
     if (isPending) return;
-    navigate('/settings/version-swap-request');
+    navigate('/settings/version-switch-request');
     closeSideMenu();
   };
 
@@ -138,9 +138,9 @@ function SideMenu({ closeSideMenu }: Props) {
                 </Layout.FlexRow>
                 <Button.Secondary
                   status={isPending ? 'disabled' : 'normal'}
-                  text={isPending ? t('request_pending') : t('request_version_swap')}
+                  text={isPending ? t('request_pending') : t('request_version_switch')}
                   sizing="fit-content"
-                  onClick={handleClickVersionSwap}
+                  onClick={handleClickVersionSwitch}
                 />
               </Layout.FlexCol>
             )}

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -248,7 +248,7 @@
                 "feedback_to_researcher": "Feedback to Researchers",
                 "question_suggest": "Suggest Questions",
                 "current_version": "You are currently using",
-                "request_version_swap": "Request Version Swap",
+                "request_version_switch": "Request Version Switch",
                 "request_pending": "Request Pending"
             },
             "bottom_sheet": {
@@ -845,8 +845,8 @@
                 "cancel": "Cancel",
                 "your_friends": "YOUR FRIENDS",
                 "more_results": "MORE RESULTS",
-                "different_version_cta": "Don't see your friend? They might be on a different version. Want to request a version swap?",
-                "request_version_swap": "Request Version Swap"
+                "different_version_cta": "Don't see your friend? They might be on a different version. Want to request a version switch?",
+                "request_version_switch": "Request Version Switch"
             },
             "invite": {
                 "text": "Invite Friends",
@@ -1233,22 +1233,22 @@
             "suppressed": "{{count}} words said by fewer than {{min}} people are hidden to protect privacy."
         }
     },
-    "version_swap": {
-        "title": "Request Version Swap",
-        "confirm_question": "Are you sure you want to swap?",
-        "confirm_explanation": "Have you confirmed with your friend? They can check their version in the side menu.",
-        "your_version_is": "Your version is",
-        "reason_label": "Why do you want to swap? (optional)",
-        "reason_placeholder": "Tell us briefly why you'd like to swap versions.",
-        "understand_irreversible": "I understand this request cannot be cancelled. The swap cannot be reversed — to go back, I'd need to create a new account.",
+    "version_switch": {
+        "title": "Request Version Switch",
+        "confirm_question": "Are you sure you want to switch versions?",
+        "confirm_explanation": "Did you check in with your friend first? They can find their version anytime in the side menu.",
+        "your_version_is": "You're on",
+        "reason_label": "Why do you want to switch? (optional)",
+        "reason_placeholder": "Briefly tell us why you'd like to switch.",
+        "understand_irreversible": "I understand this is a one-way switch. Once I change versions, the only way to go back is to create a new account.",
         "submit": "Submit Request",
         "cancel": "Cancel",
-        "confirm_modal_title": "Submit version swap request?",
-        "confirm_modal_body": "This request cannot be cancelled and the swap cannot be reversed. Do you want to continue?",
+        "confirm_modal_title": "Send version switch request?",
+        "confirm_modal_body": "This can't be undone. Want to continue?",
         "submitted_title": "Request Submitted",
-        "submitted_popup": "An admin will review your request and apply the swap.",
+        "submitted_popup": "We'll review your request and apply the switch soon.",
         "ok": "OK",
-        "already_pending": "You already have a pending version swap request.",
+        "already_pending": "You already have a pending version switch request.",
         "submit_failed": "Could not submit your request. Please try again."
     },
     "browse_mode": {

--- a/src/i18n/locales/ko/translation.json
+++ b/src/i18n/locales/ko/translation.json
@@ -248,7 +248,7 @@
         "feedback_to_researcher": "연구팀에게 피드백",
         "question_suggest": "질문 제안하기",
         "current_version": "현재 사용 중인 버전:",
-        "request_version_swap": "버전 변경 신청",
+        "request_version_switch": "버전 변경 신청",
         "request_pending": "신청 처리 중"
       },
       "bottom_sheet": {
@@ -838,7 +838,7 @@
         "your_friends": "친구",
         "more_results": "더 많은 검색 결과",
         "different_version_cta": "친구가 안 보여? 버전이 달라서 그럴 수도 있어. 버전 변경 신청할래?",
-        "request_version_swap": "버전 변경 신청"
+        "request_version_switch": "버전 변경 신청"
       },
       "invite": {
         "text": "친구 초대",
@@ -1224,7 +1224,7 @@
       "suppressed": "{{min}}명 미만이 답한 단어 {{count}}개는 개인정보 보호를 위해 숨겼어요."
     }
   },
-  "version_swap": {
+  "version_switch": {
     "title": "버전 변경 신청",
     "confirm_question": "변경하고자 하는 게 확실해?",
     "confirm_explanation": "친구랑 확인했어? 그들은 사이드바를 통해 자신의 버전을 확인할 수 있어.",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -67,7 +67,7 @@ import DeleteAccount from './routes/settings/DeleteAccount';
 import EditProfile from './routes/settings/EditProfile';
 import ResetPassword from './routes/settings/ResetPassword';
 import Settings from './routes/settings/Settings';
-import VersionSwapRequest from './routes/settings/VersionSwapRequest';
+import VersionSwitchRequest from './routes/settings/VersionSwitchRequest';
 import Share from './routes/share/Share';
 import Email from './routes/sign-up/Email';
 import Info from './routes/sign-up/Info';
@@ -321,7 +321,7 @@ const router = createBrowserRouter([
           { path: 'reset-password', element: <ResetPassword /> },
           { path: 'daily-noti-setting', element: <DailyNotiSetting /> },
           { path: 'delete-account', element: <DeleteAccount /> },
-          { path: 'version-swap-request', element: <VersionSwapRequest /> },
+          { path: 'version-switch-request', element: <VersionSwitchRequest /> },
         ],
       },
       {

--- a/src/models/api/user.ts
+++ b/src/models/api/user.ts
@@ -159,7 +159,7 @@ export interface SentFriendRequest {
   requestee_detail: User;
 }
 
-export interface VersionSwapRequest {
+export interface VersionSwitchRequest {
   id: number;
   reason: string | null;
   from_version: VersionType;
@@ -168,6 +168,6 @@ export interface VersionSwapRequest {
   created_at: string;
 }
 
-export interface VersionSwapRequestPendingResponse {
-  pending: VersionSwapRequest | null;
+export interface VersionSwitchRequestPendingResponse {
+  pending: VersionSwitchRequest | null;
 }

--- a/src/routes/settings/VersionSwitchRequest.tsx
+++ b/src/routes/settings/VersionSwitchRequest.tsx
@@ -14,15 +14,15 @@ import { DEFAULT_MARGIN, TITLE_HEADER_HEIGHT } from '@constants/layout';
 import { Button, CheckBox, Font, Layout, Typo } from '@design-system';
 import { VersionType } from '@models/api/user';
 import { useBoundStore } from '@stores/useBoundStore';
-import { requestVersionSwap } from '@utils/apis/user';
+import { requestVersionSwitch } from '@utils/apis/user';
 
 const VERSION_LABEL: Record<VersionType, string> = {
   [VersionType.VER_W]: 'Ver.W',
   [VersionType.VER_Q]: 'Ver.Q',
 };
 
-function VersionSwapRequest() {
-  const [t] = useTranslation('translation', { keyPrefix: 'version_swap' });
+function VersionSwitchRequest() {
+  const [t] = useTranslation('translation', { keyPrefix: 'version_switch' });
   const navigate = useNavigate();
   const { mutate } = useSWRConfig();
   const { myProfile, openToast } = useBoundStore((state) => ({
@@ -48,9 +48,9 @@ function VersionSwapRequest() {
   const handleConfirm = async () => {
     setSubmitting(true);
     try {
-      await requestVersionSwap(reason.trim() || undefined);
+      await requestVersionSwitch(reason.trim() || undefined);
       setConfirmVisible(false);
-      mutate('/user/version-swap-request/me/');
+      mutate('/user/version-switch-request/me/');
       setSuccessVisible(true);
     } catch (e) {
       setConfirmVisible(false);
@@ -102,7 +102,7 @@ function VersionSwapRequest() {
 
         <WarningBox>
           <CheckBox
-            name="version-swap-understood"
+            name="version-switch-understood"
             checked={understood}
             onChange={(e) => setUnderstood(e.target.checked)}
             label={
@@ -170,4 +170,4 @@ const WarningBox = styled.div`
   background: ${({ theme }) => theme.INPUT_GRAY};
 `;
 
-export default VersionSwapRequest;
+export default VersionSwitchRequest;

--- a/src/utils/apis/user.ts
+++ b/src/utils/apis/user.ts
@@ -17,8 +17,8 @@ import {
   SignInResponse,
   SignUpParams,
   UsernameError,
-  VersionSwapRequest,
-  VersionSwapRequestPendingResponse,
+  VersionSwitchRequest,
+  VersionSwitchRequestPendingResponse,
 } from '@models/api/user';
 import { Note, Response } from '@models/post';
 import { User, UserProfile } from '@models/user';
@@ -567,16 +567,16 @@ export const getUserAllPosts = async (username: string) => {
   return data;
 };
 
-export const requestVersionSwap = async (reason?: string) => {
-  const { data } = await axios.post<VersionSwapRequest>('/user/version-swap-request/', {
+export const requestVersionSwitch = async (reason?: string) => {
+  const { data } = await axios.post<VersionSwitchRequest>('/user/version-switch-request/', {
     reason: reason ?? '',
   });
   return data;
 };
 
-export const getMyPendingVersionSwapRequest = async () => {
-  const { data } = await axios.get<VersionSwapRequestPendingResponse>(
-    '/user/version-swap-request/me/',
+export const getMyPendingVersionSwitchRequest = async () => {
+  const { data } = await axios.get<VersionSwitchRequestPendingResponse>(
+    '/user/version-switch-request/me/',
   );
   return data;
 };


### PR DESCRIPTION
## Summary
- "Switch versions" reads more naturally than "swap versions" to native English speakers, so unify naming end-to-end.
- Rename route (`/settings/version-switch-request`), component, API helpers (`requestVersionSwitch`, `getMyPendingVersionSwitchRequest`), types, and i18n keys.
- Reword EN copy on the request page so it reads naturally (e.g. "Are you sure you want to switch versions?", "This is a one-way switch — once I change versions, the only way back is to create a new account.").

## Pairs with
Backend PR (must merge together — API URL path changes): chore/version-switch-rename

## Test plan
- [ ] `npx craco build` clean (verified locally)
- [ ] Side menu → "Request Version Switch" navigates to the new route
- [ ] Submit a request, verify backend persists and pending state shows
- [ ] EN copy renders as expected on the request page (320px / 393px)