### PR TITLE
feat(analytics): compose flow abandonment tracking

### DIFF
--- a/src/components/chat/chat-message-input/ChatMessageInput.tsx
+++ b/src/components/chat/chat-message-input/ChatMessageInput.tsx
@@ -6,6 +6,7 @@ import CommonDialog from '@components/_common/alert-dialog/common-dialog/CommonD
 import Icon from '@components/_common/icon/Icon';
 import { BOTTOM_TABBAR_HEIGHT } from '@constants/layout';
 import { Layout, Typo } from '@design-system';
+import { useTrackEvent } from '@hooks/useTrackEvent';
 import {
   ChatEmojiDict,
   ChatEmojiType,
@@ -99,6 +100,16 @@ function ChatMessageInput({
   const fileInputRef = useRef<HTMLInputElement>(null);
   const { openToast } = useBoundStore((state) => ({ openToast: state.openToast }));
   const [t] = useTranslation('translation', { keyPrefix: 'chat' });
+  const trackEvent = useTrackEvent();
+  // Engagement signal: did the user start composing in this room? Set when
+  // first character or image is added; reset after a successful send so
+  // multi-message sessions don't double-count abandonment. Used by the
+  // unmount cleanup to fire `chat_compose_abandoned` only when relevant.
+  const hasContentRef = useRef(false);
+  // True iff the user typed anything during this mount — separate from
+  // hasContent because that gets reset on send. This one stays true so we
+  // track engagement ("typed something") regardless of whether they sent.
+  const everTypedRef = useRef(false);
 
   const maxHeight = isAnnouncement ? MAX_HEIGHT_ANNOUNCEMENT : MAX_HEIGHT_DEFAULT;
 
@@ -118,8 +129,36 @@ function ChatMessageInput({
     }
   }, [replyTarget]);
 
+  // Fire `chat_compose_abandoned` on unmount IF the user typed something
+  // (or attached an image) but the input still has content (they didn't
+  // send the last draft). This catches "wrote a long message, navigated
+  // away" — which is invisible to the backend.
+  useEffect(() => {
+    return () => {
+      if (hasContentRef.current) {
+        trackEvent('chat_compose_abandoned', {
+          is_group: isGroup ? 'true' : 'false',
+          is_announcement: isAnnouncement ? 'true' : 'false',
+        });
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const handleChangeInput = (e: ChangeEvent<HTMLTextAreaElement>) => {
     setInputValue(e.target.value);
+    // Mark composition started on first non-empty input — fires once per
+    // unmount cycle, distinct from `_sent` (success) and `_abandoned`
+    // (unmount with content). Tells us how many users started typing,
+    // which the backend can't see at all.
+    if (!everTypedRef.current && e.target.value.length > 0) {
+      everTypedRef.current = true;
+      trackEvent('chat_compose_started', {
+        is_group: isGroup ? 'true' : 'false',
+        is_announcement: isAnnouncement ? 'true' : 'false',
+      });
+    }
+    hasContentRef.current = e.target.value.length > 0 || !!selectedImage;
     if (onTyping) {
       const now = Date.now();
       if (now - lastTypingSent.current > TYPING_DEBOUNCE_MS) {
@@ -170,6 +209,9 @@ function ChatMessageInput({
       setSelectedImage(null);
       setImagePreview(null);
       onClearReply();
+      // Successful send — clear the abandonment guard. (everTypedRef
+      // intentionally NOT reset: that's a per-mount engagement flag.)
+      hasContentRef.current = false;
     } catch (err) {
       const axiosErr = err as AxiosError<{ detail?: string }>;
       const status = axiosErr?.response?.status;
@@ -192,6 +234,7 @@ function ChatMessageInput({
     const file = e.target.files?.[0];
     if (file) {
       setSelectedImage(file);
+      hasContentRef.current = true;
       const reader = new FileReader();
       reader.onload = (ev) => {
         setImagePreview(ev.target?.result as string);
@@ -204,6 +247,7 @@ function ChatMessageInput({
   const removeImage = () => {
     setSelectedImage(null);
     setImagePreview(null);
+    hasContentRef.current = inputValue.length > 0;
   };
 
   return (

--- a/src/components/note/new-note-header/NewNoteHeader.tsx
+++ b/src/components/note/new-note-header/NewNoteHeader.tsx
@@ -1,11 +1,12 @@
 import { AxiosError } from 'axios';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 import UploadLoadingOverlay from '@components/_common/upload-loading-overlay/UploadLoadingOverlay';
 import { markMissionCompleted } from '@components/share/MissionOfTheDay';
 import { Layout, Typo } from '@design-system';
 import { useDelayedVisible } from '@hooks/useDelayedVisible';
+import { useTrackEvent } from '@hooks/useTrackEvent';
 import { NewNoteForm } from '@models/post';
 import { useBoundStore } from '@stores/useBoundStore';
 import { patchNote, postNote } from '@utils/apis/note';
@@ -29,6 +30,34 @@ function NewNoteHeader({ status, noteId, title, noteInfo }: NewNoteHeaderProps) 
 
   const fromShare = location.state?.fromShare;
   const missionMode = location.state?.missionMode;
+  const trackEvent = useTrackEvent();
+  const publishedRef = useRef(false);
+  const isEditing = !!noteId;
+  // Latest noteInfo via ref so the unmount cleanup checks the most recent
+  // content/image state — unmount fires AFTER state is frozen.
+  const noteInfoRef = useRef(noteInfo);
+  noteInfoRef.current = noteInfo;
+
+  useEffect(() => {
+    trackEvent('note_compose_started', {
+      mode: isEditing ? 'edit' : 'create',
+      mission_mode: missionMode ? 'true' : 'false',
+      from_share: fromShare ? 'true' : 'false',
+    });
+    return () => {
+      if (publishedRef.current) return;
+      // had_content distinguishes "opened then immediately backed out" from
+      // "wrote / attached image then walked away" — different friction signals.
+      const hasContent =
+        !!noteInfoRef.current.content ||
+        (noteInfoRef.current.images && noteInfoRef.current.images.length > 0);
+      trackEvent('note_compose_abandoned', {
+        mode: isEditing ? 'edit' : 'create',
+        had_content: hasContent ? 'true' : 'false',
+      });
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const cancelPost = () => {
     if (fromShare) {
@@ -52,6 +81,13 @@ function NewNoteHeader({ status, noteId, title, noteInfo }: NewNoteHeaderProps) 
         markMissionCompleted();
       }
 
+      publishedRef.current = true;
+      trackEvent('note_compose_published', {
+        mode: isEditing ? 'edit' : 'create',
+        content_length: noteInfo.content?.length ?? 0,
+        image_count: noteInfo.images?.length ?? 0,
+        mission_mode: missionMode ? 'true' : 'false',
+      });
       navigate(`/notes/${newNoteId}`, { state: { new: true, fromShare } });
       openToast({
         message: t(status === 'edit' ? 'updated' : 'posted'),

--- a/src/components/share/PhotoOfTheDayFlow.tsx
+++ b/src/components/share/PhotoOfTheDayFlow.tsx
@@ -1,10 +1,11 @@
-import { ChangeEvent, useRef, useState } from 'react';
+import { ChangeEvent, useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import VisibilityToggle from '@components/check-in/visibility-toggle/VisibilityToggle';
 import NewNoteImageEdit from '@components/note/new-note-image-edit/NewNoteImageEdit';
 import SubHeader from '@components/sub-header/SubHeader';
 import { Layout, Typo } from '@design-system';
+import { useTrackEvent } from '@hooks/useTrackEvent';
 import { ComponentVisibility } from '@models/checkIn';
 import { PostVisibility, ShareType } from '@models/post';
 import { useBoundStore } from '@stores/useBoundStore';
@@ -37,6 +38,28 @@ function PhotoOfTheDayFlow() {
     setLastVisibility(VisibilityMemoryKeys.share.photo, v);
   };
   const [isPosting, setIsPosting] = useState(false);
+  const trackEvent = useTrackEvent();
+  // Track which step the user reached so the unmount-abandonment event
+  // can record where in the funnel they bailed. Stored in a ref so the
+  // cleanup callback sees the latest value (state would be stale).
+  const stepRef = useRef(step);
+  stepRef.current = step;
+  const publishedRef = useRef(false);
+
+  // Fire `started` once on mount + `abandoned` on unmount unless they
+  // published. The funnel is:
+  //   started → picked → cropped → published
+  // and abandoned can fire at any step, so the event includes the
+  // last-reached step in `last_step`.
+  useEffect(() => {
+    trackEvent('photo_flow_started', { entry_step: step });
+    return () => {
+      if (!publishedRef.current) {
+        trackEvent('photo_flow_abandoned', { last_step: stepRef.current });
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const handlePickGallery = () => {
     fileInputRef.current?.click();
@@ -49,6 +72,7 @@ function PhotoOfTheDayFlow() {
       if (typeof dataUrl !== 'string') return;
       setRawImageUrl(dataUrl);
       setStep('edit');
+      trackEvent('photo_flow_picked');
     } catch {
       openToast({ message: 'Failed to load image' });
     }
@@ -57,6 +81,7 @@ function PhotoOfTheDayFlow() {
   const handleCropComplete = (img: CroppedImg) => {
     setCroppedImg(img);
     setStep('caption');
+    trackEvent('photo_flow_cropped');
   };
 
   const handlePost = async () => {
@@ -68,6 +93,12 @@ function PhotoOfTheDayFlow() {
         images: [croppedImg],
         visibility: [visibility as unknown as PostVisibility],
         share_type: ShareType.PHOTO_OF_THE_DAY,
+      });
+      // Mark BEFORE navigate so the unmount cleanup doesn't fire abandoned.
+      publishedRef.current = true;
+      trackEvent('photo_flow_published', {
+        caption_length: caption.length,
+        visibility: String(visibility),
       });
       navigate(`/notes/${newNoteId}`, { state: { new: true } });
       openToast({ message: 'Photo posted!' });

--- a/src/components/share/ThoughtSnippetInput.tsx
+++ b/src/components/share/ThoughtSnippetInput.tsx
@@ -1,6 +1,7 @@
 import { KeyboardEvent, useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { Layout, Typo } from '@design-system';
+import { useTrackEvent } from '@hooks/useTrackEvent';
 
 const ROTATING_PLACEHOLDERS = [
   'What is on your mind right now?',
@@ -34,20 +35,40 @@ function ThoughtSnippetInput({ visible, onClose, onSubmit }: Props) {
   const [text, setText] = useState('');
   const [placeholder] = useState(getRandomPlaceholder);
   const inputRef = useRef<HTMLTextAreaElement>(null);
+  const trackEvent = useTrackEvent();
+  // Mirrors the photo / note pattern: submitted=true on the success path
+  // suppresses the abandoned event on close.
+  const submittedRef = useRef(false);
 
   useEffect(() => {
     if (visible) {
+      submittedRef.current = false;
+      trackEvent('thought_snippet_opened');
       setTimeout(() => inputRef.current?.focus(), 100);
     } else {
       setText('');
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [visible]);
 
   const handleSubmit = () => {
     const trimmed = text.trim();
     if (!trimmed) return;
+    submittedRef.current = true;
+    trackEvent('thought_snippet_submitted', { length: trimmed.length });
     onSubmit(trimmed);
     setText('');
+    onClose();
+  };
+
+  const handleClose = () => {
+    if (!submittedRef.current) {
+      // had_text distinguishes "opened, typed something, closed" from
+      // "opened then immediately closed" — different friction signals.
+      trackEvent('thought_snippet_abandoned', {
+        had_text: text.trim().length > 0 ? 'true' : 'false',
+      });
+    }
     onClose();
   };
 
@@ -61,7 +82,7 @@ function ThoughtSnippetInput({ visible, onClose, onSubmit }: Props) {
   if (!visible) return null;
 
   return (
-    <Overlay onClick={onClose}>
+    <Overlay onClick={handleClose}>
       <InputCard onClick={(e) => e.stopPropagation()}>
         <Layout.FlexRow w="100%" justifyContent="space-between" alignItems="center" pb={8}>
           <Typo type="title-medium">Be Random</Typo>


### PR DESCRIPTION
## Summary

Instruments every client-side compose surface (photo, note, chat, thought snippet) with started → published / abandoned events. Backend only sees the publish moment; everything before that — opens, drafts, walk-aways — was invisible to research analytics.

### Funnels added

**Photo of the Day** (\`PhotoOfTheDayFlow\`):
\`photo_flow_started\` (entry_step) → \`_picked\` → \`_cropped\` → \`_published\` / \`_abandoned\` (last_step)

**Note compose** (\`NewNoteHeader\`):
\`note_compose_started\` (mode: edit|create, mission_mode, from_share) → \`_published\` (content_length, image_count) / \`_abandoned\` (had_content)

**Chat compose** (\`ChatMessageInput\`):
\`chat_compose_started\` (first char typed) → \`_abandoned\` on unmount with content (publish event already implicit from backend's message row)

**Thought snippet** (\`ThoughtSnippetInput\`):
\`thought_snippet_opened\` → \`_submitted\` (length) / \`_abandoned\` (had_text)

### Pattern

Each flow uses a \`publishedRef\` set on the success path before navigate, plus a \`useEffect\` cleanup that fires the abandoned event only if the ref is false. Same shape already used in the browse-mode customize sheet.

\`had_content\` / \`had_text\` params distinguish "opened then immediately backed out" from "wrote something then walked away" — different friction signals.

## Test plan
- [x] \`npx craco build\` clean
- [x] Existing publish paths still work — only added events around them
- [ ] Verify in DebugView once shipped: each flow shows started → published or started → abandoned, never both