### PR TITLE
fix(profile): Photo of the Day copy + chip multi-category selection bug

### DIFF
--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -756,7 +756,7 @@
         "tmi_of_the_day": "TMI of the day",
         "tmi_placeholder": "had the best reindeer hotdog today!!!",
         "photo_of_the_day": "Photo of the day",
-        "photo_description": "Post your favourite photo for the day and let everyone know what you are up to",
+        "photo_description": "What's today like for you? Share it in a photo!",
         "share_photo": "Share photo",
         "questions_of_the_day": "Question of the day",
         "about_me": "A Snippet of Me",

--- a/src/models/api/user.ts
+++ b/src/models/api/user.ts
@@ -144,6 +144,10 @@ export interface MyProfile extends User {
   following_count: number;
   friend_count: number;
   is_public: boolean;
+  /** Backend-grouped chips: keyed by chip category, values are the chip texts the user selected.
+   * Authoritative for category disambiguation — `user_interests`/`user_personas` are flat legacy arrays. */
+  chips_by_category?: Record<string, string[]>;
+  custom_chips?: { id: number; text: string; category: string }[];
 }
 
 export interface FriendRequest {

--- a/src/routes/settings/EditProfile.tsx
+++ b/src/routes/settings/EditProfile.tsx
@@ -65,23 +65,32 @@ function EditProfile() {
 
   const { categories } = useChipCategories();
 
-  // Parse existing user chips into per-category selections
+  // Parse existing user chips into per-category selections.
+  //
+  // Source of truth: `myProfile.chips_by_category` (keyed by category, set per Interest row).
+  // The legacy flat arrays `user_interests`/`user_personas` lose the category attribution,
+  // so a chip name shared across categories (e.g. "Instagram" appearing in both
+  // favorite_platform and least_favorite_platform, or "Night Owl" in both basic_identities
+  // and as_a_friend) would resolve to ALL matching categories — visible to users as
+  // a chip wrongly selected in every category. Read from chips_by_category instead.
   const parseExistingChips = () => {
-    const existing = [
-      ...(myProfile?.user_interests ?? []).map((i) => i.replace(/^#+/, '')),
-      ...(myProfile?.user_personas ?? []).map((p) => p.replace(/^#+/, '')),
-    ];
+    const chipsByCategory = myProfile?.chips_by_category ?? {};
     const result: Record<string, string[]> = {};
-    const customResult: CustomChip[] = [];
 
     categories.forEach((cat) => {
-      const matched = existing.filter((chip) =>
-        cat.chips.some((c) => normalizeChipText(c) === normalizeChipText(chip)),
-      );
-      result[cat.key] = matched.map(
+      const stored = chipsByCategory[cat.key] ?? [];
+      // Map each stored chip to its canonical-cased option, falling back to the stored
+      // text (so chips removed from the option list still render as user-selected).
+      result[cat.key] = stored.map(
         (m) => cat.chips.find((c) => normalizeChipText(c) === normalizeChipText(m)) || m,
       );
     });
+
+    const customResult: CustomChip[] = (myProfile?.custom_chips ?? []).map((c) => ({
+      id: c.id,
+      text: c.text,
+      category: c.category as ChipCategory,
+    }));
     return { selections: result, customs: customResult };
   };
 


### PR DESCRIPTION
## Summary

1. **Share tab Photo of the Day copy** — replaced with shorter, more direct text:
   - Old: \"Post your favourite photo for the day and let everyone know what you are up to\"
   - New: \"What's today like for you? Share it in a photo!\"

2. **Edit Profile chip multi-category selection bug** (related to backend [WhoamI-Today-backend#985](https://github.com/ssm0318/WhoamI-Today-backend/pull/985)):
   - **Bug**: chip names that appear in multiple categories (e.g. \"Instagram\" in both `favorite_platform` and `least_favorite_platform`, \"Night Owl\" in both `basic_identities` and `as_a_friend`) showed as selected in EVERY matching category. Users saw \"all chips selected\" for fav/least-fav platforms after picking one of them, and Night Owl appeared duplicated.
   - **Root cause**: `parseExistingChips` in `EditProfile.tsx` combined `user_interests` + `user_personas` (legacy flat arrays without category info) and matched against each category's option list. Any chip whose name appeared in N categories ended up in N selection lists.
   - **Fix**: source category-attributed chip data from `myProfile.chips_by_category`, which the backend already populates from `Interest` rows (each row has a `category` field). Custom chips now also come from `myProfile.custom_chips` directly.

## Files changed

- `src/i18n/locales/en/translation.json` — `share_page.photo_description`
- `src/models/api/user.ts` — add `chips_by_category` and `custom_chips` to `MyProfile`
- `src/routes/settings/EditProfile.tsx` — rewrite `parseExistingChips`

## Verification

- [x] `craco build` — exit 0.
- [x] Browser preview: Share tab shows new photo copy.
- [x] Browser preview: Edit Profile -> Interests renders without compile errors.
- [ ] After deploy: select a chip in `favorite_platform`, save, reopen Edit Profile, confirm the chip is selected ONLY in `favorite_platform` (not in `least_favorite_platform` too).
- [ ] Confirm Night Owl in `basic_identities` doesn't also render as selected in `as_a_friend` (depends on backend PR shipping the chip-list cleanup).

## Compatibility note

Existing users whose chip data lives only in legacy `user_interests`/`user_personas` arrays (no `Interest` rows with category attribution — e.g. seeded users on staging) will see fewer chips marked as selected in the Edit Profile screen, since those legacy strings can't be unambiguously categorized. Their data is not deleted; it's just not surfaced in this category-segmented UI. New chip selections after this lands will be properly categorized via the existing save endpoint that already writes `chips_by_category`.