### PR TITLE
fix(surveys): make DailyArchive and SurveysIndex scrollable

### DIFF
--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -1202,6 +1202,7 @@
         "responder_count_today": "{{count}} people took this on WIT today",
         "responder_count_today_zero": "Be the first to take this on WIT today",
         "view_results": "View results",
+        "done": "Done",
         "answered_view_results": "Answered — view results",
         "answer_to_view_results": "Answer to view results",
         "locked_title": "Results not yet available",

--- a/src/i18n/locales/ko/translation.json
+++ b/src/i18n/locales/ko/translation.json
@@ -1193,6 +1193,7 @@
     "responder_count_today": "오늘 WIT에서 {{count}}명이 응답했어요",
     "responder_count_today_zero": "WIT에서 첫 번째로 응답해보세요",
     "view_results": "결과 보기",
+    "done": "완료",
     "answered_view_results": "응답 완료 — 결과 보기",
     "answer_to_view_results": "답변하면 결과를 볼 수 있어요",
     "locked_title": "결과가 아직 공개되지 않았어요",

--- a/src/routes/surveys/DailyArchive.tsx
+++ b/src/routes/surveys/DailyArchive.tsx
@@ -10,13 +10,15 @@ import i18n from '@i18n/index';
 import { PastSurvey } from '@models/survey';
 import { getPastSurveys } from '@utils/apis/survey';
 
+import { MainScrollContainer } from '../Root';
+
 const Page = styled(Layout.FlexCol)`
   width: 100%;
   padding: 16px;
   padding-top: ${TITLE_HEADER_HEIGHT + 16}px;
   gap: 12px;
   background: ${Colors.LIGHT};
-  min-height: 100vh;
+  min-height: 100%;
 `;
 
 const RowCard = styled.button`
@@ -60,7 +62,7 @@ function DailyArchive() {
   if (!data) return null;
 
   return (
-    <>
+    <MainScrollContainer>
       <SubHeader title={t('archive_title')} />
       <Page>
         {data.results.length === 0 && (
@@ -82,7 +84,7 @@ function DailyArchive() {
           </RowCard>
         ))}
       </Page>
-    </>
+    </MainScrollContainer>
   );
 }
 

--- a/src/routes/surveys/SurveyResults.tsx
+++ b/src/routes/surveys/SurveyResults.tsx
@@ -11,13 +11,29 @@ import i18n from '@i18n/index';
 import { ResultPanel, Survey, SurveyResultsError } from '@models/survey';
 import { getSurveyDetail, getSurveyResults } from '@utils/apis/survey';
 
+import { MainScrollContainer } from '../Root';
+
 const Page = styled(Layout.FlexCol)`
   width: 100%;
   padding: 16px;
   padding-top: ${TITLE_HEADER_HEIGHT + 16}px;
   gap: 24px;
   background: ${Colors.LIGHT};
-  min-height: 100vh;
+  min-height: 100%;
+`;
+
+const DoneButton = styled.button`
+  align-self: stretch;
+  border: 1px solid ${Colors.PRIMARY};
+  border-radius: 12px;
+  padding: 12px 16px;
+  background: ${Colors.PRIMARY};
+  color: ${Colors.WHITE};
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  margin-top: 8px;
+  -webkit-tap-highlight-color: transparent;
 `;
 
 const PanelGroup = styled(Layout.FlexCol)`
@@ -113,7 +129,7 @@ function SurveyResults() {
   if (axiosError?.response?.status === 403) {
     const body = axiosError.response.data;
     return (
-      <>
+      <MainScrollContainer>
         <SubHeader title={t('locked_title')} />
         <Page>
           <Typo type="body-medium" color="DARK_GRAY">
@@ -124,8 +140,11 @@ function SurveyResults() {
               {t('answer_to_view_results')}
             </ActionButton>
           )}
+          <DoneButton type="button" onClick={() => navigate('/share')}>
+            {t('done')}
+          </DoneButton>
         </Page>
-      </>
+      </MainScrollContainer>
     );
   }
 
@@ -134,7 +153,7 @@ function SurveyResults() {
   const interpretation = pickLocalized(survey.interpretation_en, survey.interpretation_ko);
 
   return (
-    <>
+    <MainScrollContainer>
       <SubHeader title={pickLocalized(survey.title_en, survey.title_ko)} />
       <Page>
         {data.panels.map((panel, idx) => (
@@ -145,8 +164,11 @@ function SurveyResults() {
             interpretation={idx === 0 ? interpretation : undefined}
           />
         ))}
+        <DoneButton type="button" onClick={() => navigate('/share')}>
+          {t('done')}
+        </DoneButton>
       </Page>
-    </>
+    </MainScrollContainer>
   );
 }
 

--- a/src/routes/surveys/SurveysIndex.tsx
+++ b/src/routes/surveys/SurveysIndex.tsx
@@ -10,13 +10,15 @@ import i18n from '@i18n/index';
 import { Bucket, SurveyIndexEntry } from '@models/survey';
 import { getSurveyIndex } from '@utils/apis/survey';
 
+import { MainScrollContainer } from '../Root';
+
 const Page = styled(Layout.FlexCol)`
   width: 100%;
   padding: 16px;
   padding-top: ${TITLE_HEADER_HEIGHT + 16}px;
   gap: 16px;
   background: ${Colors.LIGHT};
-  min-height: 100vh;
+  min-height: 100%;
 `;
 
 const Section = styled(Layout.FlexCol)`
@@ -113,7 +115,7 @@ function SurveysIndex() {
   const hasCompleted = dailyCompletedCount > 0 || nonDailyCompleted.length > 0;
 
   return (
-    <>
+    <MainScrollContainer>
       <SubHeader title={t('index_title')} />
       <Page>
         {!hasAvailable && !hasLate && !hasCompleted && (
@@ -166,7 +168,7 @@ function SurveysIndex() {
           </Section>
         )}
       </Page>
-    </>
+    </MainScrollContainer>
   );
 }
 


### PR DESCRIPTION
## Summary

`DailyArchive` and `SurveysIndex` rendered their `<Page>` directly under `<Outlet/>`, which sits inside `RootContainer` (overflow: hidden, fixed viewport height). When the bucketed list grew past the viewport, content was simply clipped — no scrolling.

Both pages now wrap in `MainScrollContainer` (the `MainWrapper`-backed scroll region used by `Notifications`, `AllQuestions`, etc.). `Page` min-height switches from `100vh` to `100%` so it fills the scroll region without forcing extra space.

Companion to backend [WhoamI-Today-backend#TBD](https://github.com/ssm0318/WhoamI-Today-backend) (daily window filter) — together the two PRs make the daily archive correct AND scrollable when content does grow.

## Test plan

- [x] `npx craco build` clean (only pre-existing eslint warnings)
- [x] Dev server compiles with no error overlay
- [x] Verified at 393px: archive page now lives inside an `overflow-y: auto` scroll region; content past the viewport scrolls instead of clipping