### PR TITLE
fix(check-in): rename 'Blurb' label to 'Be Random'

### DIFF
--- a/src/components/check-in/update-quadrant/ThoughtEditor.tsx
+++ b/src/components/check-in/update-quadrant/ThoughtEditor.tsx
@@ -57,7 +57,7 @@ export default function ThoughtEditor({
       onClose={onClose}
       onShare={handleShare}
       onArchive={onArchive}
-      title="Blurb"
+      title="Be Random"
     >
       <Layout.FlexCol w="100%" gap={8} mb={16}>
         <StyledTextArea

--- a/src/routes/update/UpdateCheckin.tsx
+++ b/src/routes/update/UpdateCheckin.tsx
@@ -442,12 +442,12 @@ export default function UpdateCheckin() {
               <Typo type="body-medium" textAlign="center">
                 {thought}
               </Typo>
-              <QuadrantLabel>Blurb</QuadrantLabel>
+              <QuadrantLabel>Be Random</QuadrantLabel>
             </Layout.FlexCol>
           ) : (
             <>
               <SvgIcon name="edit" size={32} />
-              <QuadrantLabel>Blurb</QuadrantLabel>
+              <QuadrantLabel>Be Random</QuadrantLabel>
             </>
           )}
         </QuadrantCard>


### PR DESCRIPTION
## Summary

Rename the user-facing label on the check-in tab's thought quadrant and its editor popup title from "Blurb" to "Be Random". Internal component identifier `thought` (used in API payloads, Zustand state, type unions) is unchanged — this is purely a display-string rename.

## Files changed

- `src/components/check-in/update-quadrant/ThoughtEditor.tsx:60` — `title="Blurb"` → `title="Be Random"` (editor popup title)
- `src/routes/update/UpdateCheckin.tsx:445,450` — `<QuadrantLabel>Blurb</QuadrantLabel>` → `<QuadrantLabel>Be Random</QuadrantLabel>` (both empty-state and filled-state labels on the check-in grid)

## Intentionally NOT changed

- `src/components/friends/poke-button/PokeButton.tsx` — "Ping for a blurb" / "Pinged: blurb" (friends tab, not check-in)
- `src/components/share/ThoughtSnippetInput.tsx` — share-page placeholders ("Share a random blurb...", "A blurb you have not shared yet...", "Blurbs" header)
- `src/i18n/locales/en/translation.json` (`type.thought`, `my.thought`) — used by notification settings & profile page, not the check-in tab UI
- `src/models/browseMode.ts` — JSDoc comment about a different feature

If you want any of those updated for consistency, let me know.

## Test plan

- [x] `craco build` — exit 0 clean.
- [ ] Hard-refresh check-in tab on dev/prod and confirm both empty and filled thought quadrants show "Be Random" instead of "Blurb".
- [ ] Tap the thought quadrant and confirm the editor popup title reads "Be Random".