### PR TITLE
fix(profile): highlight shared traits in More About sheet; fix chip counter floating

### DIFF
--- a/src/components/profile/Profile.tsx
+++ b/src/components/profile/Profile.tsx
@@ -6,8 +6,6 @@ import { useShallow } from 'zustand/react/shallow';
 import CommonDialog from '@components/_common/alert-dialog/common-dialog/CommonDialog';
 import ChatRequestButton from '@components/_common/chat-request-button/ChatRequestButton';
 import FriendStatus from '@components/_common/friend-status/FriendStatus';
-import InfoPopup from '@components/_common/info-popup/InfoPopup';
-import MutualTraitsList from '@components/_common/mutual-meta-text/MutualTraitsList';
 import ProfileImage from '@components/_common/profile-image/ProfileImage';
 import SubscriptionPopup from '@components/friends/subscription-popup/SubscriptionPopup';
 import EditConnectionsBottomSheet from '@components/profile/edit-connections/EditConnectionsBottomSheet';
@@ -128,7 +126,6 @@ function Profile({ user }: ProfileProps) {
   };
 
   const [showMoreAbout, setShowMoreAbout] = useState(false);
-  const [showSharedTraitsModal, setShowSharedTraitsModal] = useState(false);
 
   const isVerQ = !!featureFlags?.postsVerQ;
 
@@ -350,49 +347,7 @@ function Profile({ user }: ProfileProps) {
               <ChatRequestButton user={user} />
             </Layout.FlexRow>
           )}
-          {/* Mutual friends + shared traits sit on the same row, separated by
-              a "·" so the trait link doesn't float on its own line. */}
-          {(() => {
-            const { mutuals } = user as UserProfile;
-            const hasMutualFriends = mutuals && mutuals.length > 0;
-            const traits =
-              !featureFlags?.postsVerQ && !isMyProfile(user) && viewData
-                ? [...(viewData.mutual_interests ?? []), ...(viewData.mutual_personas ?? [])]
-                : [];
-            const hasTraits = traits.length > 0;
-            if (!hasMutualFriends && !hasTraits) return null;
-            return (
-              <>
-                <Layout.FlexRow alignItems="center" gap={6} style={{ flexWrap: 'wrap' }}>
-                  {hasMutualFriends && <MutualFriendsInfo mutualFriends={mutuals} />}
-                  {hasMutualFriends && hasTraits && (
-                    <Typo type="label-medium" color="MEDIUM_GRAY">
-                      ·
-                    </Typo>
-                  )}
-                  {hasTraits && (
-                    <SharedTraitsButton
-                      type="button"
-                      onClick={() => setShowSharedTraitsModal(true)}
-                    >
-                      <Typo type="label-medium" color="PRIMARY" fontWeight={500}>
-                        {t('mutual_traits_count', { count: traits.length })}
-                      </Typo>
-                    </SharedTraitsButton>
-                  )}
-                </Layout.FlexRow>
-                {hasTraits && (
-                  <InfoPopup
-                    isOpen={showSharedTraitsModal}
-                    onClose={() => setShowSharedTraitsModal(false)}
-                    title={t('mutual_traits_title')}
-                  >
-                    <MutualTraitsList traits={traits} isLoading={false} emptyText="" />
-                  </InfoPopup>
-                )}
-              </>
-            );
-          })()}
+          <MutualFriendsInfo mutualFriends={(user as UserProfile).mutuals} />
         </>
       )}
       {/* my-page actions: Edit Profile + Public/Private toggle (Q) or View As (W) */}
@@ -489,18 +444,6 @@ const ViewAsButton = styled(Button.Secondary)`
     color: ${({ theme }) => theme.PRIMARY};
     font-size: 14.4px;
   }
-`;
-
-const SharedTraitsButton = styled.button`
-  display: inline-flex;
-  align-items: center;
-  align-self: flex-start;
-  padding: 0;
-  border: none;
-  background: transparent;
-  cursor: pointer;
-  text-decoration: underline;
-  text-underline-offset: 2px;
 `;
 
 function AccountStatusBadge({ children }: { children: ReactNode }) {

--- a/src/components/profile/chip/CategoryChip.tsx
+++ b/src/components/profile/chip/CategoryChip.tsx
@@ -7,15 +7,29 @@ interface Props {
   category: ChipCategory;
   isSelected?: boolean;
   isCustom?: boolean;
+  /** Render in a distinct (pink) color to mark this chip as shared with the viewer. */
+  isShared?: boolean;
   onClick?: (e: MouseEvent) => void;
 }
 
-function CategoryChip({ label, category, isSelected = false, isCustom = false, onClick }: Props) {
-  const colors = CHIP_CATEGORY_COLORS[category] ?? {
+// Shared-trait highlight palette. Distinct from the standard purple so users
+// can tell at a glance which chips overlap with their own profile.
+const SHARED_COLORS = { bg: '#FFE6F4', text: '#FF00A8', border: '#FF00A8' };
+
+function CategoryChip({
+  label,
+  category,
+  isSelected = false,
+  isCustom = false,
+  isShared = false,
+  onClick,
+}: Props) {
+  const baseColors = CHIP_CATEGORY_COLORS[category] ?? {
     bg: '#F3E8FF',
     text: '#8700FF',
     border: '#8700FF',
   };
+  const colors = isShared ? SHARED_COLORS : baseColors;
 
   return (
     <ChipContainer

--- a/src/components/profile/more-about-bottom-sheet/MoreAboutBottomSheet.tsx
+++ b/src/components/profile/more-about-bottom-sheet/MoreAboutBottomSheet.tsx
@@ -1,6 +1,7 @@
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
 import BottomModal from '@components/_common/bottom-modal/BottomModal';
 import Icon from '@components/_common/icon/Icon';
 import { Layout, SvgIcon, Typo } from '@design-system';
@@ -47,6 +48,29 @@ function MoreAboutBottomSheet({
   const customChips = user?.custom_chips ?? [];
   const legacyPersonas = (user?.user_personas ?? []).map((p) => p.replace(/^#+/, ''));
 
+  // Build a set of chip names (normalized) the viewer also has — used to highlight
+  // shared traits in a distinct color. Mutual interests are category-specific so we
+  // index by `${category}::${normalized name}`; mutual personas are name-only.
+  const profileWithMutuals = user as Partial<UserProfile>;
+  const sharedKeys = new Set<string>();
+  (profileWithMutuals?.mutual_interests ?? []).forEach((m) => {
+    const key = m.category
+      ? `${m.category}::${normalizeChipText(m.content)}`
+      : `*::${normalizeChipText(m.content)}`;
+    sharedKeys.add(key);
+  });
+  const sharedPersonaNames = new Set(
+    (profileWithMutuals?.mutual_personas ?? []).map((m) => normalizeChipText(m.content)),
+  );
+
+  const isChipShared = (chip: string, categoryKey: string): boolean => {
+    if (sharedKeys.has(`${categoryKey}::${normalizeChipText(chip)}`)) return true;
+    if (sharedKeys.has(`*::${normalizeChipText(chip)}`)) return true;
+    if (categoryKey === 'online_persona' && sharedPersonaNames.has(normalizeChipText(chip)))
+      return true;
+    return false;
+  };
+
   const groupedByCategory = categories
     .map((cat) => {
       const stored = chipsByCategory[cat.key] ?? [];
@@ -67,6 +91,10 @@ function MoreAboutBottomSheet({
     })
     .filter((group) => group.chips.length > 0);
 
+  const hasAnySharedChip = groupedByCategory.some(({ category, chips }) =>
+    chips.some((chip) => isChipShared(chip, category.key)),
+  );
+
   return createPortal(
     <BottomModal visible={visible} onClose={onClose}>
       <Layout.FlexCol w="100%" ph={16} pv={16} gap={16}>
@@ -83,6 +111,17 @@ function MoreAboutBottomSheet({
           )}
         </Layout.FlexRow>
 
+        {/* Legend for shared-trait highlighting (only when viewing a non-self
+            profile and at least one trait overlaps with the viewer). */}
+        {!isMyPage && hasAnySharedChip && (
+          <Layout.FlexRow alignItems="center" gap={6}>
+            <SharedSwatch />
+            <Typo type="label-medium" color="MEDIUM_GRAY">
+              shared with you
+            </Typo>
+          </Layout.FlexRow>
+        )}
+
         {/* Chips grouped by category */}
         {groupedByCategory.map(({ category, chips }) => (
           <Layout.FlexCol key={category.key} gap={6}>
@@ -91,7 +130,13 @@ function MoreAboutBottomSheet({
             </Typo>
             <Layout.FlexRow w="100%" gap={8} style={{ flexWrap: 'wrap' }}>
               {chips.map((chip) => (
-                <CategoryChip key={chip} label={chip} category={category.key} isSelected />
+                <CategoryChip
+                  key={chip}
+                  label={chip}
+                  category={category.key}
+                  isSelected
+                  isShared={!isMyPage && isChipShared(chip, category.key)}
+                />
               ))}
             </Layout.FlexRow>
           </Layout.FlexCol>
@@ -103,3 +148,12 @@ function MoreAboutBottomSheet({
 }
 
 export default MoreAboutBottomSheet;
+
+const SharedSwatch = styled.span`
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 4px;
+  background-color: #ffe6f4;
+  border: 1px solid #ff00a8;
+`;

--- a/src/routes/settings/EditProfile.tsx
+++ b/src/routes/settings/EditProfile.tsx
@@ -13,7 +13,7 @@ import VisibilityToggle from '@components/check-in/visibility-toggle/VisibilityT
 import ChipCategorySection from '@components/profile/chip/ChipCategorySection';
 import { StyledEditProfileButton } from '@components/settings/SettingsButtons.styled';
 import SubHeader from '@components/sub-header/SubHeader';
-import { TITLE_HEADER_HEIGHT } from '@constants/layout';
+import { MAX_WINDOW_WIDTH, TITLE_HEADER_HEIGHT, Z_INDEX } from '@constants/layout';
 import { Colors, Layout, Typo } from '@design-system';
 import { useChipCategories } from '@hooks/useChipCategories';
 import { useDelayedVisible } from '@hooks/useDelayedVisible';
@@ -510,29 +510,31 @@ function EditProfile() {
                 {MAX_TOTAL_PROFILE_CHIPS} chips selected
               </Typo>
             </ChipCounterBar>
-            {categories.map((categoryInfo) => (
-              <Layout.FlexCol key={categoryInfo.key} gap={6} w="100%">
-                <ChipCategorySection
-                  categoryInfo={categoryInfo}
-                  selectedChips={draft.chipSelections[categoryInfo.key] || []}
-                  customChips={draft.customChips}
-                  onToggleChip={handleToggleChip}
-                  onAddCustomChip={handleAddCustomChip}
-                  onRemoveCustomChip={handleRemoveCustomChip}
-                />
-                {!featureFlags?.postsVerQ && (
-                  <VisibilityToggle
-                    value={
-                      draft.categoryVisibility[categoryInfo.key as CategoryKey] ??
-                      ComponentVisibility.PUBLIC
-                    }
-                    onChange={(v) =>
-                      handleSetCategoryVisibility(categoryInfo.key as CategoryKey, v)
-                    }
+            <ChipsScrollArea>
+              {categories.map((categoryInfo) => (
+                <Layout.FlexCol key={categoryInfo.key} gap={6} w="100%">
+                  <ChipCategorySection
+                    categoryInfo={categoryInfo}
+                    selectedChips={draft.chipSelections[categoryInfo.key] || []}
+                    customChips={draft.customChips}
+                    onToggleChip={handleToggleChip}
+                    onAddCustomChip={handleAddCustomChip}
+                    onRemoveCustomChip={handleRemoveCustomChip}
                   />
-                )}
-              </Layout.FlexCol>
-            ))}
+                  {!featureFlags?.postsVerQ && (
+                    <VisibilityToggle
+                      value={
+                        draft.categoryVisibility[categoryInfo.key as CategoryKey] ??
+                        ComponentVisibility.PUBLIC
+                      }
+                      onChange={(v) =>
+                        handleSetCategoryVisibility(categoryInfo.key as CategoryKey, v)
+                      }
+                    />
+                  )}
+                </Layout.FlexCol>
+              ))}
+            </ChipsScrollArea>
           </>
         )}
       </Layout.FlexCol>
@@ -574,15 +576,34 @@ const EditProfileTabButton = styled.button<{ $active: boolean }>`
   margin-bottom: -1px;
 `;
 
+// Position fixed (not sticky) so the counter sits reliably below the SubHeader
+// regardless of which scroll context is active or what overflow rules nearby
+// flex containers might enforce. Centered to honor the app's MAX_WINDOW_WIDTH.
+const CHIP_COUNTER_BAR_HEIGHT = 36;
+
 const ChipCounterBar = styled.div`
-  position: sticky;
+  position: fixed;
   top: ${TITLE_HEADER_HEIGHT}px;
-  z-index: 10;
+  left: 50%;
+  transform: translateX(-50%);
   width: 100%;
-  padding: 8px 12px;
+  max-width: ${MAX_WINDOW_WIDTH}px;
+  height: ${CHIP_COUNTER_BAR_HEIGHT}px;
+  z-index: ${Z_INDEX.TITLE_HEADER - 1};
+  padding: 8px 16px;
   background-color: ${Colors.WHITE};
   border-bottom: 1px solid ${Colors.LIGHT_GRAY};
   display: flex;
   align-items: center;
   justify-content: center;
+`;
+
+// Spacer pushes the chip categories below the fixed counter so the first
+// section isn't hidden behind it.
+const ChipsScrollArea = styled.div`
+  width: 100%;
+  padding-top: ${CHIP_COUNTER_BAR_HEIGHT}px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
 `;


### PR DESCRIPTION
## Three fixes in one

### 1. Restore plain `MutualFriendsInfo` row on profile

Reverts the inline \`N mutual traits · MutualFriendsInfo\` layout from #1311/#1312 — that wrapped \`MutualFriendsInfo\` in an outer FlexRow which broke its click target and visual alignment. Profile now shows the original \`<MutualFriendsInfo />\` (clickable as before) and drops the inline trait button entirely.

### 2. Highlight shared traits in the More About sheet

Surface shared traits where they're already discoverable — inside the \"See more details\" bottom sheet — instead of as a separate button. Shared chips render in a distinct pink color (\`#FF00A8\` border/text on \`#FFE6F4\` bg) vs the standard purple. A small swatch + \`shared with you\` legend appears at the top of the sheet whenever there's at least one shared chip.

Implementation:
- New \`isShared\` prop on \`CategoryChip\` swaps in a pink palette
- \`MoreAboutBottomSheet\` builds a Set of \`\${category}::\${normalized name}\` from \`mutual_interests\` (which carry category) and a name-only Set for \`mutual_personas\`, then asks \`isChipShared\` per chip

### 3. Fix the \`X / 20 chips selected\` counter floating mid-page

The previous \`position: sticky\` implementation broke unpredictably depending on overflow ancestors and rendered the counter mid-page between chip rows. Switched to \`position: fixed; top: TITLE_HEADER_HEIGHT\` centered with \`MAX_WINDOW_WIDTH\`. A \`ChipsScrollArea\` spacer pushes the first category below the bar so nothing tucks behind it.

## Verification (preview)

- Friend profile (adoor_2): plain \`wit_admin, adoor_3, and 3 more\` row, no inline trait link, mutual friends clickable
- More About sheet on adoor_2: \`shared with you\` legend visible; Instagram + Pinterest pink (shared favorites), YouTube purple (her favorite, not yours), Lurker pink (shared online persona)
- Edit Profile → Interests at 320px and 375px: counter pinned at top during scroll, no longer drifts