### PR TITLE
feat(analytics): instrument CommonDialog with confirm/cancel/dismiss events

### DIFF
--- a/src/components/_common/alert-dialog/common-dialog/CommonDialog.tsx
+++ b/src/components/_common/alert-dialog/common-dialog/CommonDialog.tsx
@@ -1,5 +1,6 @@
-import { ComponentProps } from 'react';
+import { ComponentProps, useCallback, useEffect, useRef } from 'react';
 import { ColorKeys, Layout, Typo } from '@design-system';
+import { useTrackEvent } from '@hooks/useTrackEvent';
 import { StyledCommonDialog } from './CommonDialog.styled';
 
 export interface CommonDialogProps {
@@ -14,6 +15,30 @@ export interface CommonDialogProps {
   onClickConfirm: () => void;
   onClickCancel?: () => void;
   onClickClose: () => void;
+  /**
+   * Stable identifier used to tag analytics events for this dialog. Lets
+   * us tell e.g. "delete preset confirm" apart from "block user confirm"
+   * in Firebase. Recommend snake_case and unique-per-dialog-purpose. If
+   * omitted, the dialog's `title` string is used as a fallback — works
+   * but couples analytics keys to copy changes, so explicit is better.
+   */
+  trackingId?: string;
+}
+
+/**
+ * Generates an analytics-safe id from arbitrary text. Lower-case, replaces
+ * runs of non-word characters with `_`, trims leading/trailing `_`. Cap at
+ * 60 chars so Firebase doesn't reject it (their event-param length limit
+ * is 100, but we leave headroom).
+ */
+function fallbackId(title: string): string {
+  return (
+    title
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '_')
+      .replace(/^_+|_+$/g, '')
+      .slice(0, 60) || 'untitled'
+  );
 }
 
 function CommonDialog({
@@ -28,9 +53,52 @@ function CommonDialog({
   onClickConfirm,
   onClickCancel,
   onClickClose,
+  trackingId,
 }: CommonDialogProps) {
+  const trackEvent = useTrackEvent();
+  // Resolved analytics id, stable across renders within a session.
+  const dialogId = trackingId ?? fallbackId(title);
+  // Tracks whether the user resolved the dialog explicitly (confirm or
+  // cancel button) vs implicitly (dimmed-area click / Escape). Lets us
+  // tell the difference between "considered, then declined" and "tapped
+  // outside without thinking" — different UX signals.
+  const explicitOutcomeRef = useRef(false);
+
+  // Fire `_shown` when visible flips to true. The dependency on `visible`
+  // alone (not dialogId) is intentional — re-rendering the same dialog
+  // shouldn't re-fire a shown event.
+  useEffect(() => {
+    if (visible) {
+      explicitOutcomeRef.current = false;
+      trackEvent('confirm_dialog_shown', { dialog_id: dialogId });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [visible]);
+
+  const handleConfirm = useCallback(() => {
+    explicitOutcomeRef.current = true;
+    trackEvent('confirm_dialog_confirmed', { dialog_id: dialogId });
+    onClickConfirm();
+  }, [dialogId, onClickConfirm, trackEvent]);
+
+  const handleCancel = useCallback(() => {
+    explicitOutcomeRef.current = true;
+    trackEvent('confirm_dialog_canceled', { dialog_id: dialogId });
+    if (onClickCancel) onClickCancel();
+    else onClickClose();
+  }, [dialogId, onClickCancel, onClickClose, trackEvent]);
+
+  // Dim-area click and Escape key both route through onClickClose. Only
+  // count as "dismissed" if neither button was tapped first.
+  const handleDismiss = useCallback(() => {
+    if (!explicitOutcomeRef.current) {
+      trackEvent('confirm_dialog_dismissed', { dialog_id: dialogId });
+    }
+    onClickClose();
+  }, [dialogId, onClickClose, trackEvent]);
+
   return (
-    <StyledCommonDialog visible={visible} onClickDimmed={onClickClose}>
+    <StyledCommonDialog visible={visible} onClickDimmed={handleDismiss}>
       <Layout.FlexCol w="100%" h="100%" alignItems="center">
         <Layout.FlexCol className="text_area" w="100%" p={16} alignItems="center">
           <Typo type={titleType} textAlign="center">
@@ -43,12 +111,12 @@ function CommonDialog({
           )}
         </Layout.FlexCol>
         <Layout.FlexRow w="100%" h="100%">
-          <button type="button" onClick={onClickCancel ?? onClickClose}>
+          <button type="button" onClick={handleCancel}>
             <Typo type="button-medium" color={cancelTextColor}>
               {cancelText}
             </Typo>
           </button>
-          <button type="button" onClick={onClickConfirm}>
+          <button type="button" onClick={handleConfirm}>
             <Typo type="button-medium" color={confirmTextColor}>
               {confirmText}
             </Typo>


### PR DESCRIPTION
## Summary

Single-file change that instruments all 52 confirmation dialogs in the app for free. Adds shown / confirmed / canceled / dismissed events emitted from \`CommonDialog\` itself with a per-dialog \`dialog_id\` param.

### Why this matters

Every confirmation flow currently leaves a backend trace ONLY when the user confirms (because that's when the API fires). Cancellations and dim-area dismissals are invisible to research analytics. With 52 dialogs in the codebase covering deletes, blocks, friend operations, etc., this is a major blind spot.

### What we get

- **confirm_dialog_shown** — funnel start
- **confirm_dialog_confirmed** — primary button (already inferable from backend success but logged here for funnel symmetry)
- **confirm_dialog_canceled** — secondary button (explicit decline, considered the action)
- **confirm_dialog_dismissed** — tapped dim area / pressed escape (walked away without committing)

The cancel-vs-dismiss distinction is intentional: they're different UX signals.

### dialog_id

New optional \`trackingId\` prop on \`CommonDialog\` lets call sites set a stable id. If omitted, the dialog's \`title\` string is slugified (lowercase + non-word → \`_\`) for a fallback id. We can audit-and-fill in trackingIds later — the fallback works in the meantime.

## Test plan
- [x] \`npx craco build\` clean
- [x] No call-site signature changes (\`trackingId\` is optional) — existing 52 usages keep working
- [ ] Once shipped: verify Firebase DebugView receives the new events with \`dialog_id\` param