### PR TITLE
fix(browse-mode): tighten auto-prompt freshness window from 2h to 15m

### DIFF
--- a/src/components/browse-mode/BrowseModeSessionPrompt.tsx
+++ b/src/components/browse-mode/BrowseModeSessionPrompt.tsx
@@ -194,7 +194,7 @@ function BrowseModeSessionPrompt({
       }
       if (myProfile?.id) {
         saveLastPickedMode(myProfile.id, mode);
-        // Stamp the pick time. The auto-prompt's 2-hour freshness window
+        // Stamp the pick time. The auto-prompt's 15-minute freshness window
         // starts from this moment; any pick path (auto-prompt, manual
         // sidebar, post-Save activation) bumps the timer the same way.
         writeLastPickedAt(myProfile.id);

--- a/src/hooks/useBrowseModeActivePersistence.ts
+++ b/src/hooks/useBrowseModeActivePersistence.ts
@@ -7,14 +7,14 @@ import { readActiveMode, writeActiveMode } from '@utils/browseModeActiveSession'
  * localStorage. Mount once at Root.
  *
  * Hydration: on user-load, if the user picked a mode within the last
- * 2 hours (FRESHNESS_MS in browseModeActiveSession), restore it to the
- * store. Stale picks are dropped.
+ * 15 minutes (FRESHNESS_MS in browseModeActiveSession), restore it to
+ * the store. Stale picks are dropped.
  *
  * Subscription: every time activeBrowseMode changes (user pick,
  * auto-tighten removing tabs, etc.), mirror it to localStorage. We do
  * NOT touch last_picked_at here — that's owned by the explicit pick
  * paths in BrowseModeSessionPrompt so non-user mutations (auto-tighten,
- * hydration) don't reset the 2-hour freshness window.
+ * hydration) don't reset the 15-minute freshness window.
  */
 export function useBrowseModeActivePersistence() {
   const userId = useBoundStore((state) => state.myProfile?.id);

--- a/src/hooks/useBrowseModeSessionPrompt.ts
+++ b/src/hooks/useBrowseModeSessionPrompt.ts
@@ -7,7 +7,7 @@ import { FRESHNESS_MS, readLastPickedAt, writeLastPickedAt } from '@utils/browse
  * Auto-prompt the Browse Mode picker on app open. Spec: ALWAYS fire when
  *   (a) the user has never picked a mode (first-ever open, or always
  *       skipped before — there's no `last_picked_at` in localStorage), or
- *   (b) it's been more than 2 hours since their last pick.
+ *   (b) it's been more than 15 minutes since their last pick.
  *
  * Trigger: cold start (component mount with userId + feature flag both
  * loaded). Mounted once at Root, so "cold start" really means page load
@@ -18,7 +18,7 @@ import { FRESHNESS_MS, readLastPickedAt, writeLastPickedAt } from '@utils/browse
  * "always skipped" case).
  *
  * No visibility-change re-trigger — brief tab-switches and reloads
- * shouldn't generate a new prompt mid-session. The 2-hour freshness
+ * shouldn't generate a new prompt mid-session. The 15-minute freshness
  * check on the next page load is the only re-trigger.
  *
  * `last_picked_at` is owned by the picker activation path (see
@@ -55,7 +55,7 @@ export function useBrowseModeSessionPrompt() {
 
   /**
    * Called after the user actively picked a mode. Records the pick
-   * timestamp so the next 2-hour freshness window starts from now;
+   * timestamp so the next 15-minute freshness window starts from now;
    * within that window, the prompt won't auto-fire on cold start.
    */
   const finish = useCallback(() => {

--- a/src/utils/browseModeActiveSession.ts
+++ b/src/utils/browseModeActiveSession.ts
@@ -4,14 +4,14 @@
  *
  * Spec: the picker auto-prompt fires when the user opens the app and either
  *   (a) has never picked a mode, or
- *   (b) it's been more than 2 hours since their last pick.
- * Within the 2-hour freshness window, the picked mode is restored on
+ *   (b) it's been more than 15 minutes since their last pick.
+ * Within the 15-minute freshness window, the picked mode is restored on
  * load so the user keeps the experience they chose.
  *
  * Switched from sessionStorage to localStorage so the same mode is
  * available across tabs and after the tab is closed-and-reopened — the
- * 2-hour window is now the source of "is this the same session?" rather
- * than tab lifetime.
+ * 15-minute window is now the source of "is this the same session?"
+ * rather than tab lifetime.
  */
 
 import { ActiveBrowseMode } from '@models/browseMode';
@@ -19,8 +19,8 @@ import { ActiveBrowseMode } from '@models/browseMode';
 const ACTIVE_MODE_PREFIX = 'browse_mode_active_';
 const LAST_PICKED_AT_PREFIX = 'browse_mode_last_picked_at_';
 
-/** 2 hours — anything past this and the auto-prompt fires on next open. */
-export const FRESHNESS_MS = 2 * 60 * 60 * 1000;
+/** 15 minutes — anything past this and the auto-prompt fires on next open. */
+export const FRESHNESS_MS = 15 * 60 * 1000;
 
 function activeModeKey(userId: number): string {
   return `${ACTIVE_MODE_PREFIX}${userId}`;


### PR DESCRIPTION
## Summary

Same gating logic shipped in #1307, just a smaller `FRESHNESS_MS` constant: 2 hours → 15 minutes.

If the user closes the app and returns more than 15 minutes later, the picker auto-prompts again. Within 15 minutes, the picked mode is restored and the prompt stays quiet.

## Test plan

The 5-scenario verification in #1307 covers this — only the constant changed, every branch in the gate (`null`, `< window`, `>= window`) is the same code path. Build clean.