### PR TITLE
feat(chat): per-member Remove for admin + auto-nav to group on escalation

### DIFF
--- a/src/models/chat.ts
+++ b/src/models/chat.ts
@@ -81,6 +81,7 @@ export type ChatEventType = '' | 'member_added' | 'member_left';
 
 export interface ChatMessage extends Omit<InputChatMessage, 'parent'> {
   id: number;
+  chat_room_id: number;
   sender: Pick<User, 'id' | 'username' | 'url' | 'profile_pic' | 'profile_image'>;
   image: string | null;
   is_read: boolean;

--- a/src/routes/chat/Chat.tsx
+++ b/src/routes/chat/Chat.tsx
@@ -227,6 +227,15 @@ function Chat() {
             bot_payload: { kind: 'choice', payload: button.payload },
           });
           handleMessageSent(data);
+          // The "Call in the admin" tap triggers escalation server-side: the
+          // post_save signal runs escalate_to_human, which flips the room to
+          // is_group=True with wit_admin added. The user is currently on the
+          // 1-on-1 route (/users/:id/chat) and won't see the escalation until
+          // they navigate. Take them to the group view directly so admin
+          // appears without a refresh.
+          if (button.payload === 'admin' && data.chat_room_id) {
+            navigate(`/chats/group/${data.chat_room_id}`, { replace: true });
+          }
         } catch {
           // Silent — matches existing chat send-error pattern.
         }

--- a/src/routes/chat/GroupChat.tsx
+++ b/src/routes/chat/GroupChat.tsx
@@ -21,6 +21,7 @@ import {
 import { useBoundStore } from '@stores/useBoundStore';
 import axios from '@utils/apis/axios';
 import {
+  dismissWitAdmin,
   getGroupMessages,
   leaveGroupChat,
   markGroupMessagesRead,
@@ -303,27 +304,31 @@ function GroupChat() {
 
   const handleLeave = async () => {
     if (!roomId) return;
-    const { data } = await leaveGroupChat(Number(roomId));
-    if (data?.status === 'admin_evicted' && data?.redirect_user_id) {
-      navigate(`/users/${data.redirect_user_id}/chat`, { replace: true });
-      return;
-    }
+    await leaveGroupChat(Number(roomId));
     navigate('/chats');
   };
 
   const groupTitle = room?.name || 'Group Chat';
   const members = room?.members_detail || [];
   const typingNames = Object.values(typingUsers);
-  // wit_bot escalated room: 3-member group containing wit_bot. Leaving here
-  // doesn't actually remove the user — it dismisses the admin and demotes
-  // back to a 1-on-1 with the bot. Relabel so the user knows what they're
-  // doing.
-  const isWitBotEscalated = members.some((m) => m.username === 'wit_bot');
-  const leaveButtonLabel = isWitBotEscalated ? 'Dismiss wit_admin' : 'Leave Group';
-  const leaveConfirmText = isWitBotEscalated
-    ? 'Dismiss wit_admin and go back to chatting with wit_bot only?'
-    : 'Are you sure you want to leave this group?';
-  const leaveConfirmAction = isWitBotEscalated ? 'Dismiss' : 'Leave';
+  // wit_bot escalated room: 3-member group containing wit_bot. The user can
+  // dismiss wit_admin via the per-member Remove button (separate from Leave,
+  // which actually removes the user themselves like in any group chat).
+  const witBotMember = members.find((m) => m.username === 'wit_bot');
+  const witAdminMember = members.find((m) => m.username === 'wit_admin');
+  const isWitBotEscalated = !!witBotMember && !!witAdminMember;
+
+  const handleDismissAdmin = async () => {
+    if (!roomId || !witBotMember) return;
+    try {
+      const { data } = await dismissWitAdmin(Number(roomId));
+      if (data?.status === 'admin_dismissed' && data?.redirect_user_id) {
+        navigate(`/users/${data.redirect_user_id}/chat`, { replace: true });
+      }
+    } catch {
+      // Silent — match existing chat error pattern.
+    }
+  };
 
   return (
     <MainScrollContainer scrollRef={scrollRef} style={{ marginTop: 0 }}>
@@ -507,36 +512,65 @@ function GroupChat() {
             </Layout.FlexRow>
             {/* Member list — clickable to profile */}
             <Layout.FlexCol w="100%" style={{ flex: 1, overflowY: 'auto' }}>
-              {members.map((m) => (
-                <Layout.FlexRow
-                  key={m.id}
-                  gap={10}
-                  alignItems="center"
-                  ph={16}
-                  pv={8}
-                  cursor="pointer"
-                  onClick={() => {
-                    setShowMemberDrawer(false);
-                    navigate(`/users/${m.username}`);
-                  }}
-                >
-                  <ProfileImage imageUrl={m.profile_image} size={32} />
-                  <Typo type="body-medium" color="BLACK">
-                    {m.username}
-                  </Typo>
-                  {currentUser && Number(m.id) === Number(currentUser.id) && (
-                    <Typo type="label-small" color="MEDIUM_GRAY">
-                      (you)
+              {members.map((m) => {
+                const showRemoveAdmin =
+                  isWitBotEscalated &&
+                  m.username === 'wit_admin' &&
+                  !!currentUser &&
+                  Number(currentUser.id) !== Number(m.id);
+                return (
+                  <Layout.FlexRow
+                    key={m.id}
+                    gap={10}
+                    alignItems="center"
+                    ph={16}
+                    pv={8}
+                    cursor="pointer"
+                    onClick={() => {
+                      setShowMemberDrawer(false);
+                      navigate(`/users/${m.username}`);
+                    }}
+                  >
+                    <ProfileImage imageUrl={m.profile_image} size={32} />
+                    <Typo type="body-medium" color="BLACK">
+                      {m.username}
                     </Typo>
-                  )}
-                </Layout.FlexRow>
-              ))}
+                    {currentUser && Number(m.id) === Number(currentUser.id) && (
+                      <Typo type="label-small" color="MEDIUM_GRAY">
+                        (you)
+                      </Typo>
+                    )}
+                    {showRemoveAdmin && (
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleDismissAdmin();
+                        }}
+                        style={{
+                          marginLeft: 'auto',
+                          background: 'none',
+                          border: '1px solid #FF3B30',
+                          color: '#FF3B30',
+                          borderRadius: 8,
+                          padding: '4px 10px',
+                          fontSize: 13,
+                          fontWeight: 500,
+                          cursor: 'pointer',
+                        }}
+                      >
+                        Remove
+                      </button>
+                    )}
+                  </Layout.FlexRow>
+                );
+              })}
             </Layout.FlexCol>
             <Layout.FlexCol w="100%" ph={16} pv={12} gap={8}>
               {showLeaveConfirm ? (
                 <>
                   <Typo type="body-small" color="BLACK">
-                    {leaveConfirmText}
+                    Are you sure you want to leave this group?
                   </Typo>
                   <Layout.FlexRow gap={12}>
                     <button
@@ -553,7 +587,7 @@ function GroupChat() {
                         cursor: 'pointer',
                       }}
                     >
-                      {leaveConfirmAction}
+                      Leave
                     </button>
                     <button
                       type="button"
@@ -579,7 +613,7 @@ function GroupChat() {
                   style={{ background: 'none', border: 'none', cursor: 'pointer' }}
                 >
                   <Typo type="label-medium" color="WARNING">
-                    {leaveButtonLabel}
+                    Leave Group
                   </Typo>
                 </button>
               )}

--- a/src/utils/apis/chat.ts
+++ b/src/utils/apis/chat.ts
@@ -80,13 +80,17 @@ export const updateGroupChat = async (
   return data;
 };
 
-export interface LeaveGroupChatRes {
-  status: 'left' | 'admin_evicted';
-  redirect_user_id?: number;
+export const leaveGroupChat = async (roomId: number) => {
+  return axios.post(`/chat/groups/${roomId}/leave/`);
+};
+
+export interface DismissAdminRes {
+  status: 'admin_dismissed';
+  redirect_user_id: number;
 }
 
-export const leaveGroupChat = async (roomId: number) => {
-  return axios.post<LeaveGroupChatRes>(`/chat/groups/${roomId}/leave/`);
+export const dismissWitAdmin = async (roomId: number) => {
+  return axios.post<DismissAdminRes>(`/chat/groups/${roomId}/dismiss-admin/`);
 };
 
 export const getGroupMessages = async (roomId: number, page?: string | null) => {


### PR DESCRIPTION
## Summary
Three changes that work together for the wit_bot escalation UX:

1. **Restore Leave to its original meaning.** Reverted the previous \"Dismiss wit_admin\" relabel of \"Leave Group\". Leave now actually leaves the room (removes the user from members) in every group, including wit_bot escalated ones.
2. **Per-member Remove pill next to wit_admin.** In the members drawer, when the current user is the original owner of a wit_bot escalated room (room contains both wit_bot and wit_admin, and the current user is neither), a red-outlined \"Remove\" pill appears next to \`wit_admin\`. Tapping it calls the new \`POST /chat/groups/<id>/dismiss-admin/\` endpoint and navigates back to \`/users/<bot_id>/chat\` on success.
3. **Auto-navigate after \"Call in the admin\".** The POST response now carries \`chat_room_id\` (backend serializer change), so \`handleBotButtonClick\` routes to \`/chats/group/<id>\` immediately after the tap resolves. \`wit_admin\` was added\` event and the bot's \"Admin has been called in 👀\" reply are visible without a refresh.

## Test plan
- [x] \`craco build\` clean
- [x] Browser end-to-end (verified at 393px):
  - Tap \"Call in the admin\" on the bot card → URL flips to \`/chats/group/<id>\`, header reads \"Help: <username>\", admin-added event + bot reply are visible
  - Open members drawer → \"Remove\" pill appears next to \`wit_admin\` only
  - Tap Remove → URL flips to \`/users/<bot_id>/chat\`, \"wit_admin left\" event renders, bot replies resume on next message
  - Tap \"Leave Group\" at the bottom → user is actually removed from the room (room remains \`is_group=True\` with [bot, admin])

Paired with backend PR.