### PR TITLE
fix(survey-results): top-nav Done button + drop locked subheading

### DIFF
--- a/src/routes/surveys/SurveyResults.tsx
+++ b/src/routes/surveys/SurveyResults.tsx
@@ -22,20 +22,6 @@ const Page = styled(Layout.FlexCol)`
   min-height: 100%;
 `;
 
-const DoneButton = styled.button`
-  align-self: stretch;
-  border: 1px solid ${Colors.PRIMARY};
-  border-radius: 12px;
-  padding: 12px 16px;
-  background: ${Colors.PRIMARY};
-  color: ${Colors.WHITE};
-  font-size: 14px;
-  font-weight: 600;
-  cursor: pointer;
-  margin-top: 8px;
-  -webkit-tap-highlight-color: transparent;
-`;
-
 const PanelGroup = styled(Layout.FlexCol)`
   width: 100%;
   gap: 12px;
@@ -125,14 +111,23 @@ function SurveyResults() {
     getSurveyDetail(slug as string),
   );
 
+  const headerTitle = survey ? pickLocalized(survey.title_en, survey.title_ko) : '';
+  const headerRight = (
+    <button type="button" onClick={() => navigate('/share')}>
+      <Typo type="title-large" color="PRIMARY">
+        {t('done')}
+      </Typo>
+    </button>
+  );
+
   const axiosError = error as AxiosError | undefined;
   if (axiosError?.response?.status === 403) {
     const body = axiosError.response.data;
     return (
       <MainScrollContainer>
-        <SubHeader title={t('locked_title')} />
+        <SubHeader title={headerTitle} RightComponent={headerRight} />
         <Page>
-          <Typo type="body-medium" color="DARK_GRAY">
+          <Typo type="title-large" color="BLACK">
             {body.detail}
           </Typo>
           {body.needs_submission && (
@@ -140,9 +135,6 @@ function SurveyResults() {
               {t('answer_to_view_results')}
             </ActionButton>
           )}
-          <DoneButton type="button" onClick={() => navigate('/share')}>
-            {t('done')}
-          </DoneButton>
         </Page>
       </MainScrollContainer>
     );
@@ -154,7 +146,7 @@ function SurveyResults() {
 
   return (
     <MainScrollContainer>
-      <SubHeader title={pickLocalized(survey.title_en, survey.title_ko)} />
+      <SubHeader title={headerTitle} RightComponent={headerRight} />
       <Page>
         {data.panels.map((panel, idx) => (
           <PanelView
@@ -164,9 +156,6 @@ function SurveyResults() {
             interpretation={idx === 0 ? interpretation : undefined}
           />
         ))}
-        <DoneButton type="button" onClick={() => navigate('/share')}>
-          {t('done')}
-        </DoneButton>
       </Page>
     </MainScrollContainer>
   );


### PR DESCRIPTION
## Summary
- Move the Done button from the bottom of the page to a top-right text button on the SubHeader, matching the pattern used in NewNoteImageEdit. Done is now reachable without scrolling and stays out of the way of the results panels.
- Use the survey title as the page header instead of the generic "Results not yet available" string.
- Promote the "Results available tomorrow." line to `title-large` / `BLACK` so it reads as the page's main message now that the subheading is gone.

## Test plan
- [x] `npx craco build` — clean
- [x] Locked state at 393px (`/surveys/mock_test_2026q2/results`): header shows survey title, Done is the top-right purple text button, body reads "Results available tomorrow." in title-large, no leftover bottom button, bottom tabs visible
- [x] Unlocked state at 393px (`/surveys/demo_slider/results`): header shows survey title, Done is the top-right purple text button, results panels render, bottom tabs visible
- [x] 320px viewport — no overflow / clipping in either state
- [x] Console clean