### PR TITLE
fix(mutual-traits): bucket by trait.category, not chip-name match

### DIFF
--- a/src/components/_common/mutual-meta-text/MutualTraitsList.tsx
+++ b/src/components/_common/mutual-meta-text/MutualTraitsList.tsx
@@ -34,11 +34,17 @@ function MutualTraitsList({ traits, isLoading, emptyText }: MutualTraitsListProp
     );
   }
 
+  // Bucket each trait by its server-provided category when present; otherwise
+  // fall back to chip-name matching. Without this, chip names that appear in
+  // multiple categories (e.g. "Instagram" lives in both favorite_platform and
+  // least_favorite_platform) would surface in every matching bucket.
   const groupedByCategory = categories
     .map((cat) => ({
       category: cat,
       traits: traits.filter((trait) =>
-        cat.chips.some((c) => normalizeChipText(c) === normalizeChipText(trait.content)),
+        trait.category
+          ? trait.category === cat.key
+          : cat.chips.some((c) => normalizeChipText(c) === normalizeChipText(trait.content)),
       ),
     }))
     .filter((group) => group.traits.length > 0);

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -54,6 +54,8 @@ export interface UserFollowStatus {
 export interface MutualTrait {
   id: number;
   content: string;
+  // Backend serves category for Interest-backed traits; absent for personas.
+  category?: string;
 }
 
 export interface UserProfile extends User, UserFollowStatus {


### PR DESCRIPTION
## Bug

The Mutual Traits modal grouped traits by checking whether the trait's `content` appeared in any category's chip list. Because chip names like \"Instagram\", \"TikTok\", \"WhoamI Today (WIT)\" exist in **both** \`favorite_platform\` and \`least_favorite_platform\` lists, a single mutual trait was rendered in **both** category buckets — so a shared favorite \"Instagram\" appeared under both Favorite Platform and Least Favorite Platform.

The same shadow happened for any chip that ever moved between categories (e.g. \"Pro-Choice\" was removed from \`values_allyship\` in #985 and would have landed in \"Other\" via the chip-name fallback).

## Fix

`InterestSerializer` already returns `category` for each trait. Use it: prefer `trait.category === cat.key` when present, fall back to chip-name matching only for trait shapes without category (personas).

## Verification

Seeded shared interests for adoor_1 ↔ adoor_10 across overlapping categories:

- \"Instagram\" (favorite_platform)
- \"TikTok\" (least_favorite_platform)
- \"WhoamI Today (WIT)\" (favorite_platform)
- \"Pro-Choice\" (values_allyship — chip name no longer in canonical list)

**Before:** Instagram, WIT, TikTok each appeared in both Favorite + Least Favorite sections; Pro-Choice landed in \"Other\".
**After:** Each chip appears in exactly its server-assigned category. Pro-Choice correctly lands in Values & Allyship even though its name isn't in the current canonical list.

Build clean (`npx craco build`).