### PR TITLE
feat(analytics): reaction picker + visibility toggle + friends filter events

### DIFF
--- a/src/components/_common/post-footer/PostFooter.tsx
+++ b/src/components/_common/post-footer/PostFooter.tsx
@@ -6,6 +6,7 @@ import EmojiPicker from '@components/emoji-picker/EmojiPicker';
 import { getEmojiPickerPosition } from '@components/emoji-picker/EmojiPicker.helper';
 import { BOTTOM_TABBAR_HEIGHT } from '@constants/layout';
 import { Layout, Typo } from '@design-system';
+import { useTrackEvent } from '@hooks/useTrackEvent';
 import { Note, POST_DP_TYPE, POST_TYPE, ReactionUserSample, Response } from '@models/post';
 import { useBoundStore } from '@stores/useBoundStore';
 import { deleteReaction, postReaction } from '@utils/apis/reaction';
@@ -45,6 +46,13 @@ function PostFooter({
   const [t] = useTranslation('translation', {
     keyPrefix: post.type === POST_TYPE.RESPONSE ? 'responses' : 'notes',
   });
+  const trackEvent = useTrackEvent();
+  // True iff the picker was opened during this PostFooter mount and a
+  // reaction was posted. Lets the close-without-pick branch fire
+  // `reaction_picker_dismissed` (vs the picker being closed because the
+  // user actually reacted, which we already see via postReaction).
+  const pickerOpenedRef = useRef(false);
+  const reactionPostedRef = useRef(false);
 
   const handleClickCommentText = (e: MouseEvent) => {
     e.stopPropagation();
@@ -67,7 +75,7 @@ function PostFooter({
   const handleSelectEmoji = async (emoji: EmojiClickData) => {
     if (!myProfile) return;
     const response = await postReaction(post.type, post.id, emoji.emoji);
-
+    reactionPostedRef.current = true;
     setEmojiPickerTarget(null);
     setMyReactionList([
       ...myReactionList,
@@ -125,9 +133,24 @@ function PostFooter({
         displayType === 'DETAIL' ? BOTTOM_TABBAR_HEIGHT + 100 : BOTTOM_TABBAR_HEIGHT,
     });
 
-    setEmojiPickerTarget(
-      isCurrentlyActive ? null : { type: post.type, id: post.id, ...pickerPosition },
-    );
+    if (isCurrentlyActive) {
+      // Tapped the button again to close — count as a dismiss only if no
+      // reaction was actually posted in this open session.
+      if (pickerOpenedRef.current && !reactionPostedRef.current) {
+        trackEvent('reaction_picker_dismissed', {
+          post_type: String(post.type),
+          source: 'toggle',
+        });
+      }
+      pickerOpenedRef.current = false;
+      reactionPostedRef.current = false;
+      setEmojiPickerTarget(null);
+    } else {
+      pickerOpenedRef.current = true;
+      reactionPostedRef.current = false;
+      trackEvent('reaction_picker_opened', { post_type: String(post.type) });
+      setEmojiPickerTarget({ type: post.type, id: post.id, ...pickerPosition });
+    }
   };
 
   useEffect(() => {

--- a/src/components/check-in/visibility-toggle/VisibilityToggle.tsx
+++ b/src/components/check-in/visibility-toggle/VisibilityToggle.tsx
@@ -1,11 +1,20 @@
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
+import { useTrackEvent } from '@hooks/useTrackEvent';
 import i18n from '@i18n/index';
 import { ComponentVisibility } from '@models/checkIn';
 
 interface Props {
   value: ComponentVisibility;
   onChange: (visibility: ComponentVisibility) => void;
+  /**
+   * Optional analytics tag for distinguishing different visibility-toggle
+   * locations in Firebase (e.g. 'check_in_battery', 'photo_caption',
+   * 'note_compose'). Without this, all toggles look the same in the
+   * dashboard. Backend only sees the FINAL persisted value, so this event
+   * captures pre-save fiddle (toggling between options before settling).
+   */
+  trackingId?: string;
 }
 
 interface VisibilityOption {
@@ -36,15 +45,25 @@ export function getVisibilityLabel(value: ComponentVisibility): string {
   return opt ? i18n.t(opt.i18nKey) : '';
 }
 
-function VisibilityToggle({ value, onChange }: Props) {
+function VisibilityToggle({ value, onChange, trackingId }: Props) {
   const [t] = useTranslation('translation');
+  const trackEvent = useTrackEvent();
+  const handleChange = (next: ComponentVisibility) => {
+    if (next === value) return;
+    trackEvent('visibility_toggle_changed', {
+      from: String(value),
+      to: String(next),
+      ...(trackingId ? { surface: trackingId } : {}),
+    });
+    onChange(next);
+  };
   return (
     <ToggleContainer>
       {VISIBILITY_OPTIONS.map((opt) => (
         <ToggleOption
           key={opt.value}
           $isSelected={value === opt.value}
-          onClick={() => onChange(opt.value)}
+          onClick={() => handleChange(opt.value)}
         >
           <Label
             $isSelected={value === opt.value}

--- a/src/routes/friends/FriendsList.tsx
+++ b/src/routes/friends/FriendsList.tsx
@@ -11,6 +11,7 @@ import NoCloseFriends from '@components/friends/no-close-friends/NoCloseFriends'
 import { FLOATING_BUTTON_SIZE } from '@components/header/floating-button/FloatingButton.styled';
 import { Colors, Layout, Typo } from '@design-system';
 import { useRestoreScrollPosition } from '@hooks/useRestoreScrollPosition';
+import { useTrackEvent } from '@hooks/useTrackEvent';
 import { Connection, FriendType, UpdatedProfile } from '@models/api/friends';
 import { useBoundStore } from '@stores/useBoundStore';
 import { getMe } from '@utils/apis/my';
@@ -35,6 +36,16 @@ function FriendsList() {
   useEffect(() => {
     if (browseModeForcesCloseFriends) setCloseFriendsOnly(true);
   }, [browseModeForcesCloseFriends]);
+  const trackEvent = useTrackEvent();
+  const handleToggleCloseFriends = () => {
+    setCloseFriendsOnly((prev) => {
+      const next = !prev;
+      // Filter is local-state only — never hits the backend, so this event
+      // is the only way to know how often users actually use it.
+      trackEvent('friends_filter_close_only_toggled', { value: next ? 'on' : 'off' });
+      return next;
+    });
+  };
   const friendType: FriendType = closeFriendsOnly ? 'close_friends' : 'all';
 
   const {
@@ -176,7 +187,7 @@ function FriendsList() {
               alignItems="center"
               style={{ cursor: 'pointer' }}
               data-preview-exempt
-              onClick={() => setCloseFriendsOnly((prev) => !prev)}
+              onClick={handleToggleCloseFriends}
             >
               <CheckboxIcon checked={closeFriendsOnly} />
               <Typo type="label-medium" color={closeFriendsOnly ? 'BLACK' : 'MEDIUM_GRAY'}>


### PR DESCRIPTION
## Summary

Three more pure-client behaviors that never hit a backend endpoint, now instrumented:

- **reaction_picker_opened / _dismissed** — pairs with existing backend reaction rows to reveal "opened picker → walked away" abandon rate
- **visibility_toggle_changed** (from, to, surface?) — pre-save fiddle inside compose flows. Backend only sees the final saved value
- **friends_filter_close_only_toggled** — close-friends-only checkbox on Friends tab. 100% client state, no backend trace

The visibility toggle change auto-applies to every \`<VisibilityToggle>\` consumer (check-in panel, photo caption, note compose, etc.). Optional new \`trackingId\` prop lets call sites tag the surface for clearer dashboards. Existing usages continue to work without change.

## Test plan
- [x] \`npx craco build\` clean
- [x] No call-site signature changes — \`trackingId\` is optional