### PR TITLE
feat(visibility): remember each toggle's last selection independently

### DIFF
--- a/src/components/check-in/archive/ModifyVisibilityModal.tsx
+++ b/src/components/check-in/archive/ModifyVisibilityModal.tsx
@@ -6,6 +6,7 @@ import { DEFAULT_MARGIN } from '@constants/layout';
 import { Colors, Layout, Typo } from '@design-system';
 import { ComponentVisibility } from '@models/checkIn';
 import { CheckInComponentEntry, ComponentType } from '@models/checkInEntry';
+import { setLastVisibility, VisibilityMemoryKeys } from '@utils/visibilityMemory';
 import BatteryCardBody from './BatteryCardBody';
 import MoodCardBody from './MoodCardBody';
 import SongCardBody from './SongCardBody';
@@ -79,7 +80,16 @@ function ModifyVisibilityModal({ entry, onClose, onConfirm }: Props) {
           <Typo type="label-medium" color="MEDIUM_GRAY">
             {t('visibility_label')}
           </Typo>
-          <VisibilityToggle value={selected} onChange={setSelected} />
+          <VisibilityToggle
+            value={selected}
+            onChange={(v) => {
+              setSelected(v);
+              if (entry) {
+                const key = memoryKeyForComponent(entry.component);
+                if (key) setLastVisibility(key, v);
+              }
+            }}
+          />
         </Layout.FlexCol>
 
         <Layout.FlexRow w="100%" justifyContent="flex-end" gap={8}>
@@ -97,6 +107,21 @@ function ModifyVisibilityModal({ entry, onClose, onConfirm }: Props) {
       </Layout.FlexCol>
     </BottomModal>
   );
+}
+
+function memoryKeyForComponent(component: ComponentType): string | null {
+  switch (component) {
+    case ComponentType.BATTERY:
+      return VisibilityMemoryKeys.checkInBattery;
+    case ComponentType.MOOD:
+      return VisibilityMemoryKeys.checkInMood;
+    case ComponentType.SONG:
+      return VisibilityMemoryKeys.checkInSong;
+    case ComponentType.THOUGHT:
+      return VisibilityMemoryKeys.checkInThought;
+    default:
+      return null;
+  }
 }
 
 function renderPreview(entry: CheckInComponentEntry) {

--- a/src/components/check-in/update-quadrant/BatteryEditor.tsx
+++ b/src/components/check-in/update-quadrant/BatteryEditor.tsx
@@ -3,6 +3,11 @@ import VisibilityToggle from '@components/check-in/visibility-toggle/VisibilityT
 import SocialBatteryChip from '@components/profile/social-batter-chip/SocialBatteryChip';
 import { Layout } from '@design-system';
 import { ComponentVisibility, SocialBattery } from '@models/checkIn';
+import {
+  getLastVisibility,
+  setLastVisibility,
+  VisibilityMemoryKeys,
+} from '@utils/visibilityMemory';
 import EditorPopup from './EditorPopup';
 
 interface Props {
@@ -29,15 +34,24 @@ export default function BatteryEditor({
   onVisibilityChange,
 }: Props) {
   const [draftValue, setDraftValue] = useState<SocialBattery | null>(value);
-  const [draftVisibility, setDraftVisibility] = useState<ComponentVisibility>(visibility);
+  const [draftVisibility, setDraftVisibility] = useState<ComponentVisibility>(
+    () => getLastVisibility(VisibilityMemoryKeys.checkInBattery) ?? visibility,
+  );
 
   useEffect(() => {
     if (isOpen) {
       setDraftValue(value);
-      setDraftVisibility(visibility);
+      // Default to user's last picked visibility for this content type, falling
+      // back to the parent-supplied default for the very first share.
+      setDraftVisibility(getLastVisibility(VisibilityMemoryKeys.checkInBattery) ?? visibility);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen]);
+
+  const handleVisibilityChange = useCallback((v: ComponentVisibility) => {
+    setDraftVisibility(v);
+    setLastVisibility(VisibilityMemoryKeys.checkInBattery, v);
+  }, []);
 
   const handleShare = useCallback(() => {
     onChange(draftValue);
@@ -63,7 +77,7 @@ export default function BatteryEditor({
           />
         ))}
       </Layout.FlexRow>
-      <VisibilityToggle value={draftVisibility} onChange={setDraftVisibility} />
+      <VisibilityToggle value={draftVisibility} onChange={handleVisibilityChange} />
     </EditorPopup>
   );
 }

--- a/src/components/check-in/update-quadrant/MoodEditor.tsx
+++ b/src/components/check-in/update-quadrant/MoodEditor.tsx
@@ -4,6 +4,11 @@ import styled from 'styled-components';
 import VisibilityToggle from '@components/check-in/visibility-toggle/VisibilityToggle';
 import { Colors, Layout, Typo } from '@design-system';
 import { ComponentVisibility } from '@models/checkIn';
+import {
+  getLastVisibility,
+  setLastVisibility,
+  VisibilityMemoryKeys,
+} from '@utils/visibilityMemory';
 import EditorPopup from './EditorPopup';
 
 const MAX_MOOD_EMOJIS = 5;
@@ -30,12 +35,19 @@ export default function MoodEditor({
   onVisibilityChange,
 }: Props) {
   const [draftValue, setDraftValue] = useState<string[]>(value);
-  const [draftVisibility, setDraftVisibility] = useState<ComponentVisibility>(visibility);
+  const [draftVisibility, setDraftVisibility] = useState<ComponentVisibility>(
+    () => getLastVisibility(VisibilityMemoryKeys.checkInMood) ?? visibility,
+  );
+
+  const handleVisibilityChange = useCallback((v: ComponentVisibility) => {
+    setDraftVisibility(v);
+    setLastVisibility(VisibilityMemoryKeys.checkInMood, v);
+  }, []);
 
   useEffect(() => {
     if (isOpen) {
       setDraftValue(value);
-      setDraftVisibility(visibility);
+      setDraftVisibility(getLastVisibility(VisibilityMemoryKeys.checkInMood) ?? visibility);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen]);
@@ -104,7 +116,7 @@ export default function MoodEditor({
           previewConfig={{ showPreview: false }}
         />
       </Layout.FlexCol>
-      <VisibilityToggle value={draftVisibility} onChange={setDraftVisibility} />
+      <VisibilityToggle value={draftVisibility} onChange={handleVisibilityChange} />
     </EditorPopup>
   );
 }

--- a/src/components/check-in/update-quadrant/SongEditor.tsx
+++ b/src/components/check-in/update-quadrant/SongEditor.tsx
@@ -7,6 +7,11 @@ import { Layout, SvgIcon, Typo } from '@design-system';
 import useAsyncEffect from '@hooks/useAsyncEffect';
 import SpotifyManager from '@libs/SpotifyManager';
 import { ComponentVisibility } from '@models/checkIn';
+import {
+  getLastVisibility,
+  setLastVisibility,
+  VisibilityMemoryKeys,
+} from '@utils/visibilityMemory';
 import EditorPopup from './EditorPopup';
 
 interface Props {
@@ -31,17 +36,24 @@ export default function SongEditor({
   onVisibilityChange,
 }: Props) {
   const [draftTrackId, setDraftTrackId] = useState<string>(trackId);
-  const [draftVisibility, setDraftVisibility] = useState<ComponentVisibility>(visibility);
+  const [draftVisibility, setDraftVisibility] = useState<ComponentVisibility>(
+    () => getLastVisibility(VisibilityMemoryKeys.checkInSong) ?? visibility,
+  );
   const [query, setQuery] = useState('');
   const [trackList, setTrackList] = useState<Track[]>([]);
   const [searchError, setSearchError] = useState('');
   const [currentTrack, setCurrentTrack] = useState<Track | null>(null);
   const spotifyManager = SpotifyManager.getInstance();
 
+  const handleVisibilityChange = useCallback((v: ComponentVisibility) => {
+    setDraftVisibility(v);
+    setLastVisibility(VisibilityMemoryKeys.checkInSong, v);
+  }, []);
+
   useEffect(() => {
     if (isOpen) {
       setDraftTrackId(trackId);
-      setDraftVisibility(visibility);
+      setDraftVisibility(getLastVisibility(VisibilityMemoryKeys.checkInSong) ?? visibility);
       setQuery('');
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -161,7 +173,7 @@ export default function SongEditor({
           </Typo>
         )}
       </Layout.FlexCol>
-      <VisibilityToggle value={draftVisibility} onChange={setDraftVisibility} />
+      <VisibilityToggle value={draftVisibility} onChange={handleVisibilityChange} />
     </EditorPopup>
   );
 }

--- a/src/components/check-in/update-quadrant/ThoughtEditor.tsx
+++ b/src/components/check-in/update-quadrant/ThoughtEditor.tsx
@@ -3,6 +3,11 @@ import styled from 'styled-components';
 import VisibilityToggle from '@components/check-in/visibility-toggle/VisibilityToggle';
 import { Colors, Layout, Typo } from '@design-system';
 import { ComponentVisibility } from '@models/checkIn';
+import {
+  getLastVisibility,
+  setLastVisibility,
+  VisibilityMemoryKeys,
+} from '@utils/visibilityMemory';
 import EditorPopup from './EditorPopup';
 
 const MAX_LENGTH = 100;
@@ -29,12 +34,19 @@ export default function ThoughtEditor({
   onVisibilityChange,
 }: Props) {
   const [draftValue, setDraftValue] = useState<string>(value);
-  const [draftVisibility, setDraftVisibility] = useState<ComponentVisibility>(visibility);
+  const [draftVisibility, setDraftVisibility] = useState<ComponentVisibility>(
+    () => getLastVisibility(VisibilityMemoryKeys.checkInThought) ?? visibility,
+  );
+
+  const handleVisibilityChange = useCallback((v: ComponentVisibility) => {
+    setDraftVisibility(v);
+    setLastVisibility(VisibilityMemoryKeys.checkInThought, v);
+  }, []);
 
   useEffect(() => {
     if (isOpen) {
       setDraftValue(value);
-      setDraftVisibility(visibility);
+      setDraftVisibility(getLastVisibility(VisibilityMemoryKeys.checkInThought) ?? visibility);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen]);
@@ -73,7 +85,7 @@ export default function ThoughtEditor({
           </Typo>
         </Layout.FlexRow>
       </Layout.FlexCol>
-      <VisibilityToggle value={draftVisibility} onChange={setDraftVisibility} />
+      <VisibilityToggle value={draftVisibility} onChange={handleVisibilityChange} />
     </EditorPopup>
   );
 }

--- a/src/components/note/new-note-content/NewNoteContent.tsx
+++ b/src/components/note/new-note-content/NewNoteContent.tsx
@@ -14,6 +14,7 @@ import { UserSelector } from '@stores/user';
 import { CroppedImg, readFile } from '@utils/getCroppedImg';
 import { getMobileDeviceInfo } from '@utils/getUserAgent';
 import { processImageFromApp } from '@utils/imageHelpers';
+import { setLastVisibility, VisibilityMemoryKeys } from '@utils/visibilityMemory';
 import { FlexRow } from 'src/design-system/layouts';
 import NewNoteImageEdit from '../new-note-image-edit/NewNoteImageEdit';
 import NewNotePhotoUploadBottomSheet from '../new-note-photo-upload-bottom-sheet/NewNotePhotoUploadBottomSheet';
@@ -138,6 +139,12 @@ function NewNoteContent({
       ...prevNoteInfo,
       visibility: visibilities,
     }));
+    if (visibilities[0]) {
+      setLastVisibility(
+        VisibilityMemoryKeys.share.note,
+        visibilities[0] as unknown as ComponentVisibility,
+      );
+    }
   };
 
   const onCompleteImageCrop = (croppedImage: CroppedImg) => {

--- a/src/components/share/PhotoOfTheDayFlow.tsx
+++ b/src/components/share/PhotoOfTheDayFlow.tsx
@@ -10,6 +10,11 @@ import { PostVisibility, ShareType } from '@models/post';
 import { useBoundStore } from '@stores/useBoundStore';
 import { postNote } from '@utils/apis/note';
 import { CroppedImg, readFile } from '@utils/getCroppedImg';
+import {
+  getLastVisibility,
+  setLastVisibility,
+  VisibilityMemoryKeys,
+} from '@utils/visibilityMemory';
 import { MainScrollContainer } from '../../routes/Root';
 
 type Step = 'pick' | 'edit' | 'caption';
@@ -24,7 +29,13 @@ function PhotoOfTheDayFlow() {
   const [rawImageUrl, setRawImageUrl] = useState<string | undefined>(imageFromState);
   const [croppedImg, setCroppedImg] = useState<CroppedImg>();
   const [caption, setCaption] = useState('');
-  const [visibility, setVisibility] = useState<ComponentVisibility>(ComponentVisibility.FRIENDS);
+  const [visibility, setVisibilityState] = useState<ComponentVisibility>(
+    () => getLastVisibility(VisibilityMemoryKeys.share.photo) ?? ComponentVisibility.FRIENDS,
+  );
+  const setVisibility = (v: ComponentVisibility) => {
+    setVisibilityState(v);
+    setLastVisibility(VisibilityMemoryKeys.share.photo, v);
+  };
   const [isPosting, setIsPosting] = useState(false);
 
   const handlePickGallery = () => {

--- a/src/routes/notes/NewNote.tsx
+++ b/src/routes/notes/NewNote.tsx
@@ -5,6 +5,7 @@ import NewNoteHeader from '@components/note/new-note-header/NewNoteHeader';
 import { NewNoteForm, PostVisibility, ShareType } from '@models/post';
 import { useBoundStore } from '@stores/useBoundStore';
 import { convertImagesToFiles } from '@utils/convertImageToFiles';
+import { getLastVisibility, VisibilityMemoryKeys } from '@utils/visibilityMemory';
 import NewNoteContent from '../../components/note/new-note-content/NewNoteContent';
 import { MainScrollContainer } from '../Root';
 
@@ -22,9 +23,12 @@ function NewNote() {
   const title = !isEditing ? t('new_note') : t('edit_note');
   const noteId = location.state?.post?.id || '';
   const content = location.state?.post?.content || '';
-  const defaultVisibility = myProfile?.is_public
-    ? [PostVisibility.PUBLIC]
-    : [PostVisibility.FRIENDS];
+  const predetermined = myProfile?.is_public ? [PostVisibility.PUBLIC] : [PostVisibility.FRIENDS];
+  // For NEW notes, prefer the user's last-picked share visibility (per the
+  // "remember my last choice" rule). For EDITING an existing note, keep its
+  // original visibility so we don't silently flip what they previously shared.
+  const remembered = !isEditing ? getLastVisibility(VisibilityMemoryKeys.share.note) : undefined;
+  const defaultVisibility = remembered ? [remembered as unknown as PostVisibility] : predetermined;
   const visibility = location.state?.post?.visibility || defaultVisibility;
   const images = useMemo(() => location.state?.post?.images || [], [location.state?.post?.images]);
 

--- a/src/routes/settings/EditProfile.tsx
+++ b/src/routes/settings/EditProfile.tsx
@@ -29,6 +29,11 @@ import { useBoundStore } from '@stores/useBoundStore';
 import { createCustomChip, deleteCustomChip } from '@utils/apis/chips';
 import { editProfile, updateChipsByCategory } from '@utils/apis/my';
 import { CroppedImg, readFile } from '@utils/getCroppedImg';
+import {
+  getLastVisibility,
+  setLastVisibility,
+  VisibilityMemoryKeys,
+} from '@utils/visibilityMemory';
 import { shouldShowWidgetGuide } from '@utils/widgetInstallGuide';
 import { MainScrollContainer } from '../Root';
 
@@ -101,9 +106,17 @@ function EditProfile() {
 
   const parsed = parseExistingChips();
 
+  // Initial visibility per category: prefer the saved value (user's last
+  // explicit choice on this category), then fall back to whatever they last
+  // picked for any category, then to the predetermined default. Each category
+  // remembers its own choice so they don't get synced across categories.
   const initialCategoryVisibility = CATEGORY_KEYS.reduce((acc, key) => {
+    const saved = myProfile?.[`${key}_visibility` as keyof MyProfile] as
+      | ComponentVisibility
+      | undefined;
     acc[key] =
-      (myProfile?.[`${key}_visibility` as keyof MyProfile] as ComponentVisibility | undefined) ??
+      saved ??
+      getLastVisibility(VisibilityMemoryKeys.profile.chipCategory(key)) ??
       ComponentVisibility.PUBLIC;
     return acc;
   }, {} as Record<CategoryKey, ComponentVisibility>);
@@ -126,9 +139,18 @@ function EditProfile() {
     pronouns: myProfile?.pronouns ?? '',
     chipSelections: parsed.selections,
     customChips: parsed.customs,
-    name_visibility: myProfile?.name_visibility ?? ComponentVisibility.PUBLIC,
-    pronouns_visibility: myProfile?.pronouns_visibility ?? ComponentVisibility.PUBLIC,
-    bio_visibility: myProfile?.bio_visibility ?? ComponentVisibility.PUBLIC,
+    name_visibility:
+      myProfile?.name_visibility ??
+      getLastVisibility(VisibilityMemoryKeys.profile.name) ??
+      ComponentVisibility.PUBLIC,
+    pronouns_visibility:
+      myProfile?.pronouns_visibility ??
+      getLastVisibility(VisibilityMemoryKeys.profile.pronouns) ??
+      ComponentVisibility.PUBLIC,
+    bio_visibility:
+      myProfile?.bio_visibility ??
+      getLastVisibility(VisibilityMemoryKeys.profile.bio) ??
+      ComponentVisibility.PUBLIC,
     categoryVisibility: initialCategoryVisibility,
   });
 
@@ -225,6 +247,13 @@ function EditProfile() {
     value: ComponentVisibility,
   ) => {
     setDraft((prev) => ({ ...prev, [field]: value }));
+    const memoryKey =
+      field === 'name_visibility'
+        ? VisibilityMemoryKeys.profile.name
+        : field === 'pronouns_visibility'
+        ? VisibilityMemoryKeys.profile.pronouns
+        : VisibilityMemoryKeys.profile.bio;
+    setLastVisibility(memoryKey, value);
   };
 
   const handleSetCategoryVisibility = (categoryKey: CategoryKey, value: ComponentVisibility) => {
@@ -232,6 +261,7 @@ function EditProfile() {
       ...prev,
       categoryVisibility: { ...prev.categoryVisibility, [categoryKey]: value },
     }));
+    setLastVisibility(VisibilityMemoryKeys.profile.chipCategory(categoryKey), value);
   };
 
   const handleClickUpdate = () => {

--- a/src/utils/visibilityMemory.ts
+++ b/src/utils/visibilityMemory.ts
@@ -1,0 +1,59 @@
+import { ComponentVisibility } from '@models/checkIn';
+
+// Per-key remembered visibility, persisted to localStorage so each toggle
+// (check-in component, profile field, share flow, etc.) defaults to the
+// user's most recent choice for that specific content type. Predetermined
+// defaults only apply the very first time the user shares that type.
+//
+// localStorage in WKWebView / Android WebView is sandboxed to the app and
+// survives backgrounding, app restarts, device restarts, OS updates, and
+// app offload. It only resets on uninstall / reinstall, explicit Clear Data,
+// or new device — all acceptable here since the data is convenience, not
+// integrity.
+
+const STORAGE_KEY = 'whoamiTodayLastVisibility';
+
+type Store = Record<string, ComponentVisibility>;
+
+function readStore(): Store {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    return typeof parsed === 'object' && parsed !== null ? (parsed as Store) : {};
+  } catch {
+    return {};
+  }
+}
+
+export function getLastVisibility(key: string): ComponentVisibility | undefined {
+  return readStore()[key];
+}
+
+export function setLastVisibility(key: string, value: ComponentVisibility): void {
+  try {
+    const store = readStore();
+    store[key] = value;
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+  } catch {
+    // Best-effort — private mode / quota errors silently no-op.
+  }
+}
+
+/** Stable keys per content type so call sites can't accidentally diverge. */
+export const VisibilityMemoryKeys = {
+  checkInBattery: 'checkin.battery',
+  checkInMood: 'checkin.mood',
+  checkInSong: 'checkin.song',
+  checkInThought: 'checkin.thought',
+  share: {
+    photo: 'share.photo',
+    note: 'share.note',
+  },
+  profile: {
+    name: 'profile.name',
+    pronouns: 'profile.pronouns',
+    bio: 'profile.bio',
+    chipCategory: (category: string) => `profile.chip.${category}`,
+  },
+} as const;


### PR DESCRIPTION
## Why

Predetermined defaults (e.g., \"Public\" for songs) only make sense for the very first share. After that, every toggle should default to the user's most recent choice for that specific content type. Each toggle remembers its **own** choice — no syncing across types.

## How

New \`utils/visibilityMemory.ts\` module backed by \`localStorage\`. localStorage in WKWebView / Android WebView survives backgrounding, app restarts, OS updates, and offload — only resets on uninstall, explicit Clear Data, or new device. All acceptable for this convenience feature.

Stable keys per content type (in \`VisibilityMemoryKeys\`):
- \`checkin.battery\` / \`checkin.mood\` / \`checkin.song\` / \`checkin.thought\`
- \`share.photo\` / \`share.note\`
- \`profile.name\` / \`profile.pronouns\` / \`profile.bio\`
- \`profile.chip.<category>\` (one per chip category)

Each call site:
- **Initial state**: \`existingValue ?? lastUsed ?? predeterminedDefault\`
- **On change**: writes to memory

Edits to existing content (e.g., \`ModifyVisibilityModal\` for pinned archives, EditProfile fields with previously-saved values, NewNote when editing) preserve the existing value rather than silently flipping it; only the \"first ever\" share or fresh open with no saved value uses the remembered default.

## Files touched

- \`utils/visibilityMemory.ts\` — new
- \`components/check-in/update-quadrant/{Battery,Mood,Song,Thought}Editor.tsx\` — read \`lastUsed\` on open, write on change
- \`components/check-in/archive/ModifyVisibilityModal.tsx\` — write on change (initial keeps pin_visibility)
- \`components/share/PhotoOfTheDayFlow.tsx\` — read on init, write on change
- \`components/note/new-note-content/NewNoteContent.tsx\` — write on change
- \`routes/notes/NewNote.tsx\` — read on init for new notes (editing keeps original)
- \`routes/settings/EditProfile.tsx\` — read fallback for unsaved fields/categories, write on every change

## Verification

In preview, with \`localStorage\` cleared:
1. Open MoodEditor → defaults to Friends (parent-supplied default)
2. Pick Public → \`localStorage\` writes \`{\"checkin.mood\":\"public\"}\`
3. Close + reopen MoodEditor → defaults to Public ✓

Build clean (\`npx craco build\`).