### PR TITLE
fix(browse-mode): deterministic auto-prompt gating via last_picked_at

### DIFF
--- a/src/components/browse-mode/BrowseModePreviewBar.tsx
+++ b/src/components/browse-mode/BrowseModePreviewBar.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import styled, { createGlobalStyle } from 'styled-components';
 import { Colors, SvgIcon, Typo } from '@design-system';
 import { useBoundStore } from '@stores/useBoundStore';
+import { clearLastPickedAt } from '@utils/browseModeActiveSession';
 
 /**
  * Top-of-app bar that shows when the user activated a transient "Apply
@@ -51,6 +52,7 @@ function BrowseModePreviewBar() {
   const clearActiveBrowseMode = useBoundStore((state) => state.clearActiveBrowseMode);
   const openBrowseModePicker = useBoundStore((state) => state.openBrowseModePicker);
   const openToast = useBoundStore((state) => state.openToast);
+  const userId = useBoundStore((state) => state.myProfile?.id);
 
   const isPreview = activeBrowseMode?.kind === 'custom' && activeBrowseMode.id === -1;
   // Throttle "blocked click" toasts: rapid taps would otherwise spam the
@@ -109,6 +111,11 @@ function BrowseModePreviewBar() {
 
   const handleExit = () => {
     clearActiveBrowseMode();
+    // The user explicitly abandoned the preview — wipe last_picked_at so
+    // the next page-load auto-prompts again. Without this, the freshness
+    // window from the apply-without-saving moment would still be active
+    // and the picker wouldn't fire on next reload.
+    if (userId) clearLastPickedAt(userId);
     openBrowseModePicker();
   };
 

--- a/src/components/browse-mode/BrowseModeSessionPrompt.tsx
+++ b/src/components/browse-mode/BrowseModeSessionPrompt.tsx
@@ -18,6 +18,7 @@ import {
 import { ComponentVisibility, DEFAULT_VISIBILITY, SocialBattery } from '@models/checkIn';
 import { useBoundStore } from '@stores/useBoundStore';
 import { postCheckIn } from '@utils/apis/checkIn';
+import { writeLastPickedAt } from '@utils/browseModeActiveSession';
 import { HiddenModeKey, readHiddenModes, writeHiddenModes } from '@utils/browseModeHiddenModes';
 import { saveLastPickedMode } from '@utils/browseModeLastPick';
 import BrowseModeCustomizeSheet from './BrowseModeCustomizeSheet';
@@ -191,7 +192,13 @@ function BrowseModeSessionPrompt({
           updated_at: '',
         });
       }
-      if (myProfile?.id) saveLastPickedMode(myProfile.id, mode);
+      if (myProfile?.id) {
+        saveLastPickedMode(myProfile.id, mode);
+        // Stamp the pick time. The auto-prompt's 2-hour freshness window
+        // starts from this moment; any pick path (auto-prompt, manual
+        // sidebar, post-Save activation) bumps the timer the same way.
+        writeLastPickedAt(myProfile.id);
+      }
 
       let batteryApplied: SocialBattery | null = null;
       if (syncBattery && suggestedBattery) {
@@ -355,9 +362,13 @@ function BrowseModeSessionPrompt({
           default_battery: snapshot.default_battery,
         },
       });
+      // Apply-without-saving counts as the user actively picking a
+      // configuration to use right now — bump the freshness timer so the
+      // auto-prompt doesn't re-fire mid-preview.
+      if (myProfile?.id) writeLastPickedAt(myProfile.id);
       onFinish();
     },
-    [closeCustomize, editingPreset?.id, onFinish],
+    [closeCustomize, editingPreset?.id, myProfile?.id, onFinish],
   );
 
   const handleConfirmDelete = useCallback(async () => {

--- a/src/hooks/useBrowseModeActivePersistence.ts
+++ b/src/hooks/useBrowseModeActivePersistence.ts
@@ -1,50 +1,45 @@
 import { useEffect, useRef } from 'react';
 import { useBoundStore } from '@stores/useBoundStore';
-import { readActiveSession, writeActiveSession } from '@utils/browseModeActiveSession';
+import { readActiveMode, writeActiveMode } from '@utils/browseModeActiveSession';
 
 /**
- * Glue between the in-memory active-mode Zustand state and per-tab
- * sessionStorage. Mount once at Root.
+ * Glue between the in-memory active-mode Zustand state and per-user
+ * localStorage. Mount once at Root.
  *
- * - On user-load, if sessionStorage has an active mode for this user, push
- *   it back into the store so the page reflects the same mode the user had
- *   before refreshing. Only does this when the store is empty — never
- *   stomps on a mode the user has already picked in this fresh mount.
- * - On every change to activeBrowseMode (subscription), write through to
- *   sessionStorage so the next refresh has fresh data. clearActiveBrowseMode
- *   writes null (which removes the key) so a real "exit preview" actually
- *   clears the persisted mode.
+ * Hydration: on user-load, if the user picked a mode within the last
+ * 2 hours (FRESHNESS_MS in browseModeActiveSession), restore it to the
+ * store. Stale picks are dropped.
+ *
+ * Subscription: every time activeBrowseMode changes (user pick,
+ * auto-tighten removing tabs, etc.), mirror it to localStorage. We do
+ * NOT touch last_picked_at here — that's owned by the explicit pick
+ * paths in BrowseModeSessionPrompt so non-user mutations (auto-tighten,
+ * hydration) don't reset the 2-hour freshness window.
  */
 export function useBrowseModeActivePersistence() {
   const userId = useBoundStore((state) => state.myProfile?.id);
-  // Track whether we've already hydrated for this user so we don't
-  // overwrite the user's later picks every time the effect re-fires.
   const hydratedFor = useRef<number | null>(null);
 
-  // Hydrate from sessionStorage on user-load.
   useEffect(() => {
     if (!userId) return;
     if (hydratedFor.current === userId) return;
     hydratedFor.current = userId;
     const current = useBoundStore.getState().activeBrowseMode;
     // Don't stomp on a mode the user already picked in this mount —
-    // can happen if the picker auto-prompt fires before the rehydration
-    // effect runs, or in a re-render race.
+    // can happen if the picker auto-prompt fires before this effect
+    // runs (very tight render race).
     if (current) return;
-    const stored = readActiveSession(userId);
+    const stored = readActiveMode(userId);
     if (stored) {
       useBoundStore.setState({ activeBrowseMode: stored });
     }
   }, [userId]);
 
-  // Subscribe to activeBrowseMode changes and mirror them to sessionStorage.
-  // useBoundStore.subscribe gives us the raw zustand subscribe; we ignore
-  // changes when there's no userId (anonymous shouldn't persist anything).
   useEffect(() => {
     if (!userId) return undefined;
     const unsub = useBoundStore.subscribe((state, prev) => {
       if (state.activeBrowseMode === prev.activeBrowseMode) return;
-      writeActiveSession(userId, state.activeBrowseMode);
+      writeActiveMode(userId, state.activeBrowseMode);
     });
     return unsub;
   }, [userId]);

--- a/src/hooks/useBrowseModeSessionPrompt.ts
+++ b/src/hooks/useBrowseModeSessionPrompt.ts
@@ -1,48 +1,28 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { FeatureFlagKey } from '@constants/featureFlag';
-import { useGetAppMessage } from '@hooks/useAppMessage';
-import { SetAppStateData } from '@models/app';
 import { useBoundStore } from '@stores/useBoundStore';
-
-const AWAY_THRESHOLD_MS = 15 * 60 * 1000; // 15 min — anything shorter is "same session"
-const COOLDOWN_MS = 60 * 60 * 1000; // 1 hour cooldown after the user dismisses the prompt
-// Debounce hidden-state saves: a page reload or a tab-switch lasting under
-// this many ms shouldn't move `last_session` forward. Without this, the
-// hidden event the OLD page fires during reload writes last_session=now,
-// the new page reads it, decides the user was "just here," and skips the
-// prompt — even after hours of real away time.
-const HIDE_SETTLE_MS = 5000;
-
-function getStorageKey(userId: number, suffix: string) {
-  return `browse_mode_${suffix}_${userId}`;
-}
-
-function isCooldownActive(userId: number): boolean {
-  const ts = localStorage.getItem(getStorageKey(userId, 'dismissed'));
-  if (!ts) return false;
-  return Date.now() - Number(ts) < COOLDOWN_MS;
-}
-
-function saveLastSessionTimestamp(userId: number) {
-  localStorage.setItem(getStorageKey(userId, 'last_session'), String(Date.now()));
-}
-
-function getLastSessionTimestamp(userId: number): number | null {
-  const ts = localStorage.getItem(getStorageKey(userId, 'last_session'));
-  return ts ? Number(ts) : null;
-}
-
-function saveDismissTimestamp(userId: number) {
-  localStorage.setItem(getStorageKey(userId, 'dismissed'), String(Date.now()));
-}
+import { FRESHNESS_MS, readLastPickedAt, writeLastPickedAt } from '@utils/browseModeActiveSession';
 
 /**
- * On a new session — meaning the user has been away for at least 30 minutes —
- * surface the two-step Browse Mode prompt. Quick re-opens (close → reopen
- * within 30 min) are intentionally treated as the same session and skipped.
+ * Auto-prompt the Browse Mode picker on app open. Spec: ALWAYS fire when
+ *   (a) the user has never picked a mode (first-ever open, or always
+ *       skipped before — there's no `last_picked_at` in localStorage), or
+ *   (b) it's been more than 2 hours since their last pick.
  *
- * Mirrors the structure of `useCheckInFreshnessPrompt`: visibilitychange
- * listener + native SET_APP_STATE bridge + per-user localStorage timestamps.
+ * Trigger: cold start (component mount with userId + feature flag both
+ * loaded). Mounted once at Root, so "cold start" really means page load
+ * or full app remount.
+ *
+ * No cooldown after dismiss — if the user skips, they'll be prompted
+ * again next time they open the app (matches the user's spec for the
+ * "always skipped" case).
+ *
+ * No visibility-change re-trigger — brief tab-switches and reloads
+ * shouldn't generate a new prompt mid-session. The 2-hour freshness
+ * check on the next page load is the only re-trigger.
+ *
+ * `last_picked_at` is owned by the picker activation path (see
+ * BrowseModeSessionPrompt's applyMode) so this hook only READS it.
  */
 export function useBrowseModeSessionPrompt() {
   const [shouldShow, setShouldShow] = useState(false);
@@ -54,109 +34,36 @@ export function useBrowseModeSessionPrompt() {
   const userId = myProfile?.id;
   const browseModeEnabled = featureFlags?.[FeatureFlagKey.BROWSE_MODE] ?? false;
 
-  // Pending hidden-state save. A brief hidden state (reload, tab-switch
-  // for a few seconds) shouldn't move last_session forward — it'd trick
-  // the next foreground into thinking the user just left.
-  const pendingHideTimerRef = useRef<number | null>(null);
-
-  const tryTrigger = useCallback(() => {
-    if (!userId || !browseModeEnabled) return;
-    if (isCooldownActive(userId)) return;
-    setShouldShow(true);
-  }, [userId, browseModeEnabled]);
-
-  // Stable refs so the SET_APP_STATE callback doesn't re-bind every render.
-  const handleBecomeActive = useCallback(() => {
-    if (!userId) return;
-    // The user came back before the pending hide-save fired — that means
-    // hidden state was brief (reload, quick tab-switch). Cancel the save
-    // so last_session keeps its old (real) value.
-    if (pendingHideTimerRef.current !== null) {
-      window.clearTimeout(pendingHideTimerRef.current);
-      pendingHideTimerRef.current = null;
-    }
-    const lastTs = getLastSessionTimestamp(userId);
-    if (lastTs && Date.now() - lastTs >= AWAY_THRESHOLD_MS) {
-      tryTrigger();
-    }
-  }, [userId, tryTrigger]);
-
-  const handleBecomeInactive = useCallback(() => {
-    if (!userId) return;
-    // Only commit last_session if the page stays hidden for a few seconds.
-    // Reloads and brief tab-switches happen in well under HIDE_SETTLE_MS.
-    if (pendingHideTimerRef.current !== null) {
-      window.clearTimeout(pendingHideTimerRef.current);
-    }
-    pendingHideTimerRef.current = window.setTimeout(() => {
-      saveLastSessionTimestamp(userId);
-      pendingHideTimerRef.current = null;
-    }, HIDE_SETTLE_MS);
-  }, [userId]);
-
-  const handleBecomeActiveRef = useRef(handleBecomeActive);
-  const handleBecomeInactiveRef = useRef(handleBecomeInactive);
-  useEffect(() => {
-    handleBecomeActiveRef.current = handleBecomeActive;
-    handleBecomeInactiveRef.current = handleBecomeInactive;
-  }, [handleBecomeActive, handleBecomeInactive]);
-
-  const handleAppState = useCallback((data: SetAppStateData) => {
-    if (!data) return;
-    if (data.value === 'active') {
-      handleBecomeActiveRef.current();
-    } else if (data.value === 'inactive' || data.value === 'background') {
-      handleBecomeInactiveRef.current();
-    }
-  }, []);
-
-  useGetAppMessage({ key: 'SET_APP_STATE', cb: handleAppState });
-
-  useEffect(() => {
-    const onVisibilityChange = () => {
-      if (document.visibilityState === 'visible') {
-        handleBecomeActive();
-      } else {
-        handleBecomeInactive();
-      }
-    };
-    document.addEventListener('visibilitychange', onVisibilityChange);
-    return () => document.removeEventListener('visibilitychange', onVisibilityChange);
-  }, [handleBecomeActive, handleBecomeInactive]);
-
-  // Cold start: prompt on first-ever visit AND on returns after 30+ min away.
+  // Cold-start gate: prompt iff user has never picked OR last pick is stale.
   // Also load saved presets so they're ready when the prompt opens.
   useEffect(() => {
     if (!userId || !browseModeEnabled) return;
-
-    const lastTs = getLastSessionTimestamp(userId);
-    if (lastTs === null || Date.now() - lastTs >= AWAY_THRESHOLD_MS) {
-      tryTrigger();
-    }
+    const lastPickedAt = readLastPickedAt(userId);
+    const stale = lastPickedAt === null || Date.now() - lastPickedAt >= FRESHNESS_MS;
+    if (stale) setShouldShow(true);
     fetchPresets();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [userId, browseModeEnabled]);
 
+  /**
+   * Skip the prompt. Doesn't write anything — no cooldown — so the next
+   * time the user opens the app they'll see the prompt again (per spec).
+   */
   const dismiss = useCallback(() => {
     setShouldShow(false);
-    if (userId) {
-      saveDismissTimestamp(userId);
-      saveLastSessionTimestamp(userId);
-    }
-  }, [userId]);
+  }, []);
 
   /**
-   * Like `dismiss`, but called after the user actively chose a mode.
-   * Skips the dismiss-cooldown so the next 30-min-away gap re-prompts as expected.
+   * Called after the user actively picked a mode. Records the pick
+   * timestamp so the next 2-hour freshness window starts from now;
+   * within that window, the prompt won't auto-fire on cold start.
    */
   const finish = useCallback(() => {
     setShouldShow(false);
-    if (userId) {
-      saveLastSessionTimestamp(userId);
-    }
+    if (userId) writeLastPickedAt(userId);
   }, [userId]);
 
-  /** Manually open the prompt (e.g., from the header indicator chip). */
+  /** Manually open the prompt (e.g., from the sidebar's Browsing Mode entry). */
   const open = useCallback(() => {
     setShouldShow(true);
   }, []);

--- a/src/utils/browseModeActiveSession.ts
+++ b/src/utils/browseModeActiveSession.ts
@@ -1,33 +1,79 @@
 /**
- * Per-user, per-tab persistence of the currently active browse mode.
+ * Per-user persistence of the currently active browse mode plus a timestamp
+ * of when the user last actively *picked* one.
  *
- * Lives in sessionStorage (NOT localStorage) so it survives page refreshes
- * within a single tab but resets on tab close. That matches the user's
- * mental model of "I picked Soft mode for THIS session" — refresh shouldn't
- * forget it, but coming back tomorrow is a fresh decision.
+ * Spec: the picker auto-prompt fires when the user opens the app and either
+ *   (a) has never picked a mode, or
+ *   (b) it's been more than 2 hours since their last pick.
+ * Within the 2-hour freshness window, the picked mode is restored on
+ * load so the user keeps the experience they chose.
  *
- * Cross-tab and cross-day "do you want to re-pick" prompting stays the
- * responsibility of `useBrowseModeSessionPrompt` — this util only handles
- * the within-tab survival of an already-chosen mode.
+ * Switched from sessionStorage to localStorage so the same mode is
+ * available across tabs and after the tab is closed-and-reopened — the
+ * 2-hour window is now the source of "is this the same session?" rather
+ * than tab lifetime.
  */
 
 import { ActiveBrowseMode } from '@models/browseMode';
 
-const STORAGE_KEY_PREFIX = 'browse_mode_active_session_';
+const ACTIVE_MODE_PREFIX = 'browse_mode_active_';
+const LAST_PICKED_AT_PREFIX = 'browse_mode_last_picked_at_';
 
-function key(userId: number): string {
-  return `${STORAGE_KEY_PREFIX}${userId}`;
+/** 2 hours — anything past this and the auto-prompt fires on next open. */
+export const FRESHNESS_MS = 2 * 60 * 60 * 1000;
+
+function activeModeKey(userId: number): string {
+  return `${ACTIVE_MODE_PREFIX}${userId}`;
 }
 
-export function readActiveSession(userId: number): ActiveBrowseMode | null {
+function lastPickedAtKey(userId: number): string {
+  return `${LAST_PICKED_AT_PREFIX}${userId}`;
+}
+
+export function readLastPickedAt(userId: number): number | null {
+  const raw = localStorage.getItem(lastPickedAtKey(userId));
+  if (!raw) return null;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : null;
+}
+
+export function writeLastPickedAt(userId: number, when: number = Date.now()): void {
   try {
-    const raw = sessionStorage.getItem(key(userId));
-    if (!raw) return null;
+    localStorage.setItem(lastPickedAtKey(userId), String(when));
+  } catch {
+    /* private mode / quota — best-effort */
+  }
+}
+
+export function clearLastPickedAt(userId: number): void {
+  localStorage.removeItem(lastPickedAtKey(userId));
+}
+
+/** True iff the user picked a mode within the last FRESHNESS_MS. */
+export function isPickFresh(userId: number): boolean {
+  const ts = readLastPickedAt(userId);
+  if (ts === null) return false;
+  return Date.now() - ts < FRESHNESS_MS;
+}
+
+/**
+ * Read the persisted active mode, but only if the last pick is still fresh.
+ * Stale data is cleared as a side effect so subsequent reads are clean.
+ */
+export function readActiveMode(userId: number): ActiveBrowseMode | null {
+  if (!isPickFresh(userId)) {
+    // Drop stale data so we don't carry it across the freshness boundary.
+    localStorage.removeItem(activeModeKey(userId));
+    clearLastPickedAt(userId);
+    return null;
+  }
+  const raw = localStorage.getItem(activeModeKey(userId));
+  if (!raw) return null;
+  try {
     const parsed = JSON.parse(raw) as unknown;
     if (!parsed || typeof parsed !== 'object') return null;
     const mode = parsed as { kind?: unknown };
-    // Defensive shape check — corrupt entries (schema change, manual
-    // tampering) shouldn't blow up rehydration.
+    // Defensive shape check — don't rehydrate corrupt entries.
     if (mode.kind !== 'built_in' && mode.kind !== 'custom') return null;
     return parsed as ActiveBrowseMode;
   } catch {
@@ -35,15 +81,14 @@ export function readActiveSession(userId: number): ActiveBrowseMode | null {
   }
 }
 
-export function writeActiveSession(userId: number, mode: ActiveBrowseMode | null): void {
+export function writeActiveMode(userId: number, mode: ActiveBrowseMode | null): void {
   try {
     if (mode === null) {
-      sessionStorage.removeItem(key(userId));
+      localStorage.removeItem(activeModeKey(userId));
     } else {
-      sessionStorage.setItem(key(userId), JSON.stringify(mode));
+      localStorage.setItem(activeModeKey(userId), JSON.stringify(mode));
     }
   } catch {
-    // sessionStorage can throw in private mode / if quota exceeded —
-    // best-effort persistence, not worth crashing the app over.
+    /* private mode / quota — best-effort */
   }
 }


### PR DESCRIPTION
## Summary

Replaces the heuristic time-since-last-active gating with a deterministic check on `last_picked_at`: prompt fires iff the user has never picked a mode OR their last pick was 2+ hours ago. No more silent skips from reload-poisoned timestamps.

## What changed

- **`browseModeActiveSession.ts`** — switched from sessionStorage to localStorage; added `last_picked_at` per-user key + 2-hour freshness gate; `readActiveMode` returns null and clears stale data once the window expires.
- **`useBrowseModeSessionPrompt.ts`** — cold-start gate now reads `last_picked_at` (not the old `last_session`); dropped dismiss cooldown, visibility-change re-trigger, and SET_APP_STATE bridge. `dismiss()` writes nothing; `finish()` stamps `writeLastPickedAt` so the next 2-hour window starts from the actual user pick.
- **`useBrowseModeActivePersistence.ts`** — hydrates from `readActiveMode` (which now enforces the freshness window) and mirrors store updates; doesn't touch `last_picked_at` itself.
- **`BrowseModeSessionPrompt.tsx`** — `applyMode` and `handleCustomizeApplyWithoutSaving` stamp `writeLastPickedAt` so any explicit pick path bumps the timer the same way.
- **`BrowseModePreviewBar.tsx`** — preserves the explicit-abandon clear path for safety (still wires `clearLastPickedAt` on exit-X) so abandoning a preview re-prompts on next load.

## Spec being satisfied

> They should ALWAYS see the browsing mode if they open the app for the first time ever, or open the app when they never used the feature before (always skipped), or it's been more than 2 hours since they last set the mode.

## Test plan

Verified all five scenarios manually in the local preview (Ver.W test user, devtools-injected localStorage):

- [x] No `last_picked_at` (first-ever open OR always-skipped) → prompt fires
- [x] `last_picked_at = now` → no prompt on reload
- [x] `last_picked_at = now - 2h - 1m` → prompt fires
- [x] `last_picked_at = now - 1h59m` → no prompt (boundary)
- [x] Active mode + fresh `last_picked_at` in localStorage → mode hydrates on reload (bottom nav filtered to `Share` only for Soft mode)
- [x] `npx craco build` clean (TS + ESLint)
- [x] No console errors during preview reloads