### PR TITLE
fix(chat): relabel "Leave Group" as "Dismiss wit_admin" in escalated bot rooms

### DIFF
--- a/src/routes/chat/GroupChat.tsx
+++ b/src/routes/chat/GroupChat.tsx
@@ -314,6 +314,16 @@ function GroupChat() {
   const groupTitle = room?.name || 'Group Chat';
   const members = room?.members_detail || [];
   const typingNames = Object.values(typingUsers);
+  // wit_bot escalated room: 3-member group containing wit_bot. Leaving here
+  // doesn't actually remove the user — it dismisses the admin and demotes
+  // back to a 1-on-1 with the bot. Relabel so the user knows what they're
+  // doing.
+  const isWitBotEscalated = members.some((m) => m.username === 'wit_bot');
+  const leaveButtonLabel = isWitBotEscalated ? 'Dismiss wit_admin' : 'Leave Group';
+  const leaveConfirmText = isWitBotEscalated
+    ? 'Dismiss wit_admin and go back to chatting with wit_bot only?'
+    : 'Are you sure you want to leave this group?';
+  const leaveConfirmAction = isWitBotEscalated ? 'Dismiss' : 'Leave';
 
   return (
     <MainScrollContainer scrollRef={scrollRef} style={{ marginTop: 0 }}>
@@ -526,7 +536,7 @@ function GroupChat() {
               {showLeaveConfirm ? (
                 <>
                   <Typo type="body-small" color="BLACK">
-                    Are you sure you want to leave this group?
+                    {leaveConfirmText}
                   </Typo>
                   <Layout.FlexRow gap={12}>
                     <button
@@ -543,7 +553,7 @@ function GroupChat() {
                         cursor: 'pointer',
                       }}
                     >
-                      Leave
+                      {leaveConfirmAction}
                     </button>
                     <button
                       type="button"
@@ -569,7 +579,7 @@ function GroupChat() {
                   style={{ background: 'none', border: 'none', cursor: 'pointer' }}
                 >
                   <Typo type="label-medium" color="WARNING">
-                    Leave Group
+                    {leaveButtonLabel}
                   </Typo>
                 </button>
               )}


### PR DESCRIPTION
## Summary
The backend reroutes a user-leave on a wit_bot escalated group to admin-eviction-and-demote. But the UI button still said **"Leave Group"** with the confirm prompt **"Are you sure you want to leave this group?"** — that wording made users hunt for a separate "kick admin out" option that didn't exist.

When the room's members include wit_bot (the only case where leave actually evicts admin), swap the labels:
- Button: **Dismiss wit_admin** (red WARNING text in the members panel)
- Confirm body: **Dismiss wit_admin and go back to chatting with wit_bot only?**
- Confirm action: **Dismiss**

For all non-wit_bot groups, labels are unchanged.

## Test plan
- [x] Re-escalated room 89 in browser, opened the members panel, saw "Dismiss wit_admin" at the bottom
- [x] Clicked it, confirm dialog shows the new question + "Dismiss" / "Cancel" buttons
- [x] \`craco build\` clean