### PR TITLE
feat(notifications): inline accept/ignore + user page request button …

### DIFF
--- a/src/components/_common/chat-request-button/ChatRequestButton.tsx
+++ b/src/components/_common/chat-request-button/ChatRequestButton.tsx
@@ -1,11 +1,18 @@
 import { MouseEvent, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import styled from 'styled-components';
 import CommonDialog from '@components/_common/alert-dialog/common-dialog/CommonDialog';
 import { useIsPreviewMode } from '@components/view-as/PreviewModeContext';
-import { Button, Layout } from '@design-system';
+import { Button } from '@design-system';
 import { UserProfile } from '@models/user';
 import { useBoundStore } from '@stores/useBoundStore';
 import { cancelChatRequest, sendChatRequest } from '@utils/apis/chat';
+
+const RequestedButton = styled(Button.Highlight)`
+  && > button > .button_component {
+    background-color: ${({ theme }) => theme.MEDIUM_GRAY};
+  }
+`;
 
 interface Props {
   user: UserProfile;
@@ -63,31 +70,21 @@ function ChatRequestButton({ user, onChange }: Props) {
 
   return (
     <>
-      <Layout.FlexRow gap={8} w="100%">
-        {sent ? (
-          <>
-            <Button.Highlight
-              status="completed"
-              text={t('requested')}
-              sizing="stretch"
-              onClick={undefined}
-            />
-            <Button.Secondary
-              status="normal"
-              text={t('cancel')}
-              sizing="stretch"
-              onClick={handleClickCancel}
-            />
-          </>
-        ) : (
-          <Button.Highlight
-            status="normal"
-            text={t('request')}
-            sizing="stretch"
-            onClick={handleClickRequest}
-          />
-        )}
-      </Layout.FlexRow>
+      {sent ? (
+        <RequestedButton
+          status="normal"
+          text={t('requested_chat')}
+          sizing="stretch"
+          onClick={handleClickCancel}
+        />
+      ) : (
+        <Button.Highlight
+          status="normal"
+          text={t('request')}
+          sizing="stretch"
+          onClick={handleClickRequest}
+        />
+      )}
       {isCancelDialogVisible && (
         <CommonDialog
           visible={isCancelDialogVisible}

--- a/src/components/_common/friend-status/FriendStatus.tsx
+++ b/src/components/_common/friend-status/FriendStatus.tsx
@@ -36,6 +36,12 @@ const CompactButtonRow = styled(Layout.FlexRow)`
   }
 `;
 
+const RequestedButton = styled(Button.Highlight)`
+  && > button > .button_component {
+    background-color: ${({ theme }) => theme.MEDIUM_GRAY};
+  }
+`;
+
 export interface Props {
   type: 'sent_requests' | 'requests' | 'recommended' | 'search' | 'user';
   user: User | UserProfile;
@@ -291,15 +297,24 @@ function FriendStatus({
         ) : (
           <>
             {type === 'sent_requests' || sentFriendRequest(user) ? (
-              <>
-                <PrimaryButton status="completed" text={t('requested')} {...sizingProp} />
-                <Button.Secondary
+              isUserPage ? (
+                <RequestedButton
                   status="normal"
-                  text={t('cancel')}
+                  text={t('requested_friend')}
                   {...sizingProp}
                   onClick={handleClickCancelRequest}
                 />
-              </>
+              ) : (
+                <>
+                  <PrimaryButton status="completed" text={t('requested')} {...sizingProp} />
+                  <Button.Secondary
+                    status="normal"
+                    text={t('cancel')}
+                    {...sizingProp}
+                    onClick={handleClickCancelRequest}
+                  />
+                </>
+              )
             ) : (
               <PrimaryButton
                 status="normal"

--- a/src/components/notification/NotificationItem/NotificationActions.tsx
+++ b/src/components/notification/NotificationItem/NotificationActions.tsx
@@ -1,0 +1,174 @@
+import { MouseEvent, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import FriendEvaluationModal, {
+  EvaluationData,
+} from '@components/_common/friend-evaluation-modal/FriendEvaluationModal';
+import FriendTypeSelectModal from '@components/_common/friend-type-select-modal/FriendTypeSelectModal';
+import { Button, Layout } from '@design-system';
+import { Connection } from '@models/api/friends';
+import { Notification } from '@models/notification';
+import { useBoundStore } from '@stores/useBoundStore';
+import { respondToChatRequest } from '@utils/apis/chat';
+import { acceptFriendRequest, EvaluationParams, rejectFriendRequest } from '@utils/apis/user';
+
+interface Props {
+  item: Notification;
+  onActioned: () => void;
+}
+
+function NotificationActions({ item, onActioned }: Props) {
+  const [tFriend] = useTranslation('translation', {
+    keyPrefix: 'friends.explore_friends.friend_item',
+  });
+  const [tChat] = useTranslation('translation', {
+    keyPrefix: 'chat.request.notification_action',
+  });
+  const { openToast } = useBoundStore((s) => ({ openToast: s.openToast }));
+
+  const [busy, setBusy] = useState(false);
+  const [friendTypeSelectVisible, setFriendTypeSelectVisible] = useState(false);
+  const [evaluationState, setEvaluationState] = useState<{
+    friendType: Connection;
+    updatePastPosts?: boolean;
+  } | null>(null);
+
+  const actor = item.recent_actors[0];
+  if (!actor) return null;
+  if (!item.is_friend_request && !item.is_chat_request) return null;
+
+  const handleFriendTypeConfirm = ({
+    friendType,
+    updatePastPosts,
+  }: {
+    friendType: Connection;
+    updatePastPosts?: boolean;
+  }) => {
+    setFriendTypeSelectVisible(false);
+    setEvaluationState({ friendType, updatePastPosts });
+  };
+
+  const handleEvaluationSubmit = async (data: EvaluationData) => {
+    if (!evaluationState) return;
+    const evaluation: EvaluationParams = data.skipped
+      ? { evaluation_skipped: true }
+      : {
+          evaluation_closeness: data.closeness,
+          evaluation_relationship_type: data.relationshipType,
+          ...(data.relationshipTypeDetail && {
+            evaluation_relationship_type_detail: data.relationshipTypeDetail,
+          }),
+          evaluation_skipped: false,
+        };
+    let succeeded = false;
+    await acceptFriendRequest({
+      userId: actor.id,
+      friendType: evaluationState.friendType,
+      updatePastPosts: evaluationState.updatePastPosts,
+      evaluation,
+      onSuccess: () => {
+        succeeded = true;
+      },
+      onError: () => {},
+    });
+    setEvaluationState(null);
+    if (succeeded) {
+      openToast({ message: tFriend('friend_accept_success') ?? '' });
+      onActioned();
+    } else {
+      openToast({ message: tFriend('temporary_error') ?? '' });
+    }
+  };
+
+  const handleEvaluationClose = () => {
+    openToast({ message: tFriend('friend_evaluation.accept_failed') ?? '' });
+    setEvaluationState(null);
+  };
+
+  const handleClickFriendConfirm = (e: MouseEvent) => {
+    e.stopPropagation();
+    setFriendTypeSelectVisible(true);
+  };
+
+  const handleClickFriendReject = async (e: MouseEvent) => {
+    e.stopPropagation();
+    if (busy) return;
+    setBusy(true);
+    await rejectFriendRequest({
+      userId: actor.id,
+      onSuccess: () => openToast({ message: tFriend('friend_reject_success') ?? '' }),
+      onError: () => openToast({ message: tFriend('temporary_error') ?? '' }),
+    });
+    setBusy(false);
+    onActioned();
+  };
+
+  const handleClickChatRespond = async (e: MouseEvent, accepted: boolean) => {
+    e.stopPropagation();
+    if (busy || item.target_id === null) return;
+    setBusy(true);
+    try {
+      await respondToChatRequest(item.target_id, accepted);
+      openToast({ message: tChat(accepted ? 'accepted_toast' : 'ignored_toast') ?? '' });
+      onActioned();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <>
+      <Layout.FlexRow w="100%" gap={8}>
+        {item.is_friend_request ? (
+          <>
+            <Button.Primary
+              status="normal"
+              text={tFriend('confirm')}
+              fontType="label-medium"
+              onClick={handleClickFriendConfirm}
+            />
+            <Button.Secondary
+              status="normal"
+              text={tFriend('reject')}
+              fontType="label-medium"
+              onClick={handleClickFriendReject}
+            />
+          </>
+        ) : (
+          <>
+            <Button.Primary
+              status="normal"
+              text={tChat('accept')}
+              fontType="label-medium"
+              onClick={(e) => handleClickChatRespond(e, true)}
+            />
+            <Button.Secondary
+              status="normal"
+              text={tChat('ignore')}
+              fontType="label-medium"
+              onClick={(e) => handleClickChatRespond(e, false)}
+            />
+          </>
+        )}
+      </Layout.FlexRow>
+      {friendTypeSelectVisible && (
+        <FriendTypeSelectModal
+          visible={friendTypeSelectVisible}
+          type="accept"
+          onClickConfirm={handleFriendTypeConfirm}
+          onClickClose={() => setFriendTypeSelectVisible(false)}
+        />
+      )}
+      {evaluationState && (
+        <FriendEvaluationModal
+          visible
+          type="accept"
+          username={actor.username}
+          onSubmit={handleEvaluationSubmit}
+          onClose={handleEvaluationClose}
+        />
+      )}
+    </>
+  );
+}
+
+export default NotificationActions;

--- a/src/components/notification/NotificationItem/NotificationItem.tsx
+++ b/src/components/notification/NotificationItem/NotificationItem.tsx
@@ -1,17 +1,19 @@
-import { useState } from 'react';
+import { MouseEvent, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import ProfileImageList from '@components/_common/profile-image-list/ProfileImageList';
 import { IconNames, Layout, SvgIcon, Typo } from '@design-system';
 import { Notification } from '@models/notification';
 import { readNotification } from '@utils/apis/notification';
 import { convertTimeDiffByString } from '@utils/timeHelpers';
+import NotificationActions from './NotificationActions';
 import * as S from './NotificationItem.styled';
 
 interface NotificationItemProps {
   item: Notification;
+  onActioned?: (id: number) => void;
 }
 
-function NotificationItem({ item }: NotificationItemProps) {
+function NotificationItem({ item, onActioned }: NotificationItemProps) {
   const {
     message,
     created_at,
@@ -59,34 +61,55 @@ function NotificationItem({ item }: NotificationItemProps) {
     }
   };
 
+  const [actioned, setActioned] = useState(false);
+  const showInlineActions = !actioned && (item.is_friend_request || item.is_chat_request);
+
+  const handleActioned = async () => {
+    setActioned(true);
+    await readNotification([item.id]);
+    onActioned?.(item.id);
+  };
+
   return (
-    <Layout.FlexRow
-      w="100%"
-      onClick={handleClickNotification}
-      ph={16}
-      alignItems="center"
-      bgColor={is_read ? 'WHITE' : 'LIGHT'}
-    >
-      <S.NotificationContent alignItems="center" pb={9} w="100%" border={!is_read}>
-        <S.NotificationProfileContainer alignItems="center" justifyContent="center" h={50}>
-          <ProfileImageList images={recent_actors.map((a) => a.profile_image)} size={40} />
-          {!!getNotiIconName() && (
-            <Layout.Absolute r={0} b={-5} z={2}>
-              <SvgIcon name={getNotiIconName() as IconNames} size={20} />
-            </Layout.Absolute>
-          )}
-        </S.NotificationProfileContainer>
-        <Layout.FlexRow flex={1} ml={4}>
-          <Typo type="body-medium">{message}</Typo>
+    <Layout.FlexCol w="100%" ph={16} bgColor={is_read ? 'WHITE' : 'LIGHT'}>
+      <Layout.FlexRow w="100%" onClick={handleClickNotification} alignItems="center">
+        <S.NotificationContent
+          alignItems="center"
+          pb={showInlineActions ? 0 : 9}
+          w="100%"
+          border={!is_read && !showInlineActions}
+        >
+          <S.NotificationProfileContainer alignItems="center" justifyContent="center" h={50}>
+            <ProfileImageList images={recent_actors.map((a) => a.profile_image)} size={40} />
+            {!!getNotiIconName() && (
+              <Layout.Absolute r={0} b={-5} z={2}>
+                <SvgIcon name={getNotiIconName() as IconNames} size={20} />
+              </Layout.Absolute>
+            )}
+          </S.NotificationProfileContainer>
+          <Layout.FlexRow flex={1} ml={4}>
+            <Typo type="body-medium">{message}</Typo>
+          </Layout.FlexRow>
+          {thumbnail_url && <S.NotificationThumbnail src={thumbnail_url} alt="" />}
+          <Layout.FlexRow ml={4}>
+            <Typo type="label-small" color="MEDIUM_GRAY">
+              {convertTimeDiffByString({ now: currentDate, day: createdAt, isShortFormat: true })}
+            </Typo>
+          </Layout.FlexRow>
+        </S.NotificationContent>
+      </Layout.FlexRow>
+      {showInlineActions && (
+        <Layout.FlexRow
+          w="100%"
+          pl={44}
+          pb={9}
+          mt={-4}
+          onClick={(e: MouseEvent) => e.stopPropagation()}
+        >
+          <NotificationActions item={item} onActioned={handleActioned} />
         </Layout.FlexRow>
-        {thumbnail_url && <S.NotificationThumbnail src={thumbnail_url} alt="" />}
-        <Layout.FlexRow ml={4}>
-          <Typo type="label-small" color="MEDIUM_GRAY">
-            {convertTimeDiffByString({ now: currentDate, day: createdAt, isShortFormat: true })}
-          </Typo>
-        </Layout.FlexRow>
-      </S.NotificationContent>
-    </Layout.FlexRow>
+      )}
+    </Layout.FlexCol>
   );
 }
 

--- a/src/components/profile/Profile.tsx
+++ b/src/components/profile/Profile.tsx
@@ -1,6 +1,7 @@
 import { MouseEvent, ReactNode, useContext, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
+import styled from 'styled-components';
 import { useShallow } from 'zustand/react/shallow';
 import CommonDialog from '@components/_common/alert-dialog/common-dialog/CommonDialog';
 import ChatRequestButton from '@components/_common/chat-request-button/ChatRequestButton';
@@ -376,27 +377,27 @@ function Profile({ user }: ProfileProps) {
       {/* my-page actions: Edit Profile + Public/Private toggle (Q) or View As (W) */}
       {isMyPage && (
         <Layout.FlexRow w="100%" gap={8}>
-          <Button.Secondary
+          <ProfileActionButton
             status="normal"
             text={t('edit_profile')}
             sizing="stretch"
-            fontType="body-small"
+            fontType="button-medium"
             onClick={handleClickEditProfile}
           />
           {featureFlags?.postsVerQ ? (
-            <Button.Secondary
+            <ProfileActionButton
               status="normal"
               text={t('switch_visibility')}
               sizing="stretch"
-              fontType="body-small"
+              fontType="button-medium"
               onClick={handleTogglePublicPrivate}
             />
           ) : (
-            <Button.Secondary
+            <ViewAsButton
               status="normal"
               text={tViewAs('entry_label_long', { defaultValue: 'View As (Privacy)' })}
               sizing="stretch"
-              fontType="body-small"
+              fontType="button-medium"
               onClick={() => navigate('/my/view-as')}
             />
           )}
@@ -446,6 +447,22 @@ function Profile({ user }: ProfileProps) {
 }
 
 export default Profile;
+
+const ProfileActionButton = styled(Button.Secondary)`
+  && > button > .button_component {
+    border-width: 2px;
+  }
+`;
+
+const ViewAsButton = styled(Button.Secondary)`
+  && > button > .button_component {
+    border-width: 2px;
+    border-color: ${({ theme }) => theme.PRIMARY};
+  }
+  && > button > .button_component span {
+    color: ${({ theme }) => theme.PRIMARY};
+  }
+`;
 
 function AccountStatusBadge({ children }: { children: ReactNode }) {
   return (

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -564,6 +564,7 @@
             "button": {
                 "request": "Chat Request",
                 "requested": "Chat Requested",
+                "requested_chat": "Chat Requested",
                 "cancel": "Cancel",
                 "cancel_dialog": {
                     "title": "Cancel chat request",
@@ -571,6 +572,12 @@
                     "cancel": "Close",
                     "confirm": "Cancel request"
                 }
+            },
+            "notification_action": {
+                "accept": "Accept",
+                "ignore": "Ignore",
+                "accepted_toast": "Accepted chat request",
+                "ignored_toast": "Ignored chat request"
             }
         },
         "system": {

--- a/src/i18n/locales/ko/translation.json
+++ b/src/i18n/locales/ko/translation.json
@@ -569,6 +569,12 @@
           "cancel": "닫기",
           "confirm": "취소"
         }
+      },
+      "notification_action": {
+        "accept": "수락",
+        "ignore": "거절",
+        "accepted_toast": "채팅 요청을 수락했어요",
+        "ignored_toast": "채팅 요청을 거절했어요"
       }
     },
     "system": {

--- a/src/models/notification.ts
+++ b/src/models/notification.ts
@@ -8,15 +8,18 @@ export interface Notification {
   message: string;
   is_response_request: boolean;
   is_friend_request: boolean;
+  is_chat_request: boolean;
   is_recent: boolean;
   question_content: string;
   notification_type: NotificationType;
   recent_actors: ActorDetail[];
   thumbnail_url: string | null;
+  target_id: number | null;
 }
 
 export type NotificationType =
   | 'FriendRequest'
+  | 'ChatRequest'
   | 'ResponseRequest'
   | 'Like'
   | 'Comment'

--- a/src/routes/Notifications.tsx
+++ b/src/routes/Notifications.tsx
@@ -76,6 +76,16 @@ function Notifications() {
     }
   };
 
+  const handleNotificationActioned = (id: number) => {
+    mutateNotifications(
+      allNotifications?.map((prev) => ({
+        ...prev,
+        results: prev.results?.map((n) => (n.id === id ? { ...n, is_read: true } : n)) ?? [],
+      })) ?? [],
+      { revalidate: false },
+    );
+  };
+
   const handleReadAll = async () => {
     try {
       await readAllNotifications();
@@ -146,7 +156,11 @@ function Notifications() {
                     <Typo type="title-medium">{t('last_7_days')}</Typo>
                   </Layout.FlexRow>
                   {recentNotifications.map((noti) => (
-                    <NotificationItem item={noti} key={noti.id} />
+                    <NotificationItem
+                      item={noti}
+                      key={noti.id}
+                      onActioned={handleNotificationActioned}
+                    />
                   ))}
                 </>
               )}
@@ -157,7 +171,11 @@ function Notifications() {
                     <Typo type="title-medium">{t('earlier')}</Typo>
                   </Layout.FlexRow>
                   {restNotifications.map((noti) => (
-                    <NotificationItem item={noti} key={noti.id} />
+                    <NotificationItem
+                      item={noti}
+                      key={noti.id}
+                      onActioned={handleNotificationActioned}
+                    />
                   ))}
                 </>
               )}


### PR DESCRIPTION
…polish

- User page: single gray "Requested" button on friend/chat sent state (FriendStatus + ChatRequestButton) — click opens existing cancel dialog
- Notification list: inline Accept/Ignore for friend & chat requests (new NotificationActions, NotificationItem, Notifications)
  - Friend: FriendTypeSelectModal -> FriendEvaluationModal -> API
  - Chat: immediate respondToChatRequest, toast feedback
  - Action row hides after handled (local state); independent of read flag
- Profile actions: bolder borders + PRIMARY-colored View As button
- Notification model: add target_id + is_chat_request + 'ChatRequest' type (paired with backend serializer)
- i18n: chat.request.notification_action keys

## Issue Number:

## Self Check List

- [ ] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [ ] base branch로부터 rebase를 했나요?
- [ ] 데스크탑, 모바일에서의 정상 작동을 확인했나요?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## Testable backend branch name

## What does this PR do?

## Preview Image

## Further comments
