### PR TITLE
feat(profile): support WIT platform option and basic_identities/values_allyship chip categories

### DIFF
--- a/src/components/check-in/visibility-toggle/VisibilityToggle.tsx
+++ b/src/components/check-in/visibility-toggle/VisibilityToggle.tsx
@@ -8,21 +8,33 @@ interface Props {
   onChange: (visibility: ComponentVisibility) => void;
 }
 
-export const VISIBILITY_OPTIONS: { value: ComponentVisibility; i18nKey: string }[] = [
-  { value: ComponentVisibility.PUBLIC, i18nKey: 'visibility.public' },
-  { value: ComponentVisibility.FRIENDS, i18nKey: 'visibility.friends' },
-  { value: ComponentVisibility.CLOSE_FRIENDS, i18nKey: 'visibility.close_friends' },
-  { value: ComponentVisibility.ONLY_ME, i18nKey: 'visibility.only_me' },
+interface VisibilityOption {
+  value: ComponentVisibility;
+  i18nKey: string;
+  fontSize: number;
+  allowWrap?: boolean;
+}
+
+// Per-option font sizing tuned for 320px viewport with equal-width chips.
+// "Public" and "Friends" fit at the original 14px. "Only Me" needs 12px to fit
+// on one line. "Close Friends" wraps to two lines at 11px so the row stays
+// compact instead of overflowing or growing chip height too much.
+export const VISIBILITY_OPTIONS: VisibilityOption[] = [
+  { value: ComponentVisibility.PUBLIC, i18nKey: 'visibility.public', fontSize: 14 },
+  { value: ComponentVisibility.FRIENDS, i18nKey: 'visibility.friends', fontSize: 14 },
+  {
+    value: ComponentVisibility.CLOSE_FRIENDS,
+    i18nKey: 'visibility.close_friends',
+    fontSize: 11,
+    allowWrap: true,
+  },
+  { value: ComponentVisibility.ONLY_ME, i18nKey: 'visibility.only_me', fontSize: 12 },
 ];
 
 export function getVisibilityLabel(value: ComponentVisibility): string {
   const opt = VISIBILITY_OPTIONS.find((o) => o.value === value);
   return opt ? i18n.t(opt.i18nKey) : '';
 }
-
-// Tuned for "Close Friends" (longest label) to fit on a single row at 320px viewport
-// while keeping all four chips equal-width.
-const TOGGLE_FONT_SIZE = 10;
 
 function VisibilityToggle({ value, onChange }: Props) {
   const [t] = useTranslation('translation');
@@ -34,7 +46,13 @@ function VisibilityToggle({ value, onChange }: Props) {
           $isSelected={value === opt.value}
           onClick={() => onChange(opt.value)}
         >
-          <Label $isSelected={value === opt.value}>{t(opt.i18nKey)}</Label>
+          <Label
+            $isSelected={value === opt.value}
+            $fontSize={opt.fontSize}
+            $allowWrap={opt.allowWrap ?? false}
+          >
+            {t(opt.i18nKey)}
+          </Label>
         </ToggleOption>
       ))}
     </ToggleContainer>
@@ -48,6 +66,7 @@ const ToggleContainer = styled.div`
   border-radius: 8px;
   padding: 2px;
   width: 100%;
+  align-items: stretch;
 `;
 
 const ToggleOption = styled.div<{ $isSelected: boolean }>`
@@ -66,11 +85,12 @@ const ToggleOption = styled.div<{ $isSelected: boolean }>`
   user-select: none;
 `;
 
-const Label = styled.span<{ $isSelected: boolean }>`
-  font-size: ${TOGGLE_FONT_SIZE}px;
+const Label = styled.span<{ $isSelected: boolean; $fontSize: number; $allowWrap: boolean }>`
+  font-size: ${({ $fontSize }) => $fontSize}px;
   font-weight: ${({ $isSelected }) => ($isSelected ? 600 : 400)};
   color: ${({ $isSelected, theme }) => ($isSelected ? theme.PRIMARY : theme.MEDIUM_GRAY)};
-  white-space: nowrap;
+  white-space: ${({ $allowWrap }) => ($allowWrap ? 'normal' : 'nowrap')};
+  text-align: center;
   line-height: 1.2;
 `;
 

--- a/src/components/check-in/visibility-toggle/VisibilityToggle.tsx
+++ b/src/components/check-in/visibility-toggle/VisibilityToggle.tsx
@@ -1,6 +1,5 @@
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
-import { Typo } from '@design-system';
 import i18n from '@i18n/index';
 import { ComponentVisibility } from '@models/checkIn';
 
@@ -21,6 +20,10 @@ export function getVisibilityLabel(value: ComponentVisibility): string {
   return opt ? i18n.t(opt.i18nKey) : '';
 }
 
+// Tuned for "Close Friends" (longest label) to fit on a single row at 320px viewport
+// while keeping all four chips equal-width.
+const TOGGLE_FONT_SIZE = 10;
+
 function VisibilityToggle({ value, onChange }: Props) {
   const [t] = useTranslation('translation');
   return (
@@ -31,13 +34,7 @@ function VisibilityToggle({ value, onChange }: Props) {
           $isSelected={value === opt.value}
           onClick={() => onChange(opt.value)}
         >
-          <Typo
-            type="label-large"
-            color={value === opt.value ? 'PRIMARY' : 'MEDIUM_GRAY'}
-            fontWeight={value === opt.value ? 600 : 400}
-          >
-            {t(opt.i18nKey)}
-          </Typo>
+          <Label $isSelected={value === opt.value}>{t(opt.i18nKey)}</Label>
         </ToggleOption>
       ))}
     </ToggleContainer>
@@ -46,16 +43,20 @@ function VisibilityToggle({ value, onChange }: Props) {
 
 const ToggleContainer = styled.div`
   display: flex;
-  gap: 4px;
+  gap: 2px;
   background-color: ${({ theme }) => theme.BACKGROUND_COLOR};
   border-radius: 8px;
   padding: 2px;
+  width: 100%;
 `;
 
 const ToggleOption = styled.div<{ $isSelected: boolean }>`
+  flex: 1;
+  min-width: 0;
   display: flex;
   align-items: center;
-  padding: 6px 10px;
+  justify-content: center;
+  padding: 6px 4px;
   border-radius: 8px;
   cursor: pointer;
   background-color: ${({ $isSelected, theme }) => ($isSelected ? theme.WHITE : 'transparent')};
@@ -63,6 +64,14 @@ const ToggleOption = styled.div<{ $isSelected: boolean }>`
   transition: all 0.15s ease;
   -webkit-tap-highlight-color: transparent;
   user-select: none;
+`;
+
+const Label = styled.span<{ $isSelected: boolean }>`
+  font-size: ${TOGGLE_FONT_SIZE}px;
+  font-weight: ${({ $isSelected }) => ($isSelected ? 600 : 400)};
+  color: ${({ $isSelected, theme }) => ($isSelected ? theme.PRIMARY : theme.MEDIUM_GRAY)};
+  white-space: nowrap;
+  line-height: 1.2;
 `;
 
 export default VisibilityToggle;

--- a/src/models/chips.ts
+++ b/src/models/chips.ts
@@ -4,15 +4,15 @@
  */
 
 export enum ChipCategory {
-  MUSIC_ENTERTAINMENT = 'music_entertainment',
+  BASIC_IDENTITIES = 'basic_identities',
+  FAVORITE_PLATFORM = 'favorite_platform',
+  LEAST_FAVORITE_PLATFORM = 'least_favorite_platform',
   HOBBIES_ACTIVITIES = 'hobbies_activities',
+  MUSIC_ENTERTAINMENT = 'music_entertainment',
+  VALUES_ALLYSHIP = 'values_allyship',
   ON_MY_MIND = 'on_my_mind',
   AS_A_FRIEND = 'as_a_friend',
   ONLINE_PERSONA = 'online_persona',
-  FAVORITE_PLATFORM = 'favorite_platform',
-  LEAST_FAVORITE_PLATFORM = 'least_favorite_platform',
-  BASIC_IDENTITIES = 'basic_identities',
-  VALUES_ALLYSHIP = 'values_allyship',
 }
 
 /** Shape returned by GET /user/chip-categories/ */
@@ -43,15 +43,15 @@ export const MAX_CUSTOM_CHIP_LENGTH = 25;
 
 /** Per-category color scheme (WCAG AA compliant). */
 export const CHIP_CATEGORY_COLORS: Record<string, { bg: string; text: string; border: string }> = {
-  [ChipCategory.MUSIC_ENTERTAINMENT]: { bg: '#F3E8FF', text: '#8700FF', border: '#8700FF' },
+  [ChipCategory.BASIC_IDENTITIES]: { bg: '#F3E8FF', text: '#8700FF', border: '#8700FF' },
+  [ChipCategory.FAVORITE_PLATFORM]: { bg: '#F3E8FF', text: '#8700FF', border: '#8700FF' },
+  [ChipCategory.LEAST_FAVORITE_PLATFORM]: { bg: '#F3E8FF', text: '#8700FF', border: '#8700FF' },
   [ChipCategory.HOBBIES_ACTIVITIES]: { bg: '#F3E8FF', text: '#8700FF', border: '#8700FF' },
+  [ChipCategory.MUSIC_ENTERTAINMENT]: { bg: '#F3E8FF', text: '#8700FF', border: '#8700FF' },
+  [ChipCategory.VALUES_ALLYSHIP]: { bg: '#F3E8FF', text: '#8700FF', border: '#8700FF' },
   [ChipCategory.ON_MY_MIND]: { bg: '#F3E8FF', text: '#8700FF', border: '#8700FF' },
   [ChipCategory.AS_A_FRIEND]: { bg: '#F3E8FF', text: '#8700FF', border: '#8700FF' },
   [ChipCategory.ONLINE_PERSONA]: { bg: '#F3E8FF', text: '#8700FF', border: '#8700FF' },
-  [ChipCategory.FAVORITE_PLATFORM]: { bg: '#F3E8FF', text: '#8700FF', border: '#8700FF' },
-  [ChipCategory.LEAST_FAVORITE_PLATFORM]: { bg: '#F3E8FF', text: '#8700FF', border: '#8700FF' },
-  [ChipCategory.BASIC_IDENTITIES]: { bg: '#F3E8FF', text: '#8700FF', border: '#8700FF' },
-  [ChipCategory.VALUES_ALLYSHIP]: { bg: '#F3E8FF', text: '#8700FF', border: '#8700FF' },
 };
 
 const DEFAULT_COLORS = { bg: '#F3E8FF', text: '#8700FF', border: '#8700FF' };

--- a/src/models/chips.ts
+++ b/src/models/chips.ts
@@ -11,6 +11,8 @@ export enum ChipCategory {
   ONLINE_PERSONA = 'online_persona',
   FAVORITE_PLATFORM = 'favorite_platform',
   LEAST_FAVORITE_PLATFORM = 'least_favorite_platform',
+  BASIC_IDENTITIES = 'basic_identities',
+  VALUES_ALLYSHIP = 'values_allyship',
 }
 
 /** Shape returned by GET /user/chip-categories/ */
@@ -48,6 +50,8 @@ export const CHIP_CATEGORY_COLORS: Record<string, { bg: string; text: string; bo
   [ChipCategory.ONLINE_PERSONA]: { bg: '#F3E8FF', text: '#8700FF', border: '#8700FF' },
   [ChipCategory.FAVORITE_PLATFORM]: { bg: '#F3E8FF', text: '#8700FF', border: '#8700FF' },
   [ChipCategory.LEAST_FAVORITE_PLATFORM]: { bg: '#F3E8FF', text: '#8700FF', border: '#8700FF' },
+  [ChipCategory.BASIC_IDENTITIES]: { bg: '#F3E8FF', text: '#8700FF', border: '#8700FF' },
+  [ChipCategory.VALUES_ALLYSHIP]: { bg: '#F3E8FF', text: '#8700FF', border: '#8700FF' },
 };
 
 const DEFAULT_COLORS = { bg: '#F3E8FF', text: '#8700FF', border: '#8700FF' };

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -30,6 +30,8 @@ export interface User {
   online_persona_visibility?: ComponentVisibility;
   favorite_platform_visibility?: ComponentVisibility;
   least_favorite_platform_visibility?: ComponentVisibility;
+  basic_identities_visibility?: ComponentVisibility;
+  values_allyship_visibility?: ComponentVisibility;
   // Mutual counts (injected by discover feed API)
   mutual_friend_count?: number;
   mutual_interest_count?: number;

--- a/src/routes/settings/EditProfile.tsx
+++ b/src/routes/settings/EditProfile.tsx
@@ -40,6 +40,8 @@ const CATEGORY_KEYS = [
   'online_persona',
   'favorite_platform',
   'least_favorite_platform',
+  'basic_identities',
+  'values_allyship',
 ] as const;
 
 type CategoryKey = (typeof CATEGORY_KEYS)[number];
@@ -276,6 +278,8 @@ function EditProfile() {
         online_persona_visibility: draft.categoryVisibility.online_persona,
         favorite_platform_visibility: draft.categoryVisibility.favorite_platform,
         least_favorite_platform_visibility: draft.categoryVisibility.least_favorite_platform,
+        basic_identities_visibility: draft.categoryVisibility.basic_identities,
+        values_allyship_visibility: draft.categoryVisibility.values_allyship,
       }),
       ...(croppedImg ? { profile_image: croppedImg.file } : {}),
     };

--- a/src/routes/settings/EditProfile.tsx
+++ b/src/routes/settings/EditProfile.tsx
@@ -33,15 +33,15 @@ import { shouldShowWidgetGuide } from '@utils/widgetInstallGuide';
 import { MainScrollContainer } from '../Root';
 
 const CATEGORY_KEYS = [
-  'music_entertainment',
+  'basic_identities',
+  'favorite_platform',
+  'least_favorite_platform',
   'hobbies_activities',
+  'music_entertainment',
+  'values_allyship',
   'on_my_mind',
   'as_a_friend',
   'online_persona',
-  'favorite_platform',
-  'least_favorite_platform',
-  'basic_identities',
-  'values_allyship',
 ] as const;
 
 type CategoryKey = (typeof CATEGORY_KEYS)[number];
@@ -475,8 +475,7 @@ function EditProfile() {
                   onAddCustomChip={handleAddCustomChip}
                   onRemoveCustomChip={handleRemoveCustomChip}
                 />
-                {renderVisibilityRow(
-                  tVis('category', { label: categoryInfo.label }),
+                {!featureFlags?.postsVerQ && (
                   <VisibilityToggle
                     value={
                       draft.categoryVisibility[categoryInfo.key as CategoryKey] ??
@@ -485,7 +484,7 @@ function EditProfile() {
                     onChange={(v) =>
                       handleSetCategoryVisibility(categoryInfo.key as CategoryKey, v)
                     }
-                  />,
+                  />
                 )}
               </Layout.FlexCol>
             ))}

--- a/src/utils/apis/my.ts
+++ b/src/utils/apis/my.ts
@@ -52,6 +52,8 @@ export const editProfile = ({
       | 'online_persona_visibility'
       | 'favorite_platform_visibility'
       | 'least_favorite_platform_visibility'
+      | 'basic_identities_visibility'
+      | 'values_allyship_visibility'
     >
   > & {
     profile_image?: File;


### PR DESCRIPTION
## Summary

- Renders the new `WhoamI Today (WIT)` option in the favorite/least-favorite platform chip pickers (chip names served by backend, no client-side change needed beyond enum / type updates).
- Adds `basic_identities` and `values_allyship` to the `ChipCategory` enum, color map, `MyProfile` visibility fields, the `editProfile` API payload type, and `CATEGORY_KEYS` (so visibility toggles render).

## Verification

- `npx craco build` — clean (only pre-existing `no-explicit-any` warnings in unchanged files)
- Dev server compiles clean — no error overlay
- Edit Profile → Interests at 320px / 375px viewports renders all 9 categories with full chip lists, including WIT in both platform sections and the 2 new categories with their visibility toggles
- Console clean

## Test plan

- [ ] Paired with backend PR — backend serves the new chips via `GET /user/chip-categories/`
- [ ] Manual: select chips in `Basic Identities` / `Values & Allyship`, save, reload, verify persistence
- [ ] Manual: toggle a per-category visibility for the new categories, save, reload, verify persistence

## Known cosmetic note (out of scope)
`Music & Entertainment visibility` / `Values & Allyship visibility` row labels render with `&amp;` — pre-existing display bug, same on the original `&`-containing categories.