### PR TITLE
fix(profile): shared traits via popup; fix backdrop click navigating to post

### DIFF
--- a/src/components/_common/info-popup/InfoPopup.tsx
+++ b/src/components/_common/info-popup/InfoPopup.tsx
@@ -13,6 +13,9 @@ function InfoPopup({ isOpen, onClose, title, children }: PropsWithChildren<InfoP
   const suppressBackdropCloseUntilRef = useRef(0);
 
   const markBackdropMouseDown = (e: MouseEvent<HTMLDivElement>) => {
+    // Always stop propagation so ancestor click handlers (e.g. a post card)
+    // never see a backdrop tap meant only to dismiss the popup.
+    e.stopPropagation();
     if (Date.now() < suppressBackdropCloseUntilRef.current) {
       shouldCloseFromBackdropRef.current = false;
       return;
@@ -21,6 +24,7 @@ function InfoPopup({ isOpen, onClose, title, children }: PropsWithChildren<InfoP
   };
 
   const markBackdropTouchStart = (e: TouchEvent<HTMLDivElement>) => {
+    e.stopPropagation();
     const isBackdrop = e.target === e.currentTarget;
     if (!isBackdrop) {
       // iOS WebView can emit follow-up ghost mouse events on backdrop.
@@ -30,6 +34,7 @@ function InfoPopup({ isOpen, onClose, title, children }: PropsWithChildren<InfoP
   };
 
   const handleOverlayClick = (e: MouseEvent<HTMLDivElement>) => {
+    e.stopPropagation();
     if (Date.now() < suppressBackdropCloseUntilRef.current) {
       shouldCloseFromBackdropRef.current = false;
       return;

--- a/src/components/profile/Profile.tsx
+++ b/src/components/profile/Profile.tsx
@@ -6,6 +6,7 @@ import { useShallow } from 'zustand/react/shallow';
 import CommonDialog from '@components/_common/alert-dialog/common-dialog/CommonDialog';
 import ChatRequestButton from '@components/_common/chat-request-button/ChatRequestButton';
 import FriendStatus from '@components/_common/friend-status/FriendStatus';
+import InfoPopup from '@components/_common/info-popup/InfoPopup';
 import MutualTraitsList from '@components/_common/mutual-meta-text/MutualTraitsList';
 import ProfileImage from '@components/_common/profile-image/ProfileImage';
 import SubscriptionPopup from '@components/friends/subscription-popup/SubscriptionPopup';
@@ -127,6 +128,7 @@ function Profile({ user }: ProfileProps) {
   };
 
   const [showMoreAbout, setShowMoreAbout] = useState(false);
+  const [showSharedTraitsModal, setShowSharedTraitsModal] = useState(false);
 
   const isVerQ = !!featureFlags?.postsVerQ;
 
@@ -350,27 +352,33 @@ function Profile({ user }: ProfileProps) {
           )}
           <MutualFriendsInfo mutualFriends={(user as UserProfile).mutuals} />
 
-          {/* Shared traits — grouped by category. Shown for any non-self profile
-              (friends and non-friends) when mutual data is available. */}
-          {!featureFlags?.postsVerQ &&
-            !isMyProfile(user) &&
-            viewData &&
-            ((viewData.mutual_interests && viewData.mutual_interests.length > 0) ||
-              (viewData.mutual_personas && viewData.mutual_personas.length > 0)) && (
-              <Layout.FlexCol gap={8} w="100%">
-                <Typo type="label-medium" color="MEDIUM_GRAY">
-                  {t('shared_traits')}
-                </Typo>
-                <MutualTraitsList
-                  traits={[
-                    ...(viewData.mutual_interests ?? []),
-                    ...(viewData.mutual_personas ?? []),
-                  ]}
-                  isLoading={false}
-                  emptyText=""
-                />
-              </Layout.FlexCol>
-            )}
+          {/* Shared traits — surfaced as a tappable count that opens the
+              categorized modal. Shown for any non-self profile (friends and
+              non-friends) when mutual data is available. */}
+          {(() => {
+            if (featureFlags?.postsVerQ || isMyProfile(user) || !viewData) return null;
+            const traits = [
+              ...(viewData.mutual_interests ?? []),
+              ...(viewData.mutual_personas ?? []),
+            ];
+            if (traits.length === 0) return null;
+            return (
+              <>
+                <SharedTraitsButton type="button" onClick={() => setShowSharedTraitsModal(true)}>
+                  <Typo type="label-medium" color="PRIMARY" fontWeight={500}>
+                    {t('mutual_traits_count', { count: traits.length })}
+                  </Typo>
+                </SharedTraitsButton>
+                <InfoPopup
+                  isOpen={showSharedTraitsModal}
+                  onClose={() => setShowSharedTraitsModal(false)}
+                  title={t('mutual_traits_title')}
+                >
+                  <MutualTraitsList traits={traits} isLoading={false} emptyText="" />
+                </InfoPopup>
+              </>
+            );
+          })()}
         </>
       )}
       {/* my-page actions: Edit Profile + Public/Private toggle (Q) or View As (W) */}
@@ -467,6 +475,18 @@ const ViewAsButton = styled(Button.Secondary)`
     color: ${({ theme }) => theme.PRIMARY};
     font-size: 14.4px;
   }
+`;
+
+const SharedTraitsButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  align-self: flex-start;
+  padding: 0;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
 `;
 
 function AccountStatusBadge({ children }: { children: ReactNode }) {


### PR DESCRIPTION
## Two fixes

### 1. Profile page: shared traits via popup, not inline

Reverts the inline categorized list landed in #1310. Now the profile shows a clickable \`N mutual traits\` link (matching the same UX as the Discover post link). Tap → opens the existing \`InfoPopup\` + \`MutualTraitsList\` modal with the categorized chips. Friends and non-friends both see it.

### 2. InfoPopup backdrop click no longer click-throughs

The InfoPopup overlay sits inside the React tree of whatever rendered it (typically a post card on Discover). When the user tapped the dimmed backdrop to dismiss the modal, the click propagated up to the post card click handler and navigated to post detail.

Fix: \`stopPropagation()\` on the overlay's \`mousedown\` / \`touchstart\` / \`click\` handlers so dismissal taps stay scoped to the popup. Close button already had stopPropagation.

## Verification

- Adoor_2 (friend) profile: \`6 mutual traits\` link tap opens categorized modal (Favorite Platform, Least Favorite Platform, Hobbies & Activities, Online Persona, Other) ✓
- Discover modal: open via post link → click backdrop → modal closes, URL stays on \`/discover\` (no navigation to post) ✓
- Build clean (\`npx craco build\`)