### PR TITLE
feat(analytics): impression tracking + scroll depth + dwell time infrastructure

### DIFF
--- a/src/hooks/useDwellTime.ts
+++ b/src/hooks/useDwellTime.ts
@@ -1,0 +1,45 @@
+import { useEffect, useRef } from 'react';
+import { useTrackEvent } from './useTrackEvent';
+
+/**
+ * Fires a single `<eventName>` event on unmount with `duration_ms`.
+ * Use for "how long did the user spend on this thing" signals — post
+ * detail dwell, modal open time, profile-view duration, etc.
+ *
+ * Differs from screen_dwell in Root.tsx (which fires for every route
+ * change automatically) by being scoped to a specific component's
+ * lifecycle, so it works for modals / bottom sheets / sub-views that
+ * don't have their own URL.
+ *
+ * Drops dwells under `minMs` (default 500ms) so accidental opens /
+ * mount-then-immediate-unmount cases don't pollute the data with
+ * single-digit-millisecond noise.
+ *
+ * Optional `params` get merged into the emitted event so callers can
+ * tag e.g. post type, post id, modal name, etc.
+ */
+export function useDwellTime(
+  eventName: string,
+  params?: Record<string, string | number>,
+  options?: { minMs?: number },
+) {
+  const trackEvent = useTrackEvent();
+  const startedAtRef = useRef<number>(Date.now());
+  const minMs = options?.minMs ?? 500;
+  // Stable params reference — same reasoning as useImpressionTracker.
+  const paramsRef = useRef(params);
+  paramsRef.current = params;
+
+  useEffect(() => {
+    startedAtRef.current = Date.now();
+    return () => {
+      const duration_ms = Date.now() - startedAtRef.current;
+      if (duration_ms < minMs) return;
+      trackEvent(eventName, {
+        ...(paramsRef.current ?? {}),
+        duration_ms,
+      });
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [eventName]);
+}

--- a/src/hooks/useImpressionTracker.ts
+++ b/src/hooks/useImpressionTracker.ts
@@ -1,0 +1,84 @@
+import { RefObject, useEffect } from 'react';
+import { useTrackEvent } from './useTrackEvent';
+
+/**
+ * Fires an analytics impression event the first time the given element
+ * has spent at least `minVisibleMs` continuously inside the viewport with
+ * at least `threshold` of its area visible. Each ref instance fires at
+ * most once per mount cycle — re-mounting the component re-arms it.
+ *
+ * Why this design (rather than firing on first intersection):
+ *   - "Element rendered above the fold" is not the same as "user actually
+ *     looked at it". A scroll-by impression where the card is in view for
+ *     50ms doesn't count as engagement.
+ *   - 500ms is the same threshold YouTube / GA4 use for "viewable".
+ *   - One-shot: an impression is a Boolean per-mount, not a continuous
+ *     stream of events.
+ *
+ * Use this for read-only consumption signals that the backend can't see
+ * (Discover cards rendered, friend cards seen, story tiles visible, etc.).
+ *
+ * Usage:
+ *   const ref = useRef<HTMLDivElement>(null);
+ *   useImpressionTracker(ref, 'discover_card_impressed', { card_type: 'mutual_trait' });
+ *   return <div ref={ref}>...</div>;
+ *
+ * In a scroll container, every card mounts at once but only fires when
+ * actually intersected — so a card that never scrolls into view never
+ * emits an event.
+ */
+export function useImpressionTracker<T extends Element>(
+  ref: RefObject<T>,
+  eventName: string,
+  params?: Record<string, string | number>,
+  options?: { minVisibleMs?: number; threshold?: number },
+) {
+  const trackEvent = useTrackEvent();
+  // Stringify the params so we don't re-arm the observer on every parent
+  // render (object identity changes constantly even when keys are stable).
+  const paramsKey = params ? JSON.stringify(params) : '';
+  const minVisibleMs = options?.minVisibleMs ?? 500;
+  const threshold = options?.threshold ?? 0.5;
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return undefined;
+    if (typeof IntersectionObserver === 'undefined') return undefined;
+
+    let firedThisMount = false;
+    let visibleSince: number | null = null;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (firedThisMount) return;
+        if (entry.isIntersecting && entry.intersectionRatio >= threshold) {
+          if (visibleSince === null) {
+            visibleSince = Date.now();
+            timer = setTimeout(() => {
+              if (firedThisMount) return;
+              firedThisMount = true;
+              trackEvent(eventName, params);
+              observer.disconnect();
+            }, minVisibleMs);
+          }
+        } else {
+          // Left the viewport before the dwell timer fired — reset.
+          visibleSince = null;
+          if (timer) {
+            clearTimeout(timer);
+            timer = null;
+          }
+        }
+      },
+      { threshold },
+    );
+
+    observer.observe(el);
+    return () => {
+      observer.disconnect();
+      if (timer) clearTimeout(timer);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [eventName, paramsKey, minVisibleMs, threshold]);
+}

--- a/src/hooks/useScrollDepth.ts
+++ b/src/hooks/useScrollDepth.ts
@@ -1,0 +1,79 @@
+import { RefObject, useEffect, useRef } from 'react';
+import { useTrackEvent } from './useTrackEvent';
+
+/**
+ * Reports max scroll depth on a feed-like surface as the user scrolls.
+ * Fires `<eventName>_milestone` events at 25/50/75/100% the FIRST time
+ * each milestone is crossed during a mount cycle. Tells us not just
+ * "how many users scrolled" but "how DEEP they scrolled" — a stronger
+ * engagement signal than impressions alone.
+ *
+ * Pass a ref to the scroll container, or omit it to track window scroll.
+ * Throttles handler invocations to ~100ms so a fast scroll doesn't fire
+ * thousands of useless updates per second.
+ *
+ * Backend can't tell scroll depth at all — every API call is for a
+ * specific page of results, regardless of how many a user actually saw.
+ */
+export function useScrollDepth(
+  eventName: string,
+  scrollRef?: RefObject<HTMLElement>,
+  params?: Record<string, string | number>,
+) {
+  const trackEvent = useTrackEvent();
+  // Persist the params reference for the throttle closure but don't re-arm
+  // the listener every parent render.
+  const paramsRef = useRef(params);
+  paramsRef.current = params;
+
+  useEffect(() => {
+    const target = scrollRef?.current;
+    // 25 / 50 / 75 / 100 — anything finer (e.g. 10% steps) is noise; fewer
+    // (e.g. 50/100) misses the most actionable middle of the funnel.
+    const milestones = [25, 50, 75, 100];
+    const reached = new Set<number>();
+    let throttleTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const compute = () => {
+      let depth = 0;
+      if (target) {
+        const { scrollTop, scrollHeight, clientHeight } = target;
+        const scrollable = scrollHeight - clientHeight;
+        depth = scrollable <= 0 ? 100 : (scrollTop / scrollable) * 100;
+      } else {
+        const doc = document.documentElement;
+        const scrollable = doc.scrollHeight - window.innerHeight;
+        depth = scrollable <= 0 ? 100 : (window.scrollY / scrollable) * 100;
+      }
+      milestones.forEach((m) => {
+        if (depth >= m && !reached.has(m)) {
+          reached.add(m);
+          trackEvent(`${eventName}_milestone`, {
+            ...(paramsRef.current ?? {}),
+            depth_pct: m,
+          });
+        }
+      });
+    };
+
+    const onScroll = () => {
+      if (throttleTimer) return;
+      throttleTimer = setTimeout(() => {
+        throttleTimer = null;
+        compute();
+      }, 100);
+    };
+
+    const node: HTMLElement | Window = target ?? window;
+    node.addEventListener('scroll', onScroll, { passive: true });
+    // Compute once on mount so a short feed that already shows 100% on
+    // load still fires the milestone — without this, we'd only count
+    // depth gained AFTER mount.
+    compute();
+    return () => {
+      node.removeEventListener('scroll', onScroll);
+      if (throttleTimer) clearTimeout(throttleTimer);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [eventName, scrollRef]);
+}

--- a/src/routes/discover/Discover.tsx
+++ b/src/routes/discover/Discover.tsx
@@ -25,7 +25,9 @@ import { useChipCategories } from '@hooks/useChipCategories';
 import { useMissions } from '@hooks/useMissions';
 import { useRestoreScrollPosition } from '@hooks/useRestoreScrollPosition';
 import { useSaveAndHide } from '@hooks/useSaveAndHide';
+import { useScrollDepth } from '@hooks/useScrollDepth';
 import { useSWRInfiniteScroll } from '@hooks/useSWRInfiniteScroll';
+import { useTrackEvent } from '@hooks/useTrackEvent';
 import i18n from '@i18n/index';
 import {
   DiscoverFilter,
@@ -106,6 +108,11 @@ function Discover() {
   const { missions } = useMissions();
   const discoverFilterList = [DiscoverFilter.MUTUAL_FRIENDS, DiscoverFilter.MUTUAL_TRAITS];
   const { scrollRef } = useRestoreScrollPosition('discoverPage');
+  // Discover is a feed — depth telegraphs engagement intensity. Backend
+  // sees pagination requests but can't tell if a user actually read past
+  // the items it loaded.
+  useScrollDepth('discover_scroll', scrollRef);
+  const trackEvent = useTrackEvent();
 
   // SWR key is version-aware — Q users hit /api/q/user/discover/
   const swrKey = isVerQ ? '/q/user/discover/' : '/user/discover/';
@@ -379,7 +386,16 @@ function Discover() {
                   label={DiscoverFilterLabel[filter]}
                   isSelected={selectedFilter.includes(filter)}
                   onClick={() => {
-                    if (selectedFilter.includes(filter)) {
+                    const wasSelected = selectedFilter.includes(filter);
+                    // Filter state is purely client — backend's
+                    // /discover/feed/ call doesn't carry it. This event
+                    // is the only signal of which chips users actually
+                    // engage with.
+                    trackEvent('discover_filter_chip_toggled', {
+                      filter: String(filter),
+                      value: wasSelected ? 'off' : 'on',
+                    });
+                    if (wasSelected) {
                       setSelectedFilter(selectedFilter.filter((f) => f !== filter));
                     } else {
                       setSelectedFilter([...selectedFilter, filter]);

--- a/src/routes/notes/NoteDetail.tsx
+++ b/src/routes/notes/NoteDetail.tsx
@@ -11,6 +11,7 @@ import SubHeader from '@components/sub-header/SubHeader';
 import { BOTTOM_TABBAR_HEIGHT, TITLE_HEADER_HEIGHT } from '@constants/layout';
 import { Layout } from '@design-system';
 import useAsyncEffect from '@hooks/useAsyncEffect';
+import { useDwellTime } from '@hooks/useDwellTime';
 import { FetchState } from '@models/api/common';
 import { Note } from '@models/post';
 import { useBoundStore } from '@stores/useBoundStore';
@@ -30,6 +31,12 @@ export function NoteDetail() {
   const [noteDetail, setNoteDetail] = useState<FetchState<Note>>({ state: 'loading' });
   const [reload, setReload] = useState<boolean>(false);
   const [inputFocus, setInputFocus] = useState(false);
+
+  // Read time on a post — invisible to backend (the GET /notes/<id>/ call
+  // doesn't tell us when the user left). Pairs naturally with engagement
+  // measures: low dwell + reaction = "tapped emoji and left", high dwell
+  // + no reaction = "read carefully but didn't engage."
+  useDwellTime('note_detail_dwell', { note_id: Number(noteId) || 0 });
 
   useAsyncEffect(async () => {
     if (!noteId) return;


### PR DESCRIPTION
## Summary

Three reusable hooks for read-only-consumption analytics. Backend has zero visibility into these signals because no API call fires when a user merely sees / scrolls past / lingers on something.

### New hooks

\`\`\`ts
// One-shot impression event when element is 50%+ visible for 500ms+
useImpressionTracker(ref, 'discover_card_impressed', { card_type: 'mutual_trait' });

// 25/50/75/100% milestone events for feed scroll depth
useScrollDepth('discover_scroll', scrollContainerRef);

// Single duration_ms event on unmount (drops <500ms accidental opens)
useDwellTime('note_detail_dwell', { note_id });
\`\`\`

### Initial wiring

- **Discover** — \`discover_scroll_milestone\` (25/50/75/100%), \`discover_filter_chip_toggled\` (Mutual Friends / Mutual Traits chip toggles, since the filter is 100% client-side)
- **NoteDetail** — \`note_detail_dwell\` on unmount (read time per post)

### Why these matter

- Engagement INTENSITY: \`scroll_depth\` tells us not just "user opened Discover" but "how deep". Backend's pagination calls reflect what was loaded, not what was actually read.
- Impression vs. action: pairs \`note_detail_dwell\` with the existing reaction events. High dwell + no reaction = "read carefully but didn't engage" — different from "tapped emoji and bounced".
- Filter usage: \`discover_filter_chip_toggled\` is the only signal of which chips users actually use. Fed into the data, we can argue for keeping or removing chips.

### Future use (one line per consumer)

Drop \`useImpressionTracker\` on individual NoteItem cards inside Discover to get per-card impression rates. Drop \`useDwellTime\` on profile pages to get profile-view durations. Etc.

## Test plan
- [x] \`npx craco build\` clean
- [x] Hooks are pure additions — no existing component logic changed
- [ ] Verify in DebugView once shipped: scroll Discover → milestones fire; open + close a note → dwell event fires with duration_ms