### PR TITLE
feat(chat): BotCard interactive button cards in wit_bot chat

### DIFF
--- a/src/components/chat/bot-card/BotCard.styled.ts
+++ b/src/components/chat/bot-card/BotCard.styled.ts
@@ -1,0 +1,43 @@
+import styled, { css } from 'styled-components';
+
+export const ButtonRow = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 6px;
+  max-width: 240px;
+`;
+
+const baseChip = css`
+  background: #ffffff;
+  border-radius: 8px;
+  padding: 4px 8px;
+  font-size: 14px;
+  line-height: 1.3;
+  cursor: pointer;
+  font-family: inherit;
+  transition: background 0.1s ease;
+  &:active {
+    background: #f3e8ff;
+  }
+  &:disabled {
+    cursor: default;
+    opacity: 0.5;
+    &:active {
+      background: #ffffff;
+    }
+  }
+`;
+
+export const PrimaryChip = styled.button.attrs({ type: 'button' })`
+  ${baseChip}
+  border: 1px solid #8700ff;
+  color: #8700ff;
+  font-weight: 500;
+`;
+
+export const SecondaryChip = styled.button.attrs({ type: 'button' })`
+  ${baseChip}
+  border: 1px dashed #d9d9d9;
+  color: #555555;
+`;

--- a/src/components/chat/bot-card/BotCard.tsx
+++ b/src/components/chat/bot-card/BotCard.tsx
@@ -1,0 +1,32 @@
+import { BotButton, BotPayload } from '@models/chat';
+import { ButtonRow, PrimaryChip, SecondaryChip } from './BotCard.styled';
+
+interface Props {
+  payload: BotPayload;
+  disabled?: boolean;
+  onButtonClick?: (button: BotButton) => void;
+}
+
+const PRIMARY_PAYLOADS = new Set(['admin']);
+
+export function BotCard({ payload, disabled, onButtonClick }: Props) {
+  if (payload.kind !== 'card' || !payload.buttons?.length) return null;
+
+  return (
+    <ButtonRow>
+      {payload.buttons.map((button) => {
+        const Chip =
+          button.payload && PRIMARY_PAYLOADS.has(button.payload) ? PrimaryChip : SecondaryChip;
+        return (
+          <Chip
+            key={`${button.action}-${button.payload ?? button.url ?? button.label}`}
+            disabled={disabled}
+            onClick={() => onButtonClick?.(button)}
+          >
+            {button.label}
+          </Chip>
+        );
+      })}
+    </ButtonRow>
+  );
+}

--- a/src/components/chat/bot-card/index.ts
+++ b/src/components/chat/bot-card/index.ts
@@ -1,0 +1,1 @@
+export { BotCard } from './BotCard';

--- a/src/components/chat/chat-message-item/ChatMessageItem.tsx
+++ b/src/components/chat/chat-message-item/ChatMessageItem.tsx
@@ -5,9 +5,10 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import LinkifiedText from '@components/_common/linkified-text/LinkifiedText';
 import ProfileImage from '@components/_common/profile-image/ProfileImage';
+import { BotCard } from '@components/chat/bot-card';
 import SharedContentCard from '@components/chat/shared-content-card/SharedContentCard';
 import { Layout, Typo } from '@design-system';
-import { ChatEmojiDict, ChatEmojiType, RefinedChatMessage } from '@models/chat';
+import { BotButton, ChatEmojiDict, ChatEmojiType, RefinedChatMessage } from '@models/chat';
 import { addMessageReaction, removeMessageReaction } from '@utils/apis/chat';
 import {
   LeftBubble,
@@ -39,6 +40,7 @@ interface Props {
   showSenderName?: boolean;
   onReactionUpdate?: () => void;
   onImageLoad?: (messageId: number) => void;
+  onBotButtonClick?: (button: BotButton) => void;
 }
 
 function ChatMessageItem({
@@ -48,6 +50,7 @@ function ChatMessageItem({
   showSenderName = false,
   onReactionUpdate,
   onImageLoad,
+  onBotButtonClick,
 }: Props) {
   const navigate = useNavigate();
   const {
@@ -379,6 +382,9 @@ function ChatMessageItem({
         </Layout.FlexRow>
       ) : (
         textBubble
+      )}
+      {message.bot_payload?.kind === 'card' && (
+        <BotCard payload={message.bot_payload} onButtonClick={onBotButtonClick} />
       )}
       {reactions.length > 0 && (
         <Layout.FlexRow gap={4} mt={2} justifyContent={isMine ? 'flex-end' : 'flex-start'}>

--- a/src/models/chat.ts
+++ b/src/models/chat.ts
@@ -29,12 +29,30 @@ export interface ChatRoom {
   unread_count: number;
 }
 
+export type BotButtonAction = 'reply' | 'navigate' | 'upload' | 'external';
+
+export interface BotButton {
+  label: string;
+  action: BotButtonAction;
+  payload?: string; // for action: 'reply'
+  url?: string; // for action: 'navigate' | 'external'
+  context?: string; // for action: 'upload'
+}
+
+export interface BotPayload {
+  kind: 'card' | 'choice' | 'upload';
+  buttons?: BotButton[]; // when kind === 'card'
+  payload?: string; // when kind === 'choice'
+  context?: string; // when kind === 'upload'
+}
+
 export interface InputChatMessage {
   emoji: ChatEmojiType | '' | null;
   content: string;
   parent?: number;
   shared_content_type?: string;
   shared_object_id?: number;
+  bot_payload?: BotPayload | null;
 }
 
 export interface MessageReactionSummary {
@@ -73,6 +91,7 @@ export interface ChatMessage extends Omit<InputChatMessage, 'parent'> {
   shared_content_preview: SharedContentPreview | null;
   event_type?: ChatEventType;
   event_target_users?: ChatRoomMember[];
+  bot_payload?: BotPayload | null;
 }
 
 export interface PostChatMessageRes extends ChatMessage {

--- a/src/routes/chat/Chat.tsx
+++ b/src/routes/chat/Chat.tsx
@@ -13,13 +13,14 @@ import { CHAT_MESSAGE_INPUT_HEIGHT } from '@constants/layout';
 import { Layout } from '@design-system';
 import useInfiniteScroll from '@hooks/useInfiniteScroll';
 import {
+  BotButton,
   ChatMessage,
   MessageReactionSummary,
   PostChatMessageRes,
   RefinedChatMessage,
 } from '@models/chat';
 import { useBoundStore } from '@stores/useBoundStore';
-import { getChatMessages, markMessagesRead } from '@utils/apis/chat';
+import { getChatMessages, markMessagesRead, postChatMessage } from '@utils/apis/chat';
 import { getMyProfile } from '@utils/apis/my';
 import { getUserProfile } from '@utils/apis/user';
 import { MainScrollContainer } from '../Root';
@@ -195,6 +196,32 @@ function Chat() {
     });
   };
 
+  const handleBotButtonClick = useCallback(
+    async (button: BotButton) => {
+      if (button.action === 'navigate' && button.url) {
+        navigate(button.url);
+        return;
+      }
+      if (button.action === 'external' && button.url) {
+        window.open(button.url, '_blank', 'noopener,noreferrer');
+        return;
+      }
+      if (button.action === 'reply' && userId) {
+        try {
+          const { data } = await postChatMessage(Number(userId), {
+            emoji: '',
+            content: button.label,
+            bot_payload: { kind: 'choice', payload: button.payload },
+          });
+          handleMessageSent(data);
+        } catch {
+          // Silent — matches existing chat send-error pattern.
+        }
+      }
+    },
+    [navigate, userId],
+  );
+
   const handleImageLoaded = (messageId: number) => {
     const shouldScroll =
       justSentIdsRef.current.has(messageId) || shouldPinToBottomRef.current.has(messageId);
@@ -312,6 +339,7 @@ function Chat() {
                   }
                   isFirstInCluster={message.is_first_in_cluster}
                   onImageLoad={handleImageLoaded}
+                  onBotButtonClick={handleBotButtonClick}
                 />
               </SwipeToReply>
             ))}

--- a/src/routes/chat/GroupChat.tsx
+++ b/src/routes/chat/GroupChat.tsx
@@ -303,7 +303,11 @@ function GroupChat() {
 
   const handleLeave = async () => {
     if (!roomId) return;
-    await leaveGroupChat(Number(roomId));
+    const { data } = await leaveGroupChat(Number(roomId));
+    if (data?.status === 'admin_evicted' && data?.redirect_user_id) {
+      navigate(`/users/${data.redirect_user_id}/chat`, { replace: true });
+      return;
+    }
     navigate('/chats');
   };
 

--- a/src/utils/apis/chat.ts
+++ b/src/utils/apis/chat.ts
@@ -24,6 +24,7 @@ export const postChatMessage = async (userId: number, msg: InputChatMessage, ima
     formData.append('image', image);
     if (msg.content) formData.append('content', msg.content);
     if (msg.parent) formData.append('parent', String(msg.parent));
+    if (msg.bot_payload) formData.append('bot_payload', JSON.stringify(msg.bot_payload));
     return axiosFormDataInstance.post<PostChatMessageRes>(`/chat/user/${userId}/`, formData);
   }
   return axios.post<PostChatMessageRes>(`/chat/user/${userId}/`, msg);

--- a/src/utils/apis/chat.ts
+++ b/src/utils/apis/chat.ts
@@ -80,8 +80,13 @@ export const updateGroupChat = async (
   return data;
 };
 
+export interface LeaveGroupChatRes {
+  status: 'left' | 'admin_evicted';
+  redirect_user_id?: number;
+}
+
 export const leaveGroupChat = async (roomId: number) => {
-  return axios.post(`/chat/groups/${roomId}/leave/`);
+  return axios.post<LeaveGroupChatRes>(`/chat/groups/${roomId}/leave/`);
 };
 
 export const getGroupMessages = async (roomId: number, page?: string | null) => {


### PR DESCRIPTION
## Summary
- **`BotPayload` / `BotButton` types** on `ChatMessage` and `InputChatMessage`. Four action types defined for forward-compat (`reply`, `navigate`, `upload`, `external`), only `reply` is wired in v1.
- **`postChatMessage`** extended to accept `bot_payload` so button taps can ride along as JSON-stringified form fields (image case) or raw JSON body (text-only case).
- **New `BotCard` component** at `src/components/chat/bot-card/`. Renders interactive button chips beneath the bubble — 8px radius, 4px 8px padding, 14px font, `flex-wrap` so chips reflow at 320px. Primary-action chip ("Call in the admin") gets purple solid border; secondary ("Get started", "I'm confused", "tehehe") get dashed gray. Matches CLAUDE.md chip / ping-poke conventions.
- **Render integration in `ChatMessageItem.tsx`:** `<BotCard />` renders below the text bubble when `message.bot_payload?.kind === 'card'`.
- **Click dispatch in `Chat.tsx`:** `reply` taps post a new chat message (label as content, `{kind: 'choice', payload}` as bot_payload). `navigate`/`external` are pure frontend handlers (no backend round-trip).

## Test plan
- [x] `npx craco build` clean (no new errors; only pre-existing `validateHelpers.ts` warnings unchanged)
- [x] Wit_bot chat renders welcome card with 4 buttons (screenshot verified at 393px and 320px)
- [x] "Call in the admin" tap triggers `escalate_to_human`, bot replies "Admin has been called in 👀" with no buttons
- [x] All 3 joke buttons + free text → "hehe!" + same 4-button card (loop verified end-to-end)
- [x] Buttons wrap onto multiple rows at 320px without overflow
- [x] No console errors during interaction

Paired with backend PR.