### PR TITLE
feat(profile): switch Edit Profile visibility from checkbox to 4-way segmented toggle

### DIFF
--- a/src/components/check-in/visibility-toggle/VisibilityToggle.tsx
+++ b/src/components/check-in/visibility-toggle/VisibilityToggle.tsx
@@ -1,5 +1,7 @@
+import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 import { Typo } from '@design-system';
+import i18n from '@i18n/index';
 import { ComponentVisibility } from '@models/checkIn';
 
 interface Props {
@@ -7,18 +9,20 @@ interface Props {
   onChange: (visibility: ComponentVisibility) => void;
 }
 
-export const VISIBILITY_OPTIONS: { value: ComponentVisibility; label: string }[] = [
-  { value: ComponentVisibility.PUBLIC, label: 'Public' },
-  { value: ComponentVisibility.FRIENDS, label: 'Friends' },
-  { value: ComponentVisibility.CLOSE_FRIENDS, label: 'Close Friends' },
-  { value: ComponentVisibility.ONLY_ME, label: 'Only Me' },
+export const VISIBILITY_OPTIONS: { value: ComponentVisibility; i18nKey: string }[] = [
+  { value: ComponentVisibility.PUBLIC, i18nKey: 'visibility.public' },
+  { value: ComponentVisibility.FRIENDS, i18nKey: 'visibility.friends' },
+  { value: ComponentVisibility.CLOSE_FRIENDS, i18nKey: 'visibility.close_friends' },
+  { value: ComponentVisibility.ONLY_ME, i18nKey: 'visibility.only_me' },
 ];
 
 export function getVisibilityLabel(value: ComponentVisibility): string {
-  return VISIBILITY_OPTIONS.find((opt) => opt.value === value)?.label ?? '';
+  const opt = VISIBILITY_OPTIONS.find((o) => o.value === value);
+  return opt ? i18n.t(opt.i18nKey) : '';
 }
 
 function VisibilityToggle({ value, onChange }: Props) {
+  const [t] = useTranslation('translation');
   return (
     <ToggleContainer>
       {VISIBILITY_OPTIONS.map((opt) => (
@@ -32,7 +36,7 @@ function VisibilityToggle({ value, onChange }: Props) {
             color={value === opt.value ? 'PRIMARY' : 'MEDIUM_GRAY'}
             fontWeight={value === opt.value ? 600 : 400}
           >
-            {opt.label}
+            {t(opt.i18nKey)}
           </Typo>
         </ToggleOption>
       ))}

--- a/src/components/profile/Profile.tsx
+++ b/src/components/profile/Profile.tsx
@@ -130,15 +130,12 @@ function Profile({ user }: ProfileProps) {
 
   const [showMoreAbout, setShowMoreAbout] = useState(false);
 
-  // Friends-only visibility: hide fields for non-friends if marked as friends-only
-  const isFriend = user && !isMyProfile(user) && areFriends(user);
-  const canSeeFriendsOnly = isMyPage || isFriend;
   const isVerQ = !!featureFlags?.postsVerQ;
 
-  // Ver.Q uses account-level is_public (handled server-side), not per-item flags
-  const showName = isVerQ || canSeeFriendsOnly || !(friendData as any)?.name_friends_only;
-  const showPronouns = isVerQ || canSeeFriendsOnly || !friendData?.pronouns_friends_only;
-  const showBio = isVerQ || canSeeFriendsOnly || !friendData?.bio_friends_only;
+  // Backend already masks per-field visibility; null/empty means hidden.
+  const showName = !!user?.name;
+  const showPronouns = !!user?.pronouns;
+  const showBio = !!user?.bio;
 
   // Backend already filters user_interests / user_personas per-category for non-friends,
   // so presence of items is the source of truth for whether to render the sections.

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -1,4 +1,10 @@
 {
+    "visibility": {
+        "public": "Public",
+        "friends": "Friends",
+        "close_friends": "Close Friends",
+        "only_me": "Only Me"
+    },
     "check_in_subscription": {
         "toast": {
             "subscribed": "Subscribed",
@@ -628,11 +634,11 @@
             "error": {
                 "read_file_error": "Error uploading image. Please try again later."
             },
-            "friends_only": {
-                "name": "Show <token>name</token> only to friends",
-                "pronouns": "Show <token>pronoun</token> only to friends",
-                "bio": "Show <token>bio</token> only to friends",
-                "category": "Show <token>{{label}}</token> only to friends"
+            "visibility": {
+                "name": "Name visibility",
+                "pronouns": "Pronouns visibility",
+                "bio": "Bio visibility",
+                "category": "{{label}} visibility"
             },
             "placeholders": {
                 "bio": "Bio",
@@ -883,6 +889,7 @@
                 "delete": "Delete",
                 "request": "Friend Request",
                 "requested": "Requested",
+                "requested_friend": "Friend Requested",
                 "cancel": "Cancel",
                 "block_recommendation": "Delete",
                 "delete_request_dialog": {

--- a/src/i18n/locales/ko/translation.json
+++ b/src/i18n/locales/ko/translation.json
@@ -1,4 +1,10 @@
 {
+  "visibility": {
+    "public": "공개",
+    "friends": "친구",
+    "close_friends": "친한 친구",
+    "only_me": "나만"
+  },
   "check_in_post": {
     "new_title": "New Daily Snippet",
     "add_image": "사진 추가",
@@ -551,6 +557,7 @@
       "button": {
         "request": "채팅 요청",
         "requested": "요청됨",
+        "requested_chat": "채팅 요청됨",
         "cancel": "취소",
         "cancel_dialog": {
           "title": "채팅 요청 취소",
@@ -625,11 +632,11 @@
       "error": {
         "read_file_error": "이미지를 불러오는 중 일시적인 오류가 발생했습니다. 잠시 후 다시 시도해주세요."
       },
-      "friends_only": {
-        "name": "<token>이름</token>을 친구에게만 보이기",
-        "pronouns": "<token>대명사</token>를 친구에게만 보이기",
-        "bio": "<token>소개</token>를 친구에게만 보이기",
-        "category": "<token>{{label}}</token>을 친구에게만 보이기"
+      "visibility": {
+        "name": "이름 공개 범위",
+        "pronouns": "대명사 공개 범위",
+        "bio": "소개 공개 범위",
+        "category": "{{label}} 공개 범위"
       },
       "placeholders": {
         "bio": "소개",
@@ -875,6 +882,7 @@
         "delete": "삭제",
         "request": "친구 요청",
         "requested": "요청됨",
+        "requested_friend": "친구 요청됨",
         "cancel": "취소",
         "block_recommendation": "추천 삭제",
         "delete_request_dialog": {

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -1,6 +1,6 @@
 import { Connection } from '@models/api/friends';
 import { MyProfile } from './api/user';
-import { CheckInBase } from './checkIn';
+import { CheckInBase, ComponentVisibility } from './checkIn';
 
 export interface User {
   id: number;
@@ -9,6 +9,7 @@ export interface User {
   url: string;
   username: string;
   email?: string;
+  name?: string | null;
   bio: string;
   pronouns: string;
   has_changed_pw?: boolean;
@@ -18,19 +19,17 @@ export interface User {
   connection_status: Connection | null;
   user_interests: string[]; // ['#hiking', '#dogs']과 같은 형식
   user_personas: string[]; // ['#lurker', '#openbook']과 같은 형식
-  // Friends-only visibility flags
-  interests_friends_only?: boolean;
-  persona_friends_only?: boolean;
-  pronouns_friends_only?: boolean;
-  bio_friends_only?: boolean;
-  // Per-category visibility flags (source of truth on server)
-  music_entertainment_friends_only?: boolean;
-  hobbies_activities_friends_only?: boolean;
-  on_my_mind_friends_only?: boolean;
-  as_a_friend_friends_only?: boolean;
-  online_persona_friends_only?: boolean;
-  favorite_platform_friends_only?: boolean;
-  least_favorite_platform_friends_only?: boolean;
+  // 4-way visibility (only present on MyProfile responses; absent on others)
+  name_visibility?: ComponentVisibility;
+  pronouns_visibility?: ComponentVisibility;
+  bio_visibility?: ComponentVisibility;
+  music_entertainment_visibility?: ComponentVisibility;
+  hobbies_activities_visibility?: ComponentVisibility;
+  on_my_mind_visibility?: ComponentVisibility;
+  as_a_friend_visibility?: ComponentVisibility;
+  online_persona_visibility?: ComponentVisibility;
+  favorite_platform_visibility?: ComponentVisibility;
+  least_favorite_platform_visibility?: ComponentVisibility;
   // Mutual counts (injected by discover feed API)
   mutual_friend_count?: number;
   mutual_interest_count?: number;

--- a/src/routes/settings/EditProfile.tsx
+++ b/src/routes/settings/EditProfile.tsx
@@ -1,6 +1,6 @@
 import { isAxiosError } from 'axios';
-import { ChangeEvent, useRef, useState } from 'react';
-import { Trans, useTranslation } from 'react-i18next';
+import { ChangeEvent, ReactNode, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import styled from 'styled-components';
 import ProfileImage from '@components/_common/profile-image/ProfileImage';
@@ -9,14 +9,16 @@ import ProfileImageEditButton from '@components/_common/profile-image-edit-butto
 import UploadLoadingOverlay from '@components/_common/upload-loading-overlay/UploadLoadingOverlay';
 import ValidatedInput from '@components/_common/validated-input/ValidatedInput';
 import ValidatedTextArea from '@components/_common/validated-textarea/ValidatedTextArea';
+import VisibilityToggle from '@components/check-in/visibility-toggle/VisibilityToggle';
 import ChipCategorySection from '@components/profile/chip/ChipCategorySection';
 import { StyledEditProfileButton } from '@components/settings/SettingsButtons.styled';
 import SubHeader from '@components/sub-header/SubHeader';
 import { TITLE_HEADER_HEIGHT } from '@constants/layout';
-import { CheckBox, Colors, Layout, Typo } from '@design-system';
+import { Colors, Layout, Typo } from '@design-system';
 import { useChipCategories } from '@hooks/useChipCategories';
 import { useDelayedVisible } from '@hooks/useDelayedVisible';
 import { MyProfile } from '@models/api/user';
+import { ComponentVisibility } from '@models/checkIn';
 import {
   ChipCategory,
   CustomChip,
@@ -30,6 +32,18 @@ import { CroppedImg, readFile } from '@utils/getCroppedImg';
 import { shouldShowWidgetGuide } from '@utils/widgetInstallGuide';
 import { MainScrollContainer } from '../Root';
 
+const CATEGORY_KEYS = [
+  'music_entertainment',
+  'hobbies_activities',
+  'on_my_mind',
+  'as_a_friend',
+  'online_persona',
+  'favorite_platform',
+  'least_favorite_platform',
+] as const;
+
+type CategoryKey = (typeof CATEGORY_KEYS)[number];
+
 function EditProfile() {
   type EditProfileTab = 'pronouns_bio' | 'interests';
   const location = useLocation();
@@ -39,6 +53,7 @@ function EditProfile() {
   const tabParam = searchParams.get('tab');
   const initialTab: EditProfileTab = tabParam === 'interests' ? 'interests' : 'pronouns_bio';
   const [t] = useTranslation('translation', { keyPrefix: 'settings.edit_profile' });
+  const [tVis] = useTranslation('translation', { keyPrefix: 'settings.edit_profile.visibility' });
   const { myProfile, updateMyProfile, openToast, featureFlags } = useBoundStore((state) => ({
     myProfile: state.myProfile,
     updateMyProfile: state.updateMyProfile,
@@ -47,10 +62,6 @@ function EditProfile() {
   }));
 
   const { categories } = useChipCategories();
-  const profileWithOptionalName = myProfile as MyProfile & {
-    name?: string;
-    name_friends_only?: boolean;
-  };
 
   // Parse existing user chips into per-category selections
   const parseExistingChips = () => {
@@ -74,6 +85,13 @@ function EditProfile() {
 
   const parsed = parseExistingChips();
 
+  const initialCategoryVisibility = CATEGORY_KEYS.reduce((acc, key) => {
+    acc[key] =
+      (myProfile?.[`${key}_visibility` as keyof MyProfile] as ComponentVisibility | undefined) ??
+      ComponentVisibility.PUBLIC;
+    return acc;
+  }, {} as Record<CategoryKey, ComponentVisibility>);
+
   const [draft, setDraft] = useState<{
     bio: string;
     username: string;
@@ -81,29 +99,21 @@ function EditProfile() {
     pronouns: string;
     chipSelections: Record<string, string[]>;
     customChips: CustomChip[];
-    name_friends_only: boolean;
-    pronouns_friends_only: boolean;
-    bio_friends_only: boolean;
-    categoryFriendsOnly: Record<string, boolean>;
+    name_visibility: ComponentVisibility;
+    pronouns_visibility: ComponentVisibility;
+    bio_visibility: ComponentVisibility;
+    categoryVisibility: Record<CategoryKey, ComponentVisibility>;
   }>({
     bio: myProfile?.bio ?? '',
     username: myProfile?.username ?? '',
-    name: profileWithOptionalName?.name ?? '',
+    name: myProfile?.name ?? '',
     pronouns: myProfile?.pronouns ?? '',
     chipSelections: parsed.selections,
     customChips: parsed.customs,
-    name_friends_only: profileWithOptionalName?.name_friends_only ?? true,
-    pronouns_friends_only: myProfile?.pronouns_friends_only ?? false,
-    bio_friends_only: myProfile?.bio_friends_only ?? false,
-    categoryFriendsOnly: {
-      music_entertainment: myProfile?.music_entertainment_friends_only ?? false,
-      hobbies_activities: myProfile?.hobbies_activities_friends_only ?? false,
-      on_my_mind: myProfile?.on_my_mind_friends_only ?? false,
-      as_a_friend: myProfile?.as_a_friend_friends_only ?? false,
-      online_persona: myProfile?.online_persona_friends_only ?? false,
-      favorite_platform: myProfile?.favorite_platform_friends_only ?? false,
-      least_favorite_platform: myProfile?.least_favorite_platform_friends_only ?? false,
-    },
+    name_visibility: myProfile?.name_visibility ?? ComponentVisibility.PUBLIC,
+    pronouns_visibility: myProfile?.pronouns_visibility ?? ComponentVisibility.PUBLIC,
+    bio_visibility: myProfile?.bio_visibility ?? ComponentVisibility.PUBLIC,
+    categoryVisibility: initialCategoryVisibility,
   });
 
   const [usernameError, setUsernameError] = useState<string>();
@@ -181,17 +191,17 @@ function EditProfile() {
     }));
   };
 
-  const handleToggleVisibility = (field: string) => {
-    setDraft((prev) => ({ ...prev, [field]: !prev[field as keyof typeof prev] }));
+  const handleSetVisibility = (
+    field: 'name_visibility' | 'pronouns_visibility' | 'bio_visibility',
+    value: ComponentVisibility,
+  ) => {
+    setDraft((prev) => ({ ...prev, [field]: value }));
   };
 
-  const handleToggleCategoryVisibility = (categoryKey: string) => {
+  const handleSetCategoryVisibility = (categoryKey: CategoryKey, value: ComponentVisibility) => {
     setDraft((prev) => ({
       ...prev,
-      categoryFriendsOnly: {
-        ...prev.categoryFriendsOnly,
-        [categoryKey]: !prev.categoryFriendsOnly[categoryKey],
-      },
+      categoryVisibility: { ...prev.categoryVisibility, [categoryKey]: value },
     }));
   };
 
@@ -256,16 +266,16 @@ function EditProfile() {
       name: draft.name,
       pronouns: draft.pronouns,
       ...(!featureFlags?.postsVerQ && {
-        name_friends_only: draft.name_friends_only,
-        pronouns_friends_only: draft.pronouns_friends_only,
-        bio_friends_only: draft.bio_friends_only,
-        music_entertainment_friends_only: draft.categoryFriendsOnly.music_entertainment,
-        hobbies_activities_friends_only: draft.categoryFriendsOnly.hobbies_activities,
-        on_my_mind_friends_only: draft.categoryFriendsOnly.on_my_mind,
-        as_a_friend_friends_only: draft.categoryFriendsOnly.as_a_friend,
-        online_persona_friends_only: draft.categoryFriendsOnly.online_persona,
-        favorite_platform_friends_only: draft.categoryFriendsOnly.favorite_platform,
-        least_favorite_platform_friends_only: draft.categoryFriendsOnly.least_favorite_platform,
+        name_visibility: draft.name_visibility,
+        pronouns_visibility: draft.pronouns_visibility,
+        bio_visibility: draft.bio_visibility,
+        music_entertainment_visibility: draft.categoryVisibility.music_entertainment,
+        hobbies_activities_visibility: draft.categoryVisibility.hobbies_activities,
+        on_my_mind_visibility: draft.categoryVisibility.on_my_mind,
+        as_a_friend_visibility: draft.categoryVisibility.as_a_friend,
+        online_persona_visibility: draft.categoryVisibility.online_persona,
+        favorite_platform_visibility: draft.categoryVisibility.favorite_platform,
+        least_favorite_platform_visibility: draft.categoryVisibility.least_favorite_platform,
       }),
       ...(croppedImg ? { profile_image: croppedImg.file } : {}),
     };
@@ -314,6 +324,16 @@ function EditProfile() {
   };
 
   if (!myProfile) return null;
+
+  const renderVisibilityRow = (label: string, control: ReactNode) =>
+    !featureFlags?.postsVerQ && (
+      <Layout.FlexRow w="100%" justifyContent="space-between" alignItems="center" gap={8}>
+        <Typo type="label-medium" color="MEDIUM_GRAY">
+          {label}
+        </Typo>
+        {control}
+      </Layout.FlexRow>
+    );
 
   return (
     <MainScrollContainer>
@@ -387,7 +407,7 @@ function EditProfile() {
               error={usernameError}
             />
 
-            <Layout.FlexCol gap={4} w="100%">
+            <Layout.FlexCol gap={6} w="100%">
               <ValidatedInput
                 label="Name"
                 name="name"
@@ -396,47 +416,33 @@ function EditProfile() {
                 onChange={handleChangeInput}
                 limit={50}
               />
-              {!featureFlags?.postsVerQ && (
-                <CheckBox
-                  name="name_friends_only"
-                  label={
-                    <Trans
-                      i18nKey="settings.edit_profile.friends_only.name"
-                      components={{ token: <TokenTag /> }}
-                    />
-                  }
-                  checked={draft.name_friends_only}
-                  onChange={() => handleToggleVisibility('name_friends_only')}
-                />
+              {renderVisibilityRow(
+                tVis('name'),
+                <VisibilityToggle
+                  value={draft.name_visibility}
+                  onChange={(v) => handleSetVisibility('name_visibility', v)}
+                />,
               )}
             </Layout.FlexCol>
 
-            <Layout.FlexCol gap={4} w="100%">
-              <Layout.FlexCol w="100%" mb={4}>
-                <ValidatedInput
-                  label={t('pronouns')}
-                  name="pronouns"
-                  type="text"
-                  value={draft.pronouns}
-                  onChange={handleChangeInput}
-                />
-              </Layout.FlexCol>
-              {!featureFlags?.postsVerQ && (
-                <CheckBox
-                  name="pronouns_friends_only"
-                  label={
-                    <Trans
-                      i18nKey="settings.edit_profile.friends_only.pronouns"
-                      components={{ token: <TokenTag /> }}
-                    />
-                  }
-                  checked={draft.pronouns_friends_only}
-                  onChange={() => handleToggleVisibility('pronouns_friends_only')}
-                />
+            <Layout.FlexCol gap={6} w="100%">
+              <ValidatedInput
+                label={t('pronouns')}
+                name="pronouns"
+                type="text"
+                value={draft.pronouns}
+                onChange={handleChangeInput}
+              />
+              {renderVisibilityRow(
+                tVis('pronouns'),
+                <VisibilityToggle
+                  value={draft.pronouns_visibility}
+                  onChange={(v) => handleSetVisibility('pronouns_visibility', v)}
+                />,
               )}
             </Layout.FlexCol>
 
-            <Layout.FlexCol gap={4} w="100%">
+            <Layout.FlexCol gap={6} w="100%">
               <ValidatedTextArea
                 label={t('bio')}
                 name="bio"
@@ -444,25 +450,19 @@ function EditProfile() {
                 onChange={handleChangeTextArea}
                 limit={120}
               />
-              {!featureFlags?.postsVerQ && (
-                <CheckBox
-                  name="bio_friends_only"
-                  label={
-                    <Trans
-                      i18nKey="settings.edit_profile.friends_only.bio"
-                      components={{ token: <TokenTag /> }}
-                    />
-                  }
-                  checked={draft.bio_friends_only}
-                  onChange={() => handleToggleVisibility('bio_friends_only')}
-                />
+              {renderVisibilityRow(
+                tVis('bio'),
+                <VisibilityToggle
+                  value={draft.bio_visibility}
+                  onChange={(v) => handleSetVisibility('bio_visibility', v)}
+                />,
               )}
             </Layout.FlexCol>
           </>
         ) : (
           <>
             {categories.map((categoryInfo) => (
-              <Layout.FlexCol key={categoryInfo.key} gap={4} w="100%">
+              <Layout.FlexCol key={categoryInfo.key} gap={6} w="100%">
                 <ChipCategorySection
                   categoryInfo={categoryInfo}
                   selectedChips={draft.chipSelections[categoryInfo.key] || []}
@@ -471,19 +471,18 @@ function EditProfile() {
                   onAddCustomChip={handleAddCustomChip}
                   onRemoveCustomChip={handleRemoveCustomChip}
                 />
-                <CheckBox
-                  name={`${categoryInfo.key}_friends_only`}
-                  label={
-                    <Trans
-                      i18nKey="settings.edit_profile.friends_only.category"
-                      values={{ label: categoryInfo.label }}
-                      components={{ token: <TokenTag /> }}
-                      tOptions={{ interpolation: { escapeValue: false } }}
-                    />
-                  }
-                  checked={!!draft.categoryFriendsOnly[categoryInfo.key]}
-                  onChange={() => handleToggleCategoryVisibility(categoryInfo.key)}
-                />
+                {renderVisibilityRow(
+                  tVis('category', { label: categoryInfo.label }),
+                  <VisibilityToggle
+                    value={
+                      draft.categoryVisibility[categoryInfo.key as CategoryKey] ??
+                      ComponentVisibility.PUBLIC
+                    }
+                    onChange={(v) =>
+                      handleSetCategoryVisibility(categoryInfo.key as CategoryKey, v)
+                    }
+                  />,
+                )}
               </Layout.FlexCol>
             ))}
           </>
@@ -525,12 +524,4 @@ const EditProfileTabButton = styled.button<{ $active: boolean }>`
   font-weight: ${({ $active }) => ($active ? 700 : 500)};
   transition: color 0.15s ease, border-color 0.15s ease;
   margin-bottom: -1px;
-`;
-
-const TokenTag = styled.span`
-  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-  font-size: 13px;
-  background-color: ${Colors.INPUT_GRAY};
-  padding: 1px 5px;
-  border-radius: 3px;
 `;

--- a/src/utils/apis/my.ts
+++ b/src/utils/apis/my.ts
@@ -35,12 +35,23 @@ export const editProfile = ({
       MyProfile,
       | 'bio'
       | 'username'
+      | 'name'
       | 'pronouns'
       | 'noti_time'
       | 'noti_period_days'
       | 'user_personas'
       | 'user_interests'
       | 'is_public'
+      | 'name_visibility'
+      | 'pronouns_visibility'
+      | 'bio_visibility'
+      | 'music_entertainment_visibility'
+      | 'hobbies_activities_visibility'
+      | 'on_my_mind_visibility'
+      | 'as_a_friend_visibility'
+      | 'online_persona_visibility'
+      | 'favorite_platform_visibility'
+      | 'least_favorite_platform_visibility'
     >
   > & {
     profile_image?: File;


### PR DESCRIPTION
## Summary
- Each profile field (name, pronouns, bio, 7 chip categories) now uses the same `VisibilityToggle` component as Check-In: Public / Friends / Close Friends / Only Me
- Replaces the binary "Show X only to friends" checkbox — the OFF state was unintuitive (couldn't tell what was the alternative)
- `VisibilityToggle` is now i18n-aware (was English-hardcoded)
- `User.name` is now a first-class field; visibility-based masking moved server-side (`Profile.tsx` no longer guesses)

## Pair PR
Backend: feat/profile-visibility-enum (must merge BEFORE this — frontend reads `*_visibility` and `name` columns added by backend migrations)

## Test plan
- [x] `npx craco build` clean
- [x] Dev server compiles with no error overlay
- [ ] Visual: 320px / 393px viewports — segmented toggle wraps gracefully
- [ ] Save round-trip: toggle each field → save → reload → values persist
- [ ] EN + KO i18n — both render correctly
- [ ] Owner profile preview (View As mode) reflects new tier