### PR TITLE
fix(browse-mode): show session prompt on first visit + lower away threshold to 15 min

### DIFF
--- a/src/hooks/useBrowseModeSessionPrompt.ts
+++ b/src/hooks/useBrowseModeSessionPrompt.ts
@@ -4,7 +4,7 @@ import { useGetAppMessage } from '@hooks/useAppMessage';
 import { SetAppStateData } from '@models/app';
 import { useBoundStore } from '@stores/useBoundStore';
 
-const AWAY_THRESHOLD_MS = 30 * 60 * 1000; // 30 min — anything shorter is "same session"
+const AWAY_THRESHOLD_MS = 15 * 60 * 1000; // 15 min — anything shorter is "same session"
 const COOLDOWN_MS = 60 * 60 * 1000; // 1 hour cooldown after the user dismisses the prompt
 
 function getStorageKey(userId: number, suffix: string) {

--- a/src/hooks/useBrowseModeSessionPrompt.ts
+++ b/src/hooks/useBrowseModeSessionPrompt.ts
@@ -98,16 +98,13 @@ export function useBrowseModeSessionPrompt() {
     return () => document.removeEventListener('visibilitychange', onVisibilityChange);
   }, [handleBecomeActive, handleBecomeInactive]);
 
-  // Cold start: if we have a stored "last session" from before, decide whether to prompt.
+  // Cold start: prompt on first-ever visit AND on returns after 30+ min away.
   // Also load saved presets so they're ready when the prompt opens.
   useEffect(() => {
     if (!userId || !browseModeEnabled) return;
 
     const lastTs = getLastSessionTimestamp(userId);
-    if (lastTs === null) {
-      // First time we've ever seen this user on this device — record now and skip prompting.
-      saveLastSessionTimestamp(userId);
-    } else if (Date.now() - lastTs >= AWAY_THRESHOLD_MS) {
+    if (lastTs === null || Date.now() - lastTs >= AWAY_THRESHOLD_MS) {
       tryTrigger();
     }
     fetchPresets();


### PR DESCRIPTION
## Summary

Two changes to make the browse-mode session prompt appear more often, so users actually see the picker when they open the app:

1. **Show on first-ever visit** — previously the cold-start `useEffect` skipped the very first visit, only recording a `last_session` timestamp; the picker appeared only on the second visit after a 30-min gap. Felt broken on fresh installs.
2. **Lower away threshold from 30 min → 15 min** — anything shorter than 15 min is treated as "same session" (a quick close-and-reopen) and skipped. Combined with #1, the picker now surfaces every time the user opens the app unless they were just here within the last 15 minutes.

## Diff

`src/hooks/useBrowseModeSessionPrompt.ts`:

```diff
-const AWAY_THRESHOLD_MS = 30 * 60 * 1000; // 30 min
+const AWAY_THRESHOLD_MS = 15 * 60 * 1000; // 15 min

 useEffect(() => {
   if (!userId || !browseModeEnabled) return;
   const lastTs = getLastSessionTimestamp(userId);
-  if (lastTs === null) {
-    saveLastSessionTimestamp(userId);
-  } else if (Date.now() - lastTs >= AWAY_THRESHOLD_MS) {
+  if (lastTs === null || Date.now() - lastTs >= AWAY_THRESHOLD_MS) {
     tryTrigger();
   }
   fetchPresets();
 }, [userId, browseModeEnabled]);
```

The `dismiss` and `finish` handlers already save the timestamp when the user takes action, so the 15-min same-session carve-out still works correctly. The 1-hour dismiss cooldown (`COOLDOWN_MS`) is unchanged.

## Test plan

- [x] `craco build` — exit 0 clean.
- [x] Bundle confirmed updated: cold-start no longer calls `saveLastSessionTimestamp`; only `inactive` / `dismiss` / `finish` callsites remain.
- [ ] After deploy, fresh device → open app → picker appears on first authenticated load.
- [ ] Open within 15 min of last session → picker does NOT appear.
- [ ] Open after 15+ min of last session → picker appears.

Note: in-browser local testing is unreliable because `window.location.reload()` triggers `visibilitychange='hidden'` on unload, which the existing `handleBecomeInactive` callback uses to save `last_session` — overwriting cleared state before the new mount. Real users on a fresh device or after backgrounding the tab won't hit this race.