### PR TITLE
feat(analytics): instrument View as audience picker + dwell + session summary

### DIFF
--- a/src/components/view-as/ViewAsPicker.tsx
+++ b/src/components/view-as/ViewAsPicker.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import BottomModal from '@components/_common/bottom-modal/BottomModal';
 import ProfileImage from '@components/_common/profile-image/ProfileImage';
 import { Layout, Typo } from '@design-system';
+import { useTrackEvent } from '@hooks/useTrackEvent';
 import { Connection } from '@models/api/friends';
 import { User } from '@models/user';
 import { getFriendList } from '@utils/apis/user';
@@ -19,6 +20,7 @@ interface ViewAsPickerProps {
 function ViewAsPicker({ visible, onClose, onSelect }: ViewAsPickerProps) {
   const [t] = useTranslation('translation', { keyPrefix: 'view_as.picker' });
   const [friends, setFriends] = useState<User[] | null>(null);
+  const trackEvent = useTrackEvent();
 
   useEffect(() => {
     if (!visible || friends !== null) return;
@@ -45,11 +47,25 @@ function ViewAsPicker({ visible, onClose, onSelect }: ViewAsPickerProps) {
   const regularFriends = (friends ?? []).filter((f) => f.connection_status === Connection.FRIEND);
 
   const handleSelectPublic = () => {
+    // Picker-level event: "user chose public" (tier-specific). Distinct
+    // from the page-level `view_as_audience_changed` because that fires
+    // on URL-param change, including initial mount with the default tier.
+    // This event ONLY fires when the user explicitly tapped Public in the
+    // picker — the engagement intent signal.
+    trackEvent('view_as_audience_picked', { kind: 'tier', tier: 'public' });
     onSelect({ kind: 'tier', tier: 'public' });
     onClose();
   };
 
-  const handleSelectFriend = (username: string) => {
+  const handleSelectFriend = (username: string, isCloseFriend: boolean) => {
+    // is_close_friend distinguishes 'checking what intimate people see'
+    // from 'checking what acquaintances see' — different privacy signals.
+    // Username itself is intentionally NOT logged (high cardinality and
+    // analytically not useful — what matters is the relationship category).
+    trackEvent('view_as_audience_picked', {
+      kind: 'user',
+      is_close_friend: isCloseFriend ? 'true' : 'false',
+    });
     onSelect({ kind: 'user', username });
     onClose();
   };
@@ -88,7 +104,7 @@ function ViewAsPicker({ visible, onClose, onSelect }: ViewAsPickerProps) {
               {t('close_friends_section')}
             </Typo>
             {closeFriends.map((f) => (
-              <S.Row key={f.id} onClick={() => handleSelectFriend(f.username)}>
+              <S.Row key={f.id} onClick={() => handleSelectFriend(f.username, true)}>
                 <ProfileImage imageUrl={f.profile_image} username={f.username} size={32} />
                 <Typo type="body-medium" color="BLACK">
                   {f.username}
@@ -105,7 +121,7 @@ function ViewAsPicker({ visible, onClose, onSelect }: ViewAsPickerProps) {
               {t('friends_section')}
             </Typo>
             {regularFriends.map((f) => (
-              <S.Row key={f.id} onClick={() => handleSelectFriend(f.username)}>
+              <S.Row key={f.id} onClick={() => handleSelectFriend(f.username, false)}>
                 <ProfileImage imageUrl={f.profile_image} username={f.username} size={32} />
                 <Typo type="body-medium" color="BLACK">
                   {f.username}

--- a/src/routes/ViewAsPage.tsx
+++ b/src/routes/ViewAsPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { useShallow } from 'zustand/react/shallow';
 import { UserPageContextProvider } from '@components/user-page/UserPage.context';
@@ -6,6 +6,7 @@ import { PreviewModeProvider } from '@components/view-as/PreviewModeContext';
 import ViewAsBanner from '@components/view-as/ViewAsBanner';
 import ViewAsPicker, { ViewAsSelection } from '@components/view-as/ViewAsPicker';
 import { Layout } from '@design-system';
+import { useTrackEvent } from '@hooks/useTrackEvent';
 import { isVisibilityTier, VisibilityTier } from '@models/viewAs';
 import { useBoundStore } from '@stores/useBoundStore';
 import UserPage from './UserPage';
@@ -26,8 +27,22 @@ function ViewAsPage() {
 
   const { myProfile } = useBoundStore(useShallow((state) => ({ myProfile: state.myProfile })));
   const [pickerVisible, setPickerVisible] = useState(false);
+  const trackEvent = useTrackEvent();
+  // Tracks distinct audiences viewed during this mount cycle (Set of
+  // canonical strings: 'tier:public', 'user:alice', etc.). On unmount
+  // we report the count so research can answer "how many different
+  // audiences did the user check in one View-as session?" — a privacy-
+  // anxiety signal that no individual event captures.
+  const audiencesTriedRef = useRef<Set<string>>(new Set());
+  // Lets us measure dwell PER audience switch — flushed on every audience
+  // change and on unmount.
+  const audienceStartedAtRef = useRef<number>(Date.now());
+  const previousAudienceKeyRef = useRef<string | null>(null);
 
-  const handleOpenPicker = () => setPickerVisible(true);
+  const handleOpenPicker = () => {
+    trackEvent('view_as_picker_opened');
+    setPickerVisible(true);
+  };
   const handleClosePicker = () => setPickerVisible(false);
 
   const handleSelect = (selection: ViewAsSelection) => {
@@ -37,6 +52,66 @@ function ViewAsPage() {
       setSearchParams({ view_as_user: selection.username }, { replace: true });
     }
   };
+
+  // Fire `_audience_changed` whenever the URL search params resolve to a
+  // new audience (initial mount + every picker selection). Also flush a
+  // dwell event for the previous audience so we can compute "time spent
+  // looking at each audience's view" — a stronger engagement signal than
+  // 'just opened the page once'.
+  useEffect(() => {
+    const audienceKey = viewAsUser ? `user:${viewAsUser}` : tier ? `tier:${tier}` : null;
+    if (!audienceKey) return;
+    // Skip the no-op when the resolved audience is identical to the
+    // previous one (defensive — searchParam changes can re-fire).
+    if (previousAudienceKeyRef.current === audienceKey) return;
+
+    // Flush dwell for the previous audience (if any) before switching.
+    if (previousAudienceKeyRef.current) {
+      const duration_ms = Date.now() - audienceStartedAtRef.current;
+      if (duration_ms >= 500) {
+        trackEvent('view_as_audience_dwell', {
+          audience_key: previousAudienceKeyRef.current,
+          duration_ms,
+        });
+      }
+    }
+
+    audiencesTriedRef.current.add(audienceKey);
+    audienceStartedAtRef.current = Date.now();
+    previousAudienceKeyRef.current = audienceKey;
+
+    trackEvent('view_as_audience_changed', {
+      kind: viewAsUser ? 'user' : 'tier',
+      // For tier picks the audience is just 'public' (only tier we expose);
+      // for user picks, dropping the username keeps the param low-cardinality
+      // for Firebase. The user-level identity isn't analytically useful
+      // anyway — what matters is "user picked a specific friend" vs "public".
+      ...(tier ? { tier } : {}),
+    });
+  }, [tier, viewAsUser, trackEvent]);
+
+  // On unmount: flush dwell for the currently-viewed audience + emit a
+  // session summary with the distinct audience count.
+  useEffect(() => {
+    return () => {
+      if (previousAudienceKeyRef.current) {
+        const duration_ms = Date.now() - audienceStartedAtRef.current;
+        if (duration_ms >= 500) {
+          trackEvent('view_as_audience_dwell', {
+            audience_key: previousAudienceKeyRef.current,
+            duration_ms,
+          });
+        }
+      }
+      // Reading .size at unmount IS the intent — the Set accumulates
+      // across the mount cycle, so snapshotting it at effect-setup time
+      // would always give 0.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      const audiencesTried = audiencesTriedRef.current.size;
+      trackEvent('view_as_session_ended', { audiences_tried: audiencesTried });
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   if (!myProfile?.username) return null;
 


### PR DESCRIPTION
## Summary

The View-as feature (\`/view-as\` route) lets users preview their profile from another perspective: Public, or as a specific friend. It's a strong privacy-anxiety / social-imagination signal that backend can't see at all — only the friend-list fetch on picker open, no audience-switch traffic.

\`screen_view\` already fires when the user navigates to \`/view-as\`, but every subsequent audience switch happens via \`setSearchParams(..., { replace: true })\` which doesn't trigger a new screen_view (we listen to \`location.pathname\`, not search params). So a user trying 5 different audiences in a row currently looks identical to one who opens the page and bounces.

## Events added

- **\`view_as_picker_opened\`** — banner tap, picker bottom sheet opens
- **\`view_as_audience_picked\`** (kind: tier|user, tier?, is_close_friend?) — fires from the picker click handler with relationship category. Username is intentionally NOT logged (high cardinality + analytically uninteresting). What matters: 'close friend' vs 'regular friend' vs 'public'
- **\`view_as_audience_changed\`** — fires on every audience switch (URL search param resolution). Pairs with audience_picked: the latter is intent, this is realized state
- **\`view_as_audience_dwell\`** (audience_key, duration_ms) — flushed on every audience change AND on unmount. Tells us how long users actually inspected each audience
- **\`view_as_session_ended\`** (audiences_tried) — distinct audience count for this mount cycle. The big-picture signal: 'this user tried 4 different audiences in one View-as session' = high privacy concern

## Why this matters for research

View-as engagement is one of the strongest privacy-related behavioral signals available. A user who opens it once and looks at \`public\` tells a different story from one who cycles through 5 specific friends in a row. None of this was previously measurable.

## Test plan
- [x] \`npx craco build\` clean
- [ ] Verify in DebugView once shipped: open /view-as → audience_changed (initial), tap banner → picker_opened, pick a friend → audience_picked + audience_dwell (previous) + audience_changed, leave page → final dwell + session_ended (audiences_tried = N)