### PR TITLE
feat(surveys): SLIDER question type frontend + LikertChips spread fix

### DIFF
--- a/src/components/survey/LikertChips.tsx
+++ b/src/components/survey/LikertChips.tsx
@@ -5,7 +5,8 @@ import { Layout, Typo } from '@design-system';
 import { Chip } from './Chip.styled';
 
 const ChipsRow = styled(Layout.FlexRow)`
-  flex-wrap: wrap;
+  width: 100%;
+  justify-content: space-between;
   gap: 8px;
 `;
 

--- a/src/components/survey/SliderInput.tsx
+++ b/src/components/survey/SliderInput.tsx
@@ -1,0 +1,79 @@
+import styled from 'styled-components';
+
+import { Colors, Layout, Typo } from '@design-system';
+
+const Range = styled.input`
+  width: 100%;
+  -webkit-appearance: none;
+  appearance: none;
+  height: 4px;
+  border-radius: 2px;
+  background: ${Colors.LIGHT_GRAY};
+  outline: none;
+
+  &::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    background: ${Colors.PRIMARY};
+    cursor: pointer;
+    border: none;
+  }
+
+  &::-moz-range-thumb {
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    background: ${Colors.PRIMARY};
+    cursor: pointer;
+    border: none;
+  }
+`;
+
+interface SliderInputProps {
+  min: number;
+  max: number;
+  value: number | undefined;
+  onChange: (v: number) => void;
+  lowLabel?: string;
+  highLabel?: string;
+}
+
+export function SliderInput({ min, max, value, onChange, lowLabel, highLabel }: SliderInputProps) {
+  // Display midpoint when the user hasn't picked yet — the slider has to render
+  // at *some* position, but `isAnswered` in SurveyAnswerForm only flips true once
+  // onChange fires (i.e. the user actually moves it).
+  const displayValue = value ?? Math.round((min + max) / 2);
+  const showsValue = value !== undefined && value !== null;
+
+  return (
+    <Layout.FlexCol gap={8} w="100%">
+      <Layout.FlexRow w="100%" justifyContent="center">
+        <Typo type="title-large" color={showsValue ? 'PRIMARY' : 'MEDIUM_GRAY'} bold>
+          {showsValue ? value : '—'}
+        </Typo>
+      </Layout.FlexRow>
+      <Range
+        type="range"
+        min={min}
+        max={max}
+        step={1}
+        value={displayValue}
+        onChange={(e) => onChange(parseInt(e.target.value, 10))}
+        aria-label="slider answer"
+      />
+      {(lowLabel || highLabel) && (
+        <Layout.FlexRow w="100%" justifyContent="space-between">
+          <Typo type="label-medium" color="MEDIUM_GRAY">
+            {lowLabel}
+          </Typo>
+          <Typo type="label-medium" color="MEDIUM_GRAY">
+            {highLabel}
+          </Typo>
+        </Layout.FlexRow>
+      )}
+    </Layout.FlexCol>
+  );
+}

--- a/src/components/survey/SurveyAnswerForm.tsx
+++ b/src/components/survey/SurveyAnswerForm.tsx
@@ -11,6 +11,7 @@ import { submitSurveyResponse } from '@utils/apis/survey';
 import { ChoiceChips } from './ChoiceChips';
 import { FreeTextInput } from './FreeTextInput';
 import { LikertChips } from './LikertChips';
+import { SliderInput } from './SliderInput';
 
 const ProgressBarTrack = styled.div`
   width: 100%;
@@ -169,6 +170,21 @@ export function SurveyAnswerForm({ survey, onSubmitted, onError }: SurveyAnswerF
             placeholder={t('free_text_placeholder') ?? undefined}
           />
         )}
+        {currentQuestion.type === 'slider' &&
+          currentQuestion.slider_min_value !== null &&
+          currentQuestion.slider_max_value !== null && (
+            <SliderInput
+              min={currentQuestion.slider_min_value}
+              max={currentQuestion.slider_max_value}
+              value={currentValue as number | undefined}
+              onChange={(v) => setAnswer(currentQuestion.id, v)}
+              lowLabel={pickLocalized(currentQuestion.low_label_en, currentQuestion.low_label_ko)}
+              highLabel={pickLocalized(
+                currentQuestion.high_label_en,
+                currentQuestion.high_label_ko,
+              )}
+            />
+          )}
       </Layout.FlexCol>
 
       <NavRow>

--- a/src/components/survey/results/SliderHistogramRenderer.tsx
+++ b/src/components/survey/results/SliderHistogramRenderer.tsx
@@ -1,0 +1,87 @@
+import styled from 'styled-components';
+
+import { Colors, Layout, Typo } from '@design-system';
+import { SliderHistogramDistribution } from '@models/survey';
+
+const CHART_HEIGHT = 96;
+
+const ChartArea = styled(Layout.FlexRow)`
+  width: 100%;
+  align-items: flex-end;
+  gap: 4px;
+  height: ${CHART_HEIGHT}px;
+`;
+
+const Bar = styled.div<{ pct: number; highlighted: boolean }>`
+  flex: 1;
+  height: ${({ pct }) => Math.max(2, pct * CHART_HEIGHT)}px;
+  background: ${({ highlighted }) => (highlighted ? Colors.PRIMARY : Colors.LIGHT_GRAY)};
+  border-radius: 4px 4px 0 0;
+  transition: height 200ms ease-out;
+  min-height: 2px;
+`;
+
+const AxisRow = styled(Layout.FlexRow)`
+  width: 100%;
+  justify-content: space-between;
+`;
+
+const StatsRow = styled(Layout.FlexRow)`
+  width: 100%;
+  justify-content: flex-start;
+  gap: 16px;
+  margin-top: 8px;
+`;
+
+interface Props {
+  distribution: SliderHistogramDistribution;
+}
+
+const formatStat = (n: number | null): string => (n === null ? '—' : `${n}`);
+
+export function SliderHistogramRenderer({ distribution }: Props) {
+  const { bins, mean, median, min_value, max_value, user_value } = distribution;
+  const max = Math.max(1, ...bins.map((b) => b.count));
+
+  // The bin holding the viewer's own value (highlight one bar). Last bin is
+  // closed on the right to match the backend's clamp at max_value.
+  const userBinIdx =
+    user_value !== null && bins.length > 0
+      ? bins.findIndex((b, i) =>
+          i === bins.length - 1
+            ? user_value >= b.lo && user_value <= b.hi
+            : user_value >= b.lo && user_value < b.hi,
+        )
+      : -1;
+
+  return (
+    <Layout.FlexCol gap={6} w="100%">
+      <ChartArea>
+        {bins.map((b, i) => (
+          <Bar
+            // bins have unique [lo, hi) so lo is a stable key
+            key={`${b.lo}-${b.hi}`}
+            pct={b.count / max}
+            highlighted={i === userBinIdx}
+          />
+        ))}
+      </ChartArea>
+      <AxisRow>
+        <Typo type="label-medium" color="DARK_GRAY">
+          {formatStat(min_value)}
+        </Typo>
+        <Typo type="label-medium" color="DARK_GRAY">
+          {formatStat(max_value)}
+        </Typo>
+      </AxisRow>
+      <StatsRow>
+        <Typo type="label-large" color="DARK_GRAY">
+          mean&nbsp;{formatStat(mean)}
+        </Typo>
+        <Typo type="label-large" color="DARK_GRAY">
+          median&nbsp;{formatStat(median)}
+        </Typo>
+      </StatsRow>
+    </Layout.FlexCol>
+  );
+}

--- a/src/components/survey/results/registry.ts
+++ b/src/components/survey/results/registry.ts
@@ -17,6 +17,7 @@ import { SurveyDistribution } from '@models/survey';
 
 import { AggregatedLikertRenderer } from './AggregatedLikertRenderer';
 import { OptionCountsRenderer } from './OptionCountsRenderer';
+import { SliderHistogramRenderer } from './SliderHistogramRenderer';
 import { WordcloudRenderer } from './WordcloudRenderer';
 
 type RendererProps<K extends SurveyDistribution['kind']> = {
@@ -29,6 +30,7 @@ export const RENDERER_REGISTRY: Record<SurveyDistribution['kind'], RendererCompo
   aggregated_likert: AggregatedLikertRenderer as RendererComponent,
   option_counts: OptionCountsRenderer as RendererComponent,
   wordcloud: WordcloudRenderer as RendererComponent,
+  slider_histogram: SliderHistogramRenderer as RendererComponent,
 };
 
 export type AnyRendererProps = RendererProps<SurveyDistribution['kind']>;

--- a/src/models/survey.ts
+++ b/src/models/survey.ts
@@ -1,6 +1,6 @@
 // Question types — defined per-question so a single Survey can mix them.
 // Mirror of surveys/models.py TYPE_CHOICES.
-export type QuestionType = 'likert_5' | 'single_choice' | 'multi_choice' | 'free_text';
+export type QuestionType = 'likert_5' | 'single_choice' | 'multi_choice' | 'free_text' | 'slider';
 
 export interface SurveyOption {
   id: number;
@@ -21,6 +21,10 @@ export interface SurveyQuestion {
   high_label_en: string;
   high_label_ko: string;
   reverse_scored: boolean;
+  // Slider-only inclusive bounds; null for non-slider types. low_label /
+  // high_label double as the slider's min/max labels.
+  slider_min_value: number | null;
+  slider_max_value: number | null;
   options: SurveyOption[];
 }
 
@@ -84,10 +88,22 @@ export interface WordcloudDistribution {
   viewer_tokens: string[];
 }
 
+export interface SliderHistogramDistribution {
+  kind: 'slider_histogram';
+  question_id: number | null;
+  min_value: number | null;
+  max_value: number | null;
+  bins: { lo: number; hi: number; count: number }[];
+  mean: number | null;
+  median: number | null;
+  user_value: number | null;
+}
+
 export type SurveyDistribution =
   | AggregatedLikertDistribution
   | OptionCountsDistribution
-  | WordcloudDistribution;
+  | WordcloudDistribution
+  | SliderHistogramDistribution;
 
 export interface BucketResult {
   n: number;


### PR DESCRIPTION
## Summary

Companion to backend [#975](https://github.com/ssm0318/WhoamI-Today-backend/pull/975). Adds the slider question type to the survey UI and a small fix for likert chip spacing.

- `'slider'` added to `QuestionType`; `slider_min_value`/`slider_max_value` on `SurveyQuestion`; `SliderHistogramDistribution` in the union
- `SliderInput`: HTML range input, primary-purple thumb, low/high labels under the slider, current value above. Renders "—" until the user actually moves the slider
- `SurveyAnswerForm` dispatches on `type === 'slider'`, guarded on non-null bounds
- `SliderHistogramRenderer`: 10 vertical bars with viewer's bin highlighted, mean + median below
- Registry maps `slider_histogram → SliderHistogramRenderer`
- Bonus: `LikertChips` now uses `width: 100%; justify-content: space-between` so the 5 chips align under "Strongly disagree"/"Strongly agree" instead of clumping at the left

## Test plan

- [x] `npx craco build` clean (only pre-existing eslint warnings)
- [x] Dev server compiles with no error overlay
- [x] LikertChips spread verified at 320px and 393px viewports