### PR TITLE
fix(browse-mode): don't poison last_session on page reloads / brief tab-switches

### DIFF
--- a/src/hooks/useBrowseModeSessionPrompt.ts
+++ b/src/hooks/useBrowseModeSessionPrompt.ts
@@ -6,6 +6,12 @@ import { useBoundStore } from '@stores/useBoundStore';
 
 const AWAY_THRESHOLD_MS = 15 * 60 * 1000; // 15 min — anything shorter is "same session"
 const COOLDOWN_MS = 60 * 60 * 1000; // 1 hour cooldown after the user dismisses the prompt
+// Debounce hidden-state saves: a page reload or a tab-switch lasting under
+// this many ms shouldn't move `last_session` forward. Without this, the
+// hidden event the OLD page fires during reload writes last_session=now,
+// the new page reads it, decides the user was "just here," and skips the
+// prompt — even after hours of real away time.
+const HIDE_SETTLE_MS = 5000;
 
 function getStorageKey(userId: number, suffix: string) {
   return `browse_mode_${suffix}_${userId}`;
@@ -48,6 +54,11 @@ export function useBrowseModeSessionPrompt() {
   const userId = myProfile?.id;
   const browseModeEnabled = featureFlags?.[FeatureFlagKey.BROWSE_MODE] ?? false;
 
+  // Pending hidden-state save. A brief hidden state (reload, tab-switch
+  // for a few seconds) shouldn't move last_session forward — it'd trick
+  // the next foreground into thinking the user just left.
+  const pendingHideTimerRef = useRef<number | null>(null);
+
   const tryTrigger = useCallback(() => {
     if (!userId || !browseModeEnabled) return;
     if (isCooldownActive(userId)) return;
@@ -57,6 +68,13 @@ export function useBrowseModeSessionPrompt() {
   // Stable refs so the SET_APP_STATE callback doesn't re-bind every render.
   const handleBecomeActive = useCallback(() => {
     if (!userId) return;
+    // The user came back before the pending hide-save fired — that means
+    // hidden state was brief (reload, quick tab-switch). Cancel the save
+    // so last_session keeps its old (real) value.
+    if (pendingHideTimerRef.current !== null) {
+      window.clearTimeout(pendingHideTimerRef.current);
+      pendingHideTimerRef.current = null;
+    }
     const lastTs = getLastSessionTimestamp(userId);
     if (lastTs && Date.now() - lastTs >= AWAY_THRESHOLD_MS) {
       tryTrigger();
@@ -65,7 +83,15 @@ export function useBrowseModeSessionPrompt() {
 
   const handleBecomeInactive = useCallback(() => {
     if (!userId) return;
-    saveLastSessionTimestamp(userId);
+    // Only commit last_session if the page stays hidden for a few seconds.
+    // Reloads and brief tab-switches happen in well under HIDE_SETTLE_MS.
+    if (pendingHideTimerRef.current !== null) {
+      window.clearTimeout(pendingHideTimerRef.current);
+    }
+    pendingHideTimerRef.current = window.setTimeout(() => {
+      saveLastSessionTimestamp(userId);
+      pendingHideTimerRef.current = null;
+    }, HIDE_SETTLE_MS);
   }, [userId]);
 
   const handleBecomeActiveRef = useRef(handleBecomeActive);


### PR DESCRIPTION
## Summary
Some users opened the app, came back hours later, and the picker auto-prompt didn't fire — even though the 'away threshold' is 15 minutes.

**Root cause:** when the page reloads, the OLD page briefly transitions to \`visibilitychange: 'hidden'\` during teardown. The hook's \`handleBecomeInactive\` fires synchronously and writes \`last_session = now\` to localStorage. The new page loads, reads that freshly-poisoned value, sees \`elapsed < 15min\`, and skips the prompt — even after hours of real away time. Same poisoning hits quick tab-switches (a second or two).

**Fix:** debounce the inactive-save by 5s. setTimeout to commit, cancel it if the user comes back before it fires, OR let it die with the JS context on full reload.

## Behaviour
| Action | Before | After |
|---|---|---|
| Reload (under 5s) | last_session = now → no prompt | timer dies with JS → last_session preserved → prompt fires correctly |
| Quick tab-switch (under 5s) | last_session = now | timer cancelled on return → last_session preserved |
| Real backgrounding (5s+) | last_session = now | timer fires → last_session = now (correct) |

## Repro
1. \`localStorage.setItem('browse_mode_last_session_<userId>', String(Date.now() - 2 * 60 * 60 * 1000))\`
2. \`localStorage.removeItem('browse_mode_dismissed_<userId>')\`
3. \`sessionStorage.removeItem('browse_mode_active_session_<userId>')\`
4. Reload — picker should auto-prompt fullScreen.

Before fix: no prompt, last_session reset to '~1 min ago.'
After fix: prompt fires, last_session stays at '~121 min ago.'

Verified in local preview.