### PR TITLE
feat(analytics): pick events + client-only flow funnel tracking

### DIFF
--- a/src/components/browse-mode/BrowseModePreviewBar.tsx
+++ b/src/components/browse-mode/BrowseModePreviewBar.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled, { createGlobalStyle } from 'styled-components';
 import { Colors, SvgIcon, Typo } from '@design-system';
+import { useTrackEvent } from '@hooks/useTrackEvent';
 import { useBoundStore } from '@stores/useBoundStore';
 import { clearLastPickedAt } from '@utils/browseModeActiveSession';
 
@@ -53,6 +54,7 @@ function BrowseModePreviewBar() {
   const openBrowseModePicker = useBoundStore((state) => state.openBrowseModePicker);
   const openToast = useBoundStore((state) => state.openToast);
   const userId = useBoundStore((state) => state.myProfile?.id);
+  const trackEvent = useTrackEvent();
 
   const isPreview = activeBrowseMode?.kind === 'custom' && activeBrowseMode.id === -1;
   // Throttle "blocked click" toasts: rapid taps would otherwise spam the
@@ -110,6 +112,7 @@ function BrowseModePreviewBar() {
   if (!isPreview) return null;
 
   const handleExit = () => {
+    trackEvent('browse_mode_preview_exited');
     clearActiveBrowseMode();
     // The user explicitly abandoned the preview — wipe last_picked_at so
     // the next page-load auto-prompts again. Without this, the freshness

--- a/src/components/browse-mode/BrowseModeSessionPrompt.tsx
+++ b/src/components/browse-mode/BrowseModeSessionPrompt.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
@@ -8,8 +8,8 @@ import BottomModal from '@components/_common/bottom-modal/BottomModal';
 import { SocialBatteryChipAssets } from '@components/profile/social-batter-chip/SocialBatteryChip.contants';
 import { BUILT_IN_BROWSE_MODES } from '@constants/browseMode';
 import { Colors, SvgIcon, Typo } from '@design-system';
-import { usePostAppMessage } from '@hooks/useAppMessage';
 import { usePreventScroll } from '@hooks/usePreventScroll';
+import { useTrackEvent } from '@hooks/useTrackEvent';
 import {
   ActiveBrowseMode,
   BrowseModeConfig,
@@ -61,11 +61,19 @@ function BrowseModeSessionPrompt({
   // Battery labels are top-level (`social_battery.<key>`) — separate `t` without a keyPrefix.
   const [tRoot] = useTranslation('translation');
   const navigate = useNavigate();
-  const postAppMessage = usePostAppMessage();
+  const trackEvent = useTrackEvent();
   usePreventScroll(fullScreen && visible);
 
   const [syncBattery, setSyncBattery] = useState<boolean>(readSyncPref);
   const [customizeOpen, setCustomizeOpen] = useState(false);
+  // Tracks customize-sheet outcome so closeCustomize knows whether to fire
+  // an "abandoned" event. Set by the save / apply-without-saving handlers
+  // before they call closeCustomize.
+  const customizeOutcomeRef = useRef<'pending' | 'saved' | 'applied'>('pending');
+  // True iff the user has activated a mode in this picker session — used
+  // by the dismiss handler to decide between `picked` (skip event suppressed)
+  // and `skipped`. applyMode and apply-without-saving both flip this on.
+  const pickedInSessionRef = useRef(false);
   // When set, BrowseModeCustomizeSheet opens in EDIT mode prefilled with this
   // preset's values. Cleared on close so the next "Add a new browsing mode"
   // tap starts from the active mode again.
@@ -94,10 +102,14 @@ function BrowseModeSessionPrompt({
   const deleteCustomBrowseModePreset = useBoundStore((state) => state.deleteCustomBrowseModePreset);
   const openToast = useBoundStore((state) => state.openToast);
 
-  const handleSyncToggle = useCallback((next: boolean) => {
-    setSyncBattery(next);
-    writeSyncPref(next);
-  }, []);
+  const handleSyncToggle = useCallback(
+    (next: boolean) => {
+      setSyncBattery(next);
+      writeSyncPref(next);
+      trackEvent('browse_mode_sync_pref_changed', { value: next ? 'on' : 'off' });
+    },
+    [trackEvent],
+  );
 
   // Hydrate hidden mode keys from localStorage every time the picker opens —
   // captures changes made elsewhere (e.g. another tab) without requiring us
@@ -107,6 +119,46 @@ function BrowseModeSessionPrompt({
       setHiddenModeKeys(readHiddenModes(myProfile.id));
     }
   }, [visible, myProfile?.id]);
+
+  // Picker funnel: prompt shown vs skipped vs picked.
+  // Reset session flags every time the picker becomes visible so the next
+  // close-without-pick correctly counts as `skipped`. `full_screen` flag
+  // distinguishes the auto-prompt path from the sidebar manual-open path,
+  // since their conversion rates probably differ.
+  useEffect(() => {
+    if (visible) {
+      pickedInSessionRef.current = false;
+      trackEvent('browse_mode_prompt_shown', {
+        full_screen: fullScreen ? 'true' : 'false',
+      });
+    }
+  }, [visible, fullScreen, trackEvent]);
+
+  const handleDismiss = useCallback(() => {
+    // Skip event only fires when nothing was picked — picks are
+    // mutually exclusive with skips in the funnel.
+    if (!pickedInSessionRef.current) {
+      trackEvent('browse_mode_prompt_skipped', {
+        full_screen: fullScreen ? 'true' : 'false',
+      });
+    }
+    onDismiss();
+  }, [fullScreen, onDismiss, trackEvent]);
+
+  // Wraps setCustomizeOpen(true) so every entry path into the customize
+  // sheet (new / edit / clone / restore-from-snapshot) emits a single
+  // `customize_opened` event with a `source` param distinguishing them.
+  // The outcome ref resets to `pending` here so the abandon-tracking in
+  // closeCustomize starts fresh per entry.
+  // Defined ahead of the customize-restore useEffect that depends on it.
+  const openCustomize = useCallback(
+    (source: 'new' | 'edit' | 'clone_built_in' | 'restore_snapshot') => {
+      customizeOutcomeRef.current = 'pending';
+      setCustomizeOpen(true);
+      trackEvent('browse_mode_customize_opened', { source });
+    },
+    [trackEvent],
+  );
 
   // When the picker opens with a customize-restore snapshot in the store
   // (the preview bar's exit-X path), re-enter the customize sheet with the
@@ -122,9 +174,15 @@ function BrowseModeSessionPrompt({
       : null;
     setEditingPreset(editingMatch);
     setCloneSeed({ config, name, description, default_battery });
-    setCustomizeOpen(true);
+    openCustomize('restore_snapshot');
     setCustomizeRestoreSnapshot(null);
-  }, [visible, customizeRestoreSnapshot, customPresets, setCustomizeRestoreSnapshot]);
+  }, [
+    visible,
+    customizeRestoreSnapshot,
+    customPresets,
+    setCustomizeRestoreSnapshot,
+    openCustomize,
+  ]);
 
   const persistHiddenModes = useCallback(
     (next: HiddenModeKey[]) => {
@@ -136,18 +194,27 @@ function BrowseModeSessionPrompt({
 
   const handleHideMode = useCallback(
     (modeKey: HiddenModeKey) => {
+      // Idempotent: only track when the key is genuinely added (not a no-op
+      // re-hide) so the count reflects actual user actions, not React StrictMode
+      // double-renders.
+      if (!hiddenModeKeys.includes(modeKey)) {
+        trackEvent('browse_mode_built_in_hidden', { mode_id: String(modeKey) });
+      }
       persistHiddenModes(
         hiddenModeKeys.includes(modeKey) ? hiddenModeKeys : [...hiddenModeKeys, modeKey],
       );
     },
-    [hiddenModeKeys, persistHiddenModes],
+    [hiddenModeKeys, persistHiddenModes, trackEvent],
   );
 
   const handleShowMode = useCallback(
     (modeKey: HiddenModeKey) => {
+      if (hiddenModeKeys.includes(modeKey)) {
+        trackEvent('browse_mode_built_in_unhidden', { mode_id: String(modeKey) });
+      }
       persistHiddenModes(hiddenModeKeys.filter((x) => x !== modeKey));
     },
-    [hiddenModeKeys, persistHiddenModes],
+    [hiddenModeKeys, persistHiddenModes, trackEvent],
   );
 
   const handleCloneBuiltIn = useCallback(
@@ -161,9 +228,9 @@ function BrowseModeSessionPrompt({
         default_battery: built.suggestedBattery,
       });
       setEditingPreset(null);
-      setCustomizeOpen(true);
+      openCustomize('clone_built_in');
     },
-    [t],
+    [t, openCustomize],
   );
 
   const applyMode = useCallback(
@@ -195,6 +262,7 @@ function BrowseModeSessionPrompt({
           updated_at: '',
         });
       }
+      pickedInSessionRef.current = true;
       if (myProfile?.id) {
         saveLastPickedMode(myProfile.id, mode);
         // Stamp the pick time. The auto-prompt's 15-minute freshness window
@@ -220,10 +288,7 @@ function BrowseModeSessionPrompt({
         eventParams.preset_id = mode.id;
         logBrowseModePick({ kind: 'custom', preset_id: mode.id });
       }
-      postAppMessage('ANALYTICS_TRACK_EVENT', {
-        name: 'browse_mode_picked',
-        params: eventParams,
-      });
+      trackEvent('browse_mode_picked', eventParams);
 
       let batteryApplied: SocialBattery | null = null;
       if (syncBattery && suggestedBattery) {
@@ -300,7 +365,7 @@ function BrowseModeSessionPrompt({
       navigate,
       onFinish,
       openToast,
-      postAppMessage,
+      trackEvent,
       setActiveBuiltIn,
       setActiveCustom,
       syncBattery,
@@ -334,29 +399,41 @@ function BrowseModeSessionPrompt({
   );
 
   const closeCustomize = useCallback(() => {
+    // Abandon = close without `save` or `apply_without_saving` having
+    // fired. Lets us measure how many users open the customize sheet
+    // and walk away without committing — a UX pain signal.
+    if (customizeOutcomeRef.current === 'pending') {
+      trackEvent('browse_mode_customize_abandoned');
+    }
+    customizeOutcomeRef.current = 'pending';
     setCustomizeOpen(false);
     setEditingPreset(null);
     setCloneSeed(null);
-  }, []);
+  }, [trackEvent]);
 
-  const handleEditPreset = useCallback((preset: CustomBrowseModePreset) => {
-    setCloneSeed(null);
-    setEditingPreset(preset);
-    setCustomizeOpen(true);
-  }, []);
+  const handleEditPreset = useCallback(
+    (preset: CustomBrowseModePreset) => {
+      setCloneSeed(null);
+      setEditingPreset(preset);
+      openCustomize('edit');
+    },
+    [openCustomize],
+  );
 
   const handleDeletePreset = useCallback((preset: CustomBrowseModePreset) => {
     setPendingDeletePreset(preset);
   }, []);
 
   const handleCustomizeSaved = useCallback(async () => {
+    customizeOutcomeRef.current = 'saved';
+    trackEvent('browse_mode_customize_saved');
     // Save just persists the preset — no auto-activation. The picker stays
     // open and the new / edited preset appears in the saved-modes list;
     // the user explicitly picks it to start browsing in it. Keeps the
     // "create" flow distinct from the "switch" flow so we don't surprise
     // them with a mode change they didn't ask for.
     closeCustomize();
-  }, [closeCustomize]);
+  }, [closeCustomize, trackEvent]);
 
   const handleCustomizeApplyWithoutSaving = useCallback(
     async (snapshot: {
@@ -392,19 +469,18 @@ function BrowseModeSessionPrompt({
       // configuration to use right now — bump the freshness timer so the
       // auto-prompt doesn't re-fire mid-preview.
       if (myProfile?.id) writeLastPickedAt(myProfile.id);
+      pickedInSessionRef.current = true;
+      customizeOutcomeRef.current = 'applied';
       // Pick log + Firebase event (best-effort, mirrors applyMode).
       logBrowseModePick({ kind: 'apply_without_saving' });
-      postAppMessage('ANALYTICS_TRACK_EVENT', {
-        name: 'browse_mode_picked',
-        params: {
-          kind: 'apply_without_saving',
-          keep_picker_open: 'false',
-          battery_synced: 'false',
-        },
+      trackEvent('browse_mode_picked', {
+        kind: 'apply_without_saving',
+        keep_picker_open: 'false',
+        battery_synced: 'false',
       });
       onFinish();
     },
-    [closeCustomize, editingPreset?.id, myProfile?.id, onFinish, postAppMessage],
+    [closeCustomize, editingPreset?.id, myProfile?.id, onFinish, trackEvent],
   );
 
   const handleConfirmDelete = useCallback(async () => {
@@ -431,9 +507,12 @@ function BrowseModeSessionPrompt({
       onOpenCustomize={() => {
         setCloneSeed(null);
         setEditingPreset(null);
-        setCustomizeOpen(true);
+        openCustomize('new');
       }}
-      onOpenWishlist={() => setWishlistOpen(true)}
+      onOpenWishlist={() => {
+        setWishlistOpen(true);
+        trackEvent('browse_mode_wishlist_opened');
+      }}
       onCloneBuiltIn={handleCloneBuiltIn}
       onEditPreset={handleEditPreset}
       onHideMode={handleHideMode}
@@ -451,7 +530,7 @@ function BrowseModeSessionPrompt({
                 <SkipBar>
                   <SkipButton
                     type="button"
-                    onClick={onDismiss}
+                    onClick={handleDismiss}
                     aria-label={String(t('full_screen.skip'))}
                   >
                     <Typo type="label-large" color="MEDIUM_GRAY">
@@ -466,7 +545,10 @@ function BrowseModeSessionPrompt({
             document.body,
           )
         : createPortal(
-            <BottomModal visible={visible && !customizeOpen && !wishlistOpen} onClose={onDismiss}>
+            <BottomModal
+              visible={visible && !customizeOpen && !wishlistOpen}
+              onClose={handleDismiss}
+            >
               {stepContent}
             </BottomModal>,
             document.body,

--- a/src/components/browse-mode/BrowseModeSessionPrompt.tsx
+++ b/src/components/browse-mode/BrowseModeSessionPrompt.tsx
@@ -8,6 +8,7 @@ import BottomModal from '@components/_common/bottom-modal/BottomModal';
 import { SocialBatteryChipAssets } from '@components/profile/social-batter-chip/SocialBatteryChip.contants';
 import { BUILT_IN_BROWSE_MODES } from '@constants/browseMode';
 import { Colors, SvgIcon, Typo } from '@design-system';
+import { usePostAppMessage } from '@hooks/useAppMessage';
 import { usePreventScroll } from '@hooks/usePreventScroll';
 import {
   ActiveBrowseMode,
@@ -17,6 +18,7 @@ import {
 } from '@models/browseMode';
 import { ComponentVisibility, DEFAULT_VISIBILITY, SocialBattery } from '@models/checkIn';
 import { useBoundStore } from '@stores/useBoundStore';
+import { logBrowseModePick } from '@utils/apis/browseMode';
 import { postCheckIn } from '@utils/apis/checkIn';
 import { writeLastPickedAt } from '@utils/browseModeActiveSession';
 import { HiddenModeKey, readHiddenModes, writeHiddenModes } from '@utils/browseModeHiddenModes';
@@ -59,6 +61,7 @@ function BrowseModeSessionPrompt({
   // Battery labels are top-level (`social_battery.<key>`) — separate `t` without a keyPrefix.
   const [tRoot] = useTranslation('translation');
   const navigate = useNavigate();
+  const postAppMessage = usePostAppMessage();
   usePreventScroll(fullScreen && visible);
 
   const [syncBattery, setSyncBattery] = useState<boolean>(readSyncPref);
@@ -200,6 +203,28 @@ function BrowseModeSessionPrompt({
         writeLastPickedAt(myProfile.id);
       }
 
+      // Append-only pick log on the backend (research analytics ground
+      // truth) + a parallel Firebase Analytics event via the WebView
+      // bridge. Both fire-and-forget; failures are silent so analytics
+      // never blocks the UI.
+      const eventParams: Record<string, string | number> = {
+        kind: mode.kind,
+        keep_picker_open: keepPickerOpen ? 'true' : 'false',
+        battery_synced: syncBattery ? 'true' : 'false',
+      };
+      if (mode.kind === 'built_in') {
+        eventParams.mode_id = mode.id;
+        logBrowseModePick({ kind: 'built_in', built_in_id: mode.id });
+      } else {
+        eventParams.mode_id = `custom:${mode.id}`;
+        eventParams.preset_id = mode.id;
+        logBrowseModePick({ kind: 'custom', preset_id: mode.id });
+      }
+      postAppMessage('ANALYTICS_TRACK_EVENT', {
+        name: 'browse_mode_picked',
+        params: eventParams,
+      });
+
       let batteryApplied: SocialBattery | null = null;
       if (syncBattery && suggestedBattery) {
         try {
@@ -275,6 +300,7 @@ function BrowseModeSessionPrompt({
       navigate,
       onFinish,
       openToast,
+      postAppMessage,
       setActiveBuiltIn,
       setActiveCustom,
       syncBattery,
@@ -366,9 +392,19 @@ function BrowseModeSessionPrompt({
       // configuration to use right now — bump the freshness timer so the
       // auto-prompt doesn't re-fire mid-preview.
       if (myProfile?.id) writeLastPickedAt(myProfile.id);
+      // Pick log + Firebase event (best-effort, mirrors applyMode).
+      logBrowseModePick({ kind: 'apply_without_saving' });
+      postAppMessage('ANALYTICS_TRACK_EVENT', {
+        name: 'browse_mode_picked',
+        params: {
+          kind: 'apply_without_saving',
+          keep_picker_open: 'false',
+          battery_synced: 'false',
+        },
+      });
       onFinish();
     },
-    [closeCustomize, editingPreset?.id, myProfile?.id, onFinish],
+    [closeCustomize, editingPreset?.id, myProfile?.id, onFinish, postAppMessage],
   );
 
   const handleConfirmDelete = useCallback(async () => {

--- a/src/components/browse-mode/BrowseModeWishlistSheet.tsx
+++ b/src/components/browse-mode/BrowseModeWishlistSheet.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
@@ -6,6 +6,7 @@ import BottomModal from '@components/_common/bottom-modal/BottomModal';
 import BottomModalActionButton from '@components/_common/bottom-modal/BottomModalActionButton';
 import Icon from '@components/_common/icon/Icon';
 import { Colors, Layout, Typo } from '@design-system';
+import { useTrackEvent } from '@hooks/useTrackEvent';
 import { useBoundStore } from '@stores/useBoundStore';
 import { submitBrowseModeWishlist } from '@utils/apis/browseMode';
 
@@ -27,13 +28,19 @@ interface BrowseModeWishlistSheetProps {
 function BrowseModeWishlistSheet({ visible, onClose }: BrowseModeWishlistSheetProps) {
   const [t] = useTranslation('translation', { keyPrefix: 'browse_mode' });
   const openToast = useBoundStore((state) => state.openToast);
+  const trackEvent = useTrackEvent();
   const [text, setText] = useState('');
   const [state, setState] = useState<'idle' | 'sending' | 'error'>('idle');
+  // Tracks whether a submit succeeded in this open session — used to
+  // decide between a `submitted` (positive) vs `abandoned` (negative)
+  // event when the sheet closes.
+  const submittedRef = useRef(false);
 
   useEffect(() => {
     if (visible) {
       setText('');
       setState('idle');
+      submittedRef.current = false;
     }
   }, [visible]);
 
@@ -43,6 +50,8 @@ function BrowseModeWishlistSheet({ visible, onClose }: BrowseModeWishlistSheetPr
     setState('sending');
     try {
       await submitBrowseModeWishlist(trimmed);
+      submittedRef.current = true;
+      trackEvent('browse_mode_wishlist_submitted', { length: trimmed.length });
       openToast({ message: String(t('wishlist.sent_toast')) });
       onClose();
     } catch {
@@ -50,8 +59,17 @@ function BrowseModeWishlistSheet({ visible, onClose }: BrowseModeWishlistSheetPr
     }
   };
 
+  const handleClose = useCallback(() => {
+    if (!submittedRef.current) {
+      // `length` lets us distinguish "opened, typed something, abandoned"
+      // from "opened, typed nothing, closed" — different UX signals.
+      trackEvent('browse_mode_wishlist_abandoned', { length: text.trim().length });
+    }
+    onClose();
+  }, [onClose, text, trackEvent]);
+
   return createPortal(
-    <BottomModal visible={visible} onClose={onClose} heightMode="content">
+    <BottomModal visible={visible} onClose={handleClose} heightMode="content">
       <Layout.FlexCol alignItems="center" w="100%" bgColor="WHITE" pb={32}>
         <Icon name="home_indicator" />
         <Layout.FlexCol alignItems="center" gap={4} pt={4} ph={16}>

--- a/src/components/share/MissionOfTheDay.tsx
+++ b/src/components/share/MissionOfTheDay.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import styled from 'styled-components';
 import { Layout, Typo } from '@design-system';
 import { useMissions } from '@hooks/useMissions';
+import { useTrackEvent } from '@hooks/useTrackEvent';
 
 export type MissionType = 'song' | 'question' | 'text' | 'compliment';
 
@@ -42,6 +43,23 @@ export function markMissionCompleted(): void {
     MISSION_STORAGE_KEY,
     JSON.stringify({ day: getDayOfYear(), count: current + 1 }),
   );
+  // Fire the completion event directly through the WebView bridge —
+  // this util is called from non-hook contexts (post-publish handlers in
+  // Share.tsx / NewNoteHeader.tsx / NewResponse.tsx) so we can't use
+  // useTrackEvent here. Bridge call mirrors what useTrackEvent emits.
+  if (typeof window !== 'undefined' && window.ReactNativeWebView) {
+    try {
+      window.ReactNativeWebView.postMessage(
+        JSON.stringify({
+          actionType: 'ANALYTICS_TRACK_EVENT',
+          name: 'mission_completed',
+          params: { attempt_number: current + 1 },
+        }),
+      );
+    } catch {
+      /* best-effort analytics */
+    }
+  }
 }
 
 interface Props {
@@ -52,11 +70,18 @@ function MissionOfTheDay({ onDoMission }: Props) {
   const { missions } = useMissions();
   const todayMission = missions[getDayOfYear() % missions.length];
   const [attempts, setAttempts] = useState(getAttemptsToday());
+  const trackEvent = useTrackEvent();
 
   const allUsed = attempts >= MAX_ATTEMPTS;
 
   const handleDoIt = () => {
     if (allUsed) return;
+    // Funnel start: paired with mission_completed in markMissionCompleted.
+    // Diff = users who tapped "Do it" but never published — abandon rate.
+    trackEvent('mission_attempt_started', {
+      mission_type: todayMission.type,
+      attempt_number: attempts + 1,
+    });
     onDoMission(todayMission);
   };
 

--- a/src/hooks/useCheckInFreshnessPrompt.ts
+++ b/src/hooks/useCheckInFreshnessPrompt.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { FeatureFlagKey } from '@constants/featureFlag';
 import { useGetAppMessage } from '@hooks/useAppMessage';
+import { useTrackEvent } from '@hooks/useTrackEvent';
 import { SetAppStateData } from '@models/app';
 import { MyCheckIn } from '@models/checkIn';
 import { useBoundStore } from '@stores/useBoundStore';
@@ -67,6 +68,7 @@ export function useCheckInFreshnessPrompt() {
   const [shouldShow, setShouldShow] = useState(false);
   const continuousTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingTriggerRef = useRef(false);
+  const trackEvent = useTrackEvent();
 
   const myProfile = useBoundStore((state) => state.myProfile);
   const featureFlags = useBoundStore((state) => state.featureFlags);
@@ -104,9 +106,10 @@ export function useCheckInFreshnessPrompt() {
       pendingTriggerRef.current = false;
       if (canShowPrompt()) {
         setShouldShow(true);
+        trackEvent('check_in_freshness_prompt_shown');
       }
     }
-  }, [checkIn, canShowPrompt]);
+  }, [checkIn, canShowPrompt, trackEvent]);
 
   // 연속 사용 타이머 시작
   const startContinuousTimer = useCallback(() => {
@@ -199,11 +202,12 @@ export function useCheckInFreshnessPrompt() {
   // dismiss 핸들러
   const dismiss = useCallback(() => {
     setShouldShow(false);
+    trackEvent('check_in_freshness_prompt_dismissed');
     if (userId) {
       saveDismissTimestamp(userId);
     }
     startContinuousTimer();
-  }, [userId, startContinuousTimer]);
+  }, [userId, startContinuousTimer, trackEvent]);
 
   return { shouldShow, dismiss, checkIn };
 }

--- a/src/hooks/useTrackEvent.ts
+++ b/src/hooks/useTrackEvent.ts
@@ -1,0 +1,32 @@
+import { useCallback } from 'react';
+import { usePostAppMessage } from './useAppMessage';
+
+/**
+ * Fire-and-forget Firebase Analytics event via the WebView bridge.
+ *
+ * The web frontend itself doesn't initialize the Firebase Analytics SDK
+ * directly — it sends an `ANALYTICS_TRACK_EVENT` postMessage that the
+ * native app forwards to `analytics().logEvent(...)` (see
+ * WhoamI-Today-app/src/hooks/useWebView.ts and useAnalytics.tsx).
+ *
+ * Use this for behaviors that DON'T leave a backend trace and would
+ * otherwise be invisible to research analytics — e.g. modal dismissals,
+ * abandoned drafts, picker skip-rate, settings toggles. If the action
+ * already mutates a backend model, query the model instead.
+ *
+ * In a non-app context (browser) the message is a no-op, which is
+ * fine — the project is mobile-first and almost all users are in the
+ * RN WebView.
+ */
+export const useTrackEvent = () => {
+  const postAppMessage = usePostAppMessage();
+  return useCallback(
+    (name: string, params?: Record<string, string | number>) => {
+      postAppMessage('ANALYTICS_TRACK_EVENT', {
+        name,
+        ...(params ? { params } : {}),
+      });
+    },
+    [postAppMessage],
+  );
+};

--- a/src/utils/apis/browseMode.ts
+++ b/src/utils/apis/browseMode.ts
@@ -48,3 +48,23 @@ export const markBrowseModePresetUsed = async (id: number): Promise<CustomBrowse
 export const submitBrowseModeWishlist = async (content: string): Promise<void> => {
   await axios.post(`/browse_mode/wishlist/`, { content });
 };
+
+export type BrowseModePickEventPayload =
+  | { kind: 'built_in'; built_in_id: 'very_social' | 'selectively_social' | 'quiet' }
+  | { kind: 'custom'; preset_id: number }
+  | { kind: 'apply_without_saving' };
+
+/**
+ * Append-only pick log. Fired every time the user actively activates a mode
+ * (built-in / custom / apply-without-saving). Skips and dismisses are NOT
+ * logged. Used by analytics to count picks, switches, and distinct types.
+ *
+ * Best-effort — callers should not block UI on this; failures are silent.
+ */
+export const logBrowseModePick = async (payload: BrowseModePickEventPayload): Promise<void> => {
+  try {
+    await axios.post(`/browse_mode/picks/`, payload);
+  } catch {
+    /* analytics is best-effort */
+  }
+};


### PR DESCRIPTION
## Summary

End-to-end instrumentation of behaviors that DON'T leave a backend trace. Pairs with the backend \`BrowseModePickEvent\` model + the app repo's WebView↔Firebase bridge wiring.

### What gets tracked now

**Browse mode picker funnel** (the original ask):
- \`browse_mode_picked\` — every active mode pick (built-in / custom / apply-without-saving). Dual-write to \`POST /api/browse_mode/picks/\` (research ground truth) and Firebase (dashboard convenience)
- \`browse_mode_prompt_shown\` / \`_skipped\` — auto-prompt funnel (with \`full_screen\` param distinguishing auto-prompt from sidebar manual-open)
- \`browse_mode_customize_opened\` (with \`source\`: new / edit / clone_built_in / restore_snapshot) / \`_saved\` / \`_abandoned\`
- \`browse_mode_wishlist_opened\` / \`_submitted\` / \`_abandoned\`
- \`browse_mode_built_in_hidden\` / \`_unhidden\` (Edit list)
- \`browse_mode_sync_pref_changed\` (battery sync toggle)
- \`browse_mode_preview_exited\` (apply-without-saving abandoned)

**Other client-only flows** (none of these hit any backend endpoint):
- \`check_in_freshness_prompt_shown\` / \`_dismissed\`
- \`mission_attempt_started\` (with \`mission_type\`, \`attempt_number\`) / \`mission_completed\`

### Why this matters

User pointed out the obvious: events that mutate DB are already answerable from backend SQL. Frontend tracking should focus exclusively on actions that DON'T persist — modal dismissals, abandoned drafts, picker skip-rate, settings toggles. That's the gap this PR closes.

### Architecture
- New \`useTrackEvent\` helper hook centralizes the \`postAppMessage('ANALYTICS_TRACK_EVENT', ...)\` shape so calls are clean: \`trackEvent('foo', { bar: 'baz' })\`
- All events fire-and-forget. No UI blocking on analytics
- Browse mode picks dual-write: backend \`POST /api/browse_mode/picks/\` (research analytics) + Firebase event (dashboard funnels)

### Depends on
- WhoamI-Today-backend#989 (\`BrowseModePickEvent\` model + endpoint)
- WhoamI-Today-app#161 (WebView bridge wiring — without this, ANALYTICS_TRACK_EVENT messages get dropped)

## Test plan
- [x] \`npx craco build\` clean (TS + ESLint)
- [x] No console errors during preview reloads
- [ ] Once app PR ships in next mobile release: verify events arrive in Firebase DebugView