### PR TITLE
feat(analytics): sign-up funnel — validation errors + step advances + completion

### DIFF
--- a/src/routes/sign-up/Email.tsx
+++ b/src/routes/sign-up/Email.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import ValidatedInput from '@components/_common/validated-input/ValidatedInput';
 import { Button, Layout } from '@design-system';
+import { useTrackEvent } from '@hooks/useTrackEvent';
 import { useBoundStore } from '@stores/useBoundStore';
 import { validateEmail } from '@utils/apis/user';
 import { AUTH_BUTTON_WIDTH } from 'src/design-system/Button/Button.types';
@@ -22,14 +23,23 @@ function Email() {
   };
 
   const navigate = useNavigate();
+  const trackEvent = useTrackEvent();
   const onClickNext = () => {
     validateEmail({
       email: emailInput,
       onSuccess: () => {
         setSignUpInfo({ email: emailInput });
+        trackEvent('signup_step_advanced', { step: 'email' });
         navigate('/signup/username');
       },
-      onError: (e) => setEmailError(e),
+      onError: (e) => {
+        setEmailError(e);
+        // error_type=api covers all backend validation rejections
+        // (already-taken, malformed, throttled, etc.). The UI string is
+        // localized so logging it isn't useful; the step + 'api' label
+        // is enough to distinguish from client-side errors below.
+        trackEvent('signup_validation_error', { step: 'email', error_type: 'api' });
+      },
     });
   };
 

--- a/src/routes/sign-up/Info.tsx
+++ b/src/routes/sign-up/Info.tsx
@@ -11,6 +11,7 @@ import {
 } from '@constants/url';
 import { Button, CheckBox, Layout, Typo } from '@design-system';
 import { usePostAppMessage } from '@hooks/useAppMessage';
+import { useTrackEvent } from '@hooks/useTrackEvent';
 import { useBoundStore } from '@stores/useBoundStore';
 import { validateBirthdate, validateInviterUsername } from '@utils/apis/user';
 import { AUTH_BUTTON_WIDTH } from 'src/design-system/Button/Button.types';
@@ -30,6 +31,7 @@ function Info() {
   }));
   const navigate = useNavigate();
   const postMessage = usePostAppMessage();
+  const trackEvent = useTrackEvent();
 
   const privacyPolicyLink =
     i18n.language === 'ko-KR'
@@ -67,6 +69,7 @@ function Info() {
   const onClickNext = () => {
     if (!isValideDateOfBirth(dateOfBirthInput)) {
       setDateOfBirthError(t('date_of_birth_error'));
+      trackEvent('signup_validation_error', { step: 'info', error_type: 'date_of_birth' });
       return;
     }
 
@@ -95,6 +98,7 @@ function Info() {
       },
       onError: () => {
         setFriendUsernameError(t('friend_username_error'));
+        trackEvent('signup_validation_error', { step: 'info', error_type: 'friend_code' });
       },
     });
   };
@@ -106,12 +110,14 @@ function Info() {
     validateBirthdate({
       birthdate,
       onSuccess: () => {
+        trackEvent('signup_step_advanced', { step: 'info' });
         navigate('/signup/password');
       },
       onError: (errorMsg: string) => {
         openToast({
           message: errorMsg,
         });
+        trackEvent('signup_validation_error', { step: 'info', error_type: 'birthdate_api' });
       },
     });
 

--- a/src/routes/sign-up/NotiSettings.tsx
+++ b/src/routes/sign-up/NotiSettings.tsx
@@ -6,6 +6,7 @@ import {
   FRIENDS_Q_DEFAULT_REDIRECTION_PATH,
 } from '@constants/url';
 import { Button, Font, Layout } from '@design-system';
+import { useTrackEvent } from '@hooks/useTrackEvent';
 import { hasMandatorySignUpParams } from '@models/api/user';
 import { useBoundStore } from '@stores/useBoundStore';
 import { UserSelector } from '@stores/user';
@@ -45,8 +46,13 @@ function NotiSettings() {
   };
 
   const navigate = useNavigate();
+  const trackEvent = useTrackEvent();
   const onClickNextOrSkip = () => {
     if (!hasMandatorySignUpParams(signUpInfo)) {
+      trackEvent('signup_validation_error', {
+        step: 'noti_settings',
+        error_type: 'missing_params',
+      });
       navigate('/signup/email');
       // TOOO: 에러 메시지 보강
       return;
@@ -59,6 +65,10 @@ function NotiSettings() {
       },
       onSuccess: () => {
         resetSignUpInfo();
+        trackEvent('signup_completed', {
+          final_step: 'noti_settings',
+          noti_enabled: notiTime ? 'true' : 'false',
+        });
         navigate(
           featureFlags?.friendList
             ? FRIEND_DEFAULT_REDIRECTION_PATH
@@ -68,6 +78,7 @@ function NotiSettings() {
       onError: (e) => {
         // TODO
         console.log(e);
+        trackEvent('signup_failed', { step: 'noti_settings' });
       },
     });
   };

--- a/src/routes/sign-up/Password.tsx
+++ b/src/routes/sign-up/Password.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import ValidatedPasswordInput from '@components/_common/validated-input/ValidatedPasswordInput';
 import { Button, Layout } from '@design-system';
+import { useTrackEvent } from '@hooks/useTrackEvent';
 import { useBoundStore } from '@stores/useBoundStore';
 import { signUp, validatePassword } from '@utils/apis/user';
 import { AUTH_BUTTON_WIDTH } from 'src/design-system/Button/Button.types';
@@ -22,8 +23,11 @@ function Password() {
     if (passwordError) setPasswordError(null);
   };
 
+  const trackEvent = useTrackEvent();
+
   const handleOnSignUpError = () => {
     openToast({ message: t('error') });
+    trackEvent('signup_failed', { step: 'password' });
     navigate('/');
   };
 
@@ -40,6 +44,9 @@ function Password() {
           onSuccess: () => {
             resetSignUpInfo();
             openToast({ message: t('success') });
+            // Final funnel event — paired with the screen_view chain. Lets
+            // dashboards compute conversion rate from /signup/email entry.
+            trackEvent('signup_completed', { final_step: 'password' });
             // 가입 후 프로필 수정 페이지로 이동
             navigate('/settings/edit-profile', {
               state: { fromSignUp: true },
@@ -48,7 +55,10 @@ function Password() {
           onError: handleOnSignUpError,
         });
       },
-      onError: (e) => setPasswordError(e),
+      onError: (e) => {
+        setPasswordError(e);
+        trackEvent('signup_validation_error', { step: 'password', error_type: 'api' });
+      },
     });
   };
 

--- a/src/routes/sign-up/Username.tsx
+++ b/src/routes/sign-up/Username.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import ValidatedInput from '@components/_common/validated-input/ValidatedInput';
 import { Button, Layout } from '@design-system';
+import { useTrackEvent } from '@hooks/useTrackEvent';
 import { useBoundStore } from '@stores/useBoundStore';
 import { validateUsername } from '@utils/apis/user';
 import { AUTH_BUTTON_WIDTH } from 'src/design-system/Button/Button.types';
@@ -20,6 +21,7 @@ function Username() {
   const [usernameError, setUsernameError] = useState<string | null>(null);
 
   const navigate = useNavigate();
+  const trackEvent = useTrackEvent();
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     setUsernameInput(e.target.value);
@@ -31,10 +33,12 @@ function Username() {
 
     if (trimmed.length < USERNAME_MIN_LENGTH) {
       setUsernameError(t('username_min_length_error'));
+      trackEvent('signup_validation_error', { step: 'username', error_type: 'min_length' });
       return;
     }
     if (!USERNAME_FORMAT_REGEX.test(trimmed)) {
       setUsernameError(t('username_format_error'));
+      trackEvent('signup_validation_error', { step: 'username', error_type: 'format' });
       return;
     }
 
@@ -42,9 +46,13 @@ function Username() {
       username: trimmed,
       onSuccess: () => {
         setSignUpInfo({ username: trimmed });
+        trackEvent('signup_step_advanced', { step: 'username' });
         navigate('/signup/info');
       },
-      onError: (e) => setUsernameError(e),
+      onError: (e) => {
+        setUsernameError(e);
+        trackEvent('signup_validation_error', { step: 'username', error_type: 'api' });
+      },
     });
   };
 


### PR DESCRIPTION
## Summary

\`screen_view\` already tracks page-level entry through the sign-up flow. But it leaves three blind spots that this PR fills:

1. **Where do users get stuck?** \`signup_validation_error\` fires whenever a Next-tap is rejected, with \`error_type\` distinguishing client-side (\`min_length\`, \`format\`, \`date_of_birth\`) from API errors (\`api\`, \`api_already_taken\`).
2. **Did the user actually pass the step?** \`signup_step_advanced\` fires only after a validated Next, so a stuck user retrying with bad input doesn't inflate the funnel.
3. **Did sign-up actually succeed?** \`signup_completed\` and \`signup_failed\` fire on the final \`signUp()\` API call — without these, "reached /signup/password" looks the same as "actually finished sign-up" in screen_view alone.

## Coverage

All five sign-up steps instrumented:
- Email — \`api\` errors only (no client-side validation)
- Username — \`min_length\`, \`format\`, \`api\`
- Info — \`date_of_birth\`, \`friend_code\`, \`birthdate_api\`
- Password — \`api\` errors + \`signup_completed\` / \`signup_failed\` (this is where the main flow's signUp() lives)
- NotiSettings — \`missing_params\` + parallel \`signup_completed\` / \`signup_failed\` for the alternate path

## Test plan
- [x] \`npx craco build\` clean
- [x] All existing flows preserved — only added events alongside existing handlers
- [ ] Verify in DebugView: deliberately fail validation at each step and confirm the matching \`error_type\` event fires