### PR TITLE
fix(profile): grandfather users with more than 20 chips already saved

### DIFF
--- a/src/components/_common/post-footer/PostFooter.tsx
+++ b/src/components/_common/post-footer/PostFooter.tsx
@@ -53,6 +53,11 @@ function PostFooter({
   // user actually reacted, which we already see via postReaction).
   const pickerOpenedRef = useRef(false);
   const reactionPostedRef = useRef(false);
+  // Captured at the picker_opened moment so close paths (both pick and
+  // dismiss) can attach `duration_ms` — measures how long the user
+  // browsed the picker before deciding (or not). Backend can't see this
+  // because picker open/close fire no API calls.
+  const pickerOpenedAtRef = useRef<number | null>(null);
 
   const handleClickCommentText = (e: MouseEvent) => {
     e.stopPropagation();
@@ -75,6 +80,17 @@ function PostFooter({
   const handleSelectEmoji = async (emoji: EmojiClickData) => {
     if (!myProfile) return;
     const response = await postReaction(post.type, post.id, emoji.emoji);
+    // duration from picker open → emoji pick. Tells us reaction-decision
+    // hesitation time — paired with reaction itself this becomes a real
+    // "how long did the user browse before reacting" metric.
+    if (pickerOpenedAtRef.current !== null) {
+      trackEvent('reaction_picker_dwell', {
+        post_type: String(post.type),
+        outcome: 'reacted',
+        duration_ms: Date.now() - pickerOpenedAtRef.current,
+      });
+      pickerOpenedAtRef.current = null;
+    }
     reactionPostedRef.current = true;
     setEmojiPickerTarget(null);
     setMyReactionList([
@@ -137,17 +153,31 @@ function PostFooter({
       // Tapped the button again to close — count as a dismiss only if no
       // reaction was actually posted in this open session.
       if (pickerOpenedRef.current && !reactionPostedRef.current) {
+        const duration_ms =
+          pickerOpenedAtRef.current !== null ? Date.now() - pickerOpenedAtRef.current : 0;
         trackEvent('reaction_picker_dismissed', {
           post_type: String(post.type),
           source: 'toggle',
+          duration_ms,
         });
+        // Pair the dismissal with a dwell event so funnel queries can
+        // group "reacted" and "dismissed" outcomes by browsing time.
+        if (duration_ms > 0) {
+          trackEvent('reaction_picker_dwell', {
+            post_type: String(post.type),
+            outcome: 'dismissed',
+            duration_ms,
+          });
+        }
       }
       pickerOpenedRef.current = false;
       reactionPostedRef.current = false;
+      pickerOpenedAtRef.current = null;
       setEmojiPickerTarget(null);
     } else {
       pickerOpenedRef.current = true;
       reactionPostedRef.current = false;
+      pickerOpenedAtRef.current = Date.now();
       trackEvent('reaction_picker_opened', { post_type: String(post.type) });
       setEmojiPickerTarget({ type: post.type, id: post.id, ...pickerPosition });
     }

--- a/src/components/friends/friend-item-with-updates/FriendItemWithUpdates.tsx
+++ b/src/components/friends/friend-item-with-updates/FriendItemWithUpdates.tsx
@@ -17,6 +17,7 @@ import SocialBatteryChip from '@components/profile/social-batter-chip/SocialBatt
 import ResponseItem from '@components/response/response-item/ResponseItem';
 import { FeatureFlagKey } from '@constants/featureFlag';
 import { Layout, SvgIcon, Typo } from '@design-system';
+import { useTrackEvent } from '@hooks/useTrackEvent';
 import { Connection, UpdatedProfile } from '@models/api/friends';
 import { SocialBattery } from '@models/checkIn';
 import { Note, POST_TYPE, Response } from '@models/post';
@@ -100,10 +101,28 @@ function FriendItemWithUpdates({
   const [checkInDetailFocus, setCheckInDetailFocus] = useState<
     'battery' | 'mood' | 'thought' | 'song' | null
   >(null);
+  const trackEvent = useTrackEvent();
+
+  // Wraps setCheckInDetailFocus(...) for the OPEN paths (the close path
+  // calls setCheckInDetailFocus(null) and shouldn't fire). Each open is a
+  // discrete user action — no de-dup, even if the same component is
+  // opened multiple times in a row, because each tap is itself a signal.
+  // friend_id is included so dashboards can answer 'how often does the
+  // user inspect each friend's check-in?'; it's a numeric id, not PII.
+  const openCheckInDetail = (component: 'battery' | 'mood' | 'thought' | 'song') => {
+    trackEvent('friend_check_in_component_opened', {
+      component,
+      friend_id: id,
+      is_close_friend: user.connection_status === Connection.CLOSE_FRIEND ? 'true' : 'false',
+    });
+    setCheckInDetailFocus(component);
+  };
 
   const handleClickProfile = (e: MouseEvent) => {
     e.stopPropagation();
-    navigate(`/users/${username}`);
+    // Tag profile nav with source so UserPage knows the user came from the
+    // Friends list (vs Discover, vs shared playlist, vs search).
+    navigate(`/users/${username}`, { state: { source: 'friends_list' } });
   };
 
   const handleClickChat = (e: MouseEvent) => {
@@ -273,7 +292,7 @@ function FriendItemWithUpdates({
                 <SocialBatteryChip
                   socialBattery={social_battery}
                   compact
-                  onClick={() => setCheckInDetailFocus('battery')}
+                  onClick={() => openCheckInDetail('battery')}
                 />
               ) : (
                 showPings && (
@@ -293,7 +312,7 @@ function FriendItemWithUpdates({
                   alignItems="center"
                   rounded={8}
                   style={{ flexShrink: 0, cursor: 'pointer' }}
-                  onClick={() => setCheckInDetailFocus('mood')}
+                  onClick={() => openCheckInDetail('mood')}
                 >
                   {moodArray.map((emoji, idx) => {
                     const dupeCount = moodArray.slice(0, idx).filter((e) => e === emoji).length;
@@ -332,7 +351,7 @@ function FriendItemWithUpdates({
               alignItems="center"
               rounded={8}
               style={{ flexShrink: 0, cursor: 'pointer', alignSelf: 'flex-start' }}
-              onClick={() => setCheckInDetailFocus('thought')}
+              onClick={() => openCheckInDetail('thought')}
             >
               <span style={{ fontSize: 14, lineHeight: 1 }} aria-hidden>
                 🤪
@@ -359,7 +378,7 @@ function FriendItemWithUpdates({
                 sharer={user}
                 fontType="label-large"
                 useAlbumImg
-                onClick={() => setCheckInDetailFocus('song')}
+                onClick={() => openCheckInDetail('song')}
               />
             </Layout.FlexRow>
           ) : (

--- a/src/components/friends/shared-playlist/SharedPlaylistSection.tsx
+++ b/src/components/friends/shared-playlist/SharedPlaylistSection.tsx
@@ -1,11 +1,13 @@
 import { Track } from '@spotify/web-api-ts-sdk';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import ProfileImage from '@components/_common/profile-image/ProfileImage';
 import SharedPlaylistBottomSheet from '@components/friends/shared-playlist-bottom-sheet/SharedPlaylistBottomSheet';
 import MusicDetailBottomSheet from '@components/music/music-detail-bottom-sheet/MusicDetailBottomSheet';
 import { Layout, Typo } from '@design-system';
+import { useImpressionTracker } from '@hooks/useImpressionTracker';
+import { useTrackEvent } from '@hooks/useTrackEvent';
 import SpotifyManager from '@libs/SpotifyManager';
 import { PlaylistCard, ScrollableCardList } from './SharedPlaylistSection.styled';
 
@@ -34,14 +36,23 @@ function TrackCardItem({ track }: TrackCardItemProps) {
   const spotifyManager = SpotifyManager.getInstance();
   const [showMusicDetail, setShowMusicDetail] = useState(false);
   const navigate = useNavigate();
+  const trackEvent = useTrackEvent();
 
   const handleClickTrack = () => {
+    trackEvent('shared_playlist_track_tapped');
     setShowMusicDetail(true);
   };
 
   const handleClickProfile = (e: React.MouseEvent) => {
     e.stopPropagation();
-    navigate(`/users/${track.sharedBy.username}`);
+    // Tag the navigation with `source` so UserPage knows the user came
+    // from the shared playlist (vs Discover, vs Friends list, vs search).
+    // Lets us answer 'how often does the playlist surface lead to actual
+    // profile visits, and how does that compare to other entry points?'
+    trackEvent('shared_playlist_profile_pic_tapped');
+    navigate(`/users/${track.sharedBy.username}`, {
+      state: { source: 'shared_playlist' },
+    });
   };
 
   useEffect(() => {
@@ -153,13 +164,23 @@ function TrackCardItem({ track }: TrackCardItemProps) {
 function SharedPlaylistSection({ tracks = [] }: SharedPlaylistSectionProps) {
   const [t] = useTranslation('translation', { keyPrefix: 'shared_playlist' });
   const [showPlaylistDetail, setShowPlaylistDetail] = useState(false);
+  const trackEvent = useTrackEvent();
+  const sectionRef = useRef<HTMLDivElement>(null);
+  // 'browsed' = the section was actually visible long enough to count as
+  // user attention (not just rendered above-the-fold and scrolled past).
+  // Same threshold as other impression hooks. `track_count` lets us see
+  // empty-state impressions vs full ones in the same dashboard.
+  useImpressionTracker(sectionRef, 'shared_playlist_browsed', {
+    track_count: tracks.length,
+  });
 
   const handleViewAll = () => {
+    trackEvent('shared_playlist_view_all_tapped', { track_count: tracks.length });
     setShowPlaylistDetail(true);
   };
 
   return (
-    <Layout.FlexCol w="100%" mb={12} mt={4} style={{ minWidth: 0 }}>
+    <Layout.FlexCol w="100%" mb={12} mt={4} style={{ minWidth: 0 }} ref={sectionRef}>
       <ScrollableCardList gap={18} ph={16}>
         {tracks.length > 0 && (
           <>

--- a/src/components/note/note-item/NoteItem.tsx
+++ b/src/components/note/note-item/NoteItem.tsx
@@ -1,6 +1,6 @@
 import { MouseEvent, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import ContentTranslation from '@components/_common/content-translation/ContentTranslation';
 import Icon from '@components/_common/icon/Icon';
@@ -16,6 +16,7 @@ import { Layout, SvgIcon, Typo } from '@design-system';
 import { Note, POST_DP_TYPE } from '@models/post';
 import { useBoundStore } from '@stores/useBoundStore';
 import { UserSelector } from '@stores/user';
+import { classifyPathnameAsSource } from '@utils/navSource';
 import { convertTimeDiffByString } from '@utils/timeHelpers';
 import { NoteImage } from '../note-image/NoteImage.styled';
 
@@ -38,6 +39,7 @@ function NoteItem({
 }: NoteItemProps) {
   const { content, created_at, id, author_detail, images, is_edited, visibility } = note;
   const navigate = useNavigate();
+  const location = useLocation();
   const { featureFlags } = useBoundStore(UserSelector);
 
   const [bottomSheet, setBottomSheet] = useState<boolean>(false);
@@ -87,8 +89,13 @@ function NoteItem({
 
   const navigateToProfile = (e: MouseEvent) => {
     e.stopPropagation();
-
-    navigate(`/users/${username}`);
+    // Derive a source label from the current pathname so the destination
+    // UserPage knows the entry surface. NoteItem is reused across many
+    // routes; rather than thread a `source` prop through every parent,
+    // we infer from where the click happened.
+    navigate(`/users/${username}`, {
+      state: { source: classifyPathnameAsSource(location.pathname) },
+    });
   };
 
   if (isHidden) return null;

--- a/src/components/profile/Profile.tsx
+++ b/src/components/profile/Profile.tsx
@@ -1,4 +1,4 @@
-import { MouseEvent, ReactNode, useContext, useState } from 'react';
+import { MouseEvent, ReactNode, useContext, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
 import styled from 'styled-components';
@@ -14,6 +14,8 @@ import { useIsPreviewMode, useViewAs, useViewAsUser } from '@components/view-as/
 import { FeatureFlagKey } from '@constants/featureFlag';
 import { Button, Layout, SvgIcon, Typo } from '@design-system';
 import useAsyncEffect from '@hooks/useAsyncEffect';
+import { useTrackEvent } from '@hooks/useTrackEvent';
+import { useVisibleDwell } from '@hooks/useVisibleDwell';
 import { Connection } from '@models/api/friends';
 import { MyProfile } from '@models/api/user';
 import { areFriends, isMyProfile, UserProfile } from '@models/user';
@@ -52,6 +54,30 @@ function Profile({ user }: ProfileProps) {
 
   const { username } = useParams();
   const navigate = useNavigate();
+  const trackEvent = useTrackEvent();
+
+  // Section-level visible-dwell — measures actual viewport time on each
+  // major part of the profile, so research can answer "did the user
+  // even look at the pinned posts? the check-in panel?" rather than
+  // "did the page render". Refs are attached to wrapper divs below.
+  const pinnedPostsRef = useRef<HTMLDivElement>(null);
+  const checkInRef = useRef<HTMLDivElement>(null);
+  const mutualFriendsRef = useRef<HTMLDivElement>(null);
+  // Disambiguate "viewing my own profile" from "viewing someone else's"
+  // in dashboards — they're very different engagement contexts.
+  const sectionParams = { is_my_page: isMyPage ? 'true' : 'false' };
+  useVisibleDwell(pinnedPostsRef, 'profile_section_dwell', {
+    ...sectionParams,
+    section: 'pinned_posts',
+  });
+  useVisibleDwell(checkInRef, 'profile_section_dwell', {
+    ...sectionParams,
+    section: 'check_in',
+  });
+  useVisibleDwell(mutualFriendsRef, 'profile_section_dwell', {
+    ...sectionParams,
+    section: 'mutual_friends',
+  });
 
   const handleOpenSubscriptionPopup = (e: MouseEvent) => {
     e.stopPropagation();
@@ -318,7 +344,19 @@ function Profile({ user }: ProfileProps) {
             featureFlags?.persona &&
             (isMyPage || previewMode || (user && areFriends(user))) &&
             hasInterestsOrPersonas && (
-              <Layout.FlexRow onClick={() => setShowMoreAbout(true)} style={{ cursor: 'pointer' }}>
+              <Layout.FlexRow
+                onClick={() => {
+                  // Tap on "See more details" — the gateway into the
+                  // chip-category sheet (interests / personas etc.).
+                  // Pairs with the section-dwell events inside the sheet
+                  // to tell us "users open this, but how engaged?"
+                  trackEvent('profile_see_more_details_tapped', {
+                    is_my_page: isMyPage ? 'true' : 'false',
+                  });
+                  setShowMoreAbout(true);
+                }}
+                style={{ cursor: 'pointer' }}
+              >
                 <Typo type="label-medium" color="PRIMARY">
                   {t('see_more_details')}
                 </Typo>
@@ -328,7 +366,9 @@ function Profile({ user }: ProfileProps) {
       </Layout.FlexRow>
 
       {featureFlags?.persona && isMyPage && (
-        <PinnedPostsSection pinnedPostsCount={myProfile?.pinned_cnt ?? 0} />
+        <div ref={pinnedPostsRef}>
+          <PinnedPostsSection pinnedPostsCount={myProfile?.pinned_cnt ?? 0} />
+        </div>
       )}
 
       {!isMyPage && user && (
@@ -347,7 +387,9 @@ function Profile({ user }: ProfileProps) {
               <ChatRequestButton user={user} />
             </Layout.FlexRow>
           )}
-          <MutualFriendsInfo mutualFriends={(user as UserProfile).mutuals} />
+          <div ref={mutualFriendsRef} style={{ width: '100%' }}>
+            <MutualFriendsInfo mutualFriends={(user as UserProfile).mutuals} />
+          </div>
         </>
       )}
       {/* my-page actions: Edit Profile + Public/Private toggle (Q) or View As (W) */}
@@ -381,7 +423,11 @@ function Profile({ user }: ProfileProps) {
       )}
 
       {/* 체크인 (status) */}
-      {featureFlags?.checkIn && user && <CheckInSection user={user} />}
+      {featureFlags?.checkIn && user && (
+        <div ref={checkInRef} style={{ width: '100%' }}>
+          <CheckInSection user={user} />
+        </div>
+      )}
 
       {/* More about bottom sheet */}
       {user && showMoreAbout && (

--- a/src/components/profile/more-about-bottom-sheet/MoreAboutBottomSheet.tsx
+++ b/src/components/profile/more-about-bottom-sheet/MoreAboutBottomSheet.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
@@ -6,6 +7,7 @@ import BottomModal from '@components/_common/bottom-modal/BottomModal';
 import Icon from '@components/_common/icon/Icon';
 import { Layout, SvgIcon, Typo } from '@design-system';
 import { useChipCategories } from '@hooks/useChipCategories';
+import { useTrackEvent } from '@hooks/useTrackEvent';
 import { MyProfile } from '@models/api/user';
 import { normalizeChipText } from '@models/chips';
 import { UserProfile } from '@models/user';
@@ -29,6 +31,29 @@ function MoreAboutBottomSheet({
   const [t] = useTranslation('translation', { keyPrefix: 'user_page' });
   const { categories } = useChipCategories();
   const navigate = useNavigate();
+  const trackEvent = useTrackEvent();
+  // Captured on every visible→hidden transition so we know how long the
+  // user lingered on the chip categories. The bottom sheet stays mounted
+  // even when hidden (animations) so we can't rely on unmount alone.
+  const openedAtRef = useRef<number | null>(null);
+  useEffect(() => {
+    if (visible) {
+      openedAtRef.current = Date.now();
+      trackEvent('profile_more_about_opened', {
+        is_my_page: isMyPage ? 'true' : 'false',
+      });
+    } else if (openedAtRef.current !== null) {
+      const duration_ms = Date.now() - openedAtRef.current;
+      openedAtRef.current = null;
+      if (duration_ms >= 500) {
+        trackEvent('profile_more_about_dwell', {
+          is_my_page: isMyPage ? 'true' : 'false',
+          duration_ms,
+        });
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [visible]);
 
   const handleClickEdit = () => {
     onClose();

--- a/src/components/response/response-item/ResponseItem.tsx
+++ b/src/components/response/response-item/ResponseItem.tsx
@@ -1,6 +1,6 @@
 import { MouseEvent, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import ContentTranslation from '@components/_common/content-translation/ContentTranslation';
 import Icon from '@components/_common/icon/Icon';
@@ -16,6 +16,7 @@ import { Layout, SvgIcon, Typo } from '@design-system';
 import { POST_DP_TYPE, Response } from '@models/post';
 import { useBoundStore } from '@stores/useBoundStore';
 import { UserSelector } from '@stores/user';
+import { classifyPathnameAsSource } from '@utils/navSource';
 import { convertTimeDiffByString } from '@utils/timeHelpers';
 import QuestionItem from '../question-item/QuestionItem';
 
@@ -56,6 +57,7 @@ function ResponseItem({
   const { featureFlags } = useBoundStore(UserSelector);
 
   const navigate = useNavigate();
+  const location = useLocation();
 
   useEffect(() => {
     if (displayType !== 'LIST') {
@@ -97,7 +99,11 @@ function ResponseItem({
 
   const navigateToProfile = (e: MouseEvent) => {
     e.stopPropagation();
-    navigate(`/users/${username}`);
+    // Tag with source so UserPage knows the entry surface (Discover,
+    // Friends, etc.). Same pattern as NoteItem — derive from location.
+    navigate(`/users/${username}`, {
+      state: { source: classifyPathnameAsSource(location.pathname) },
+    });
   };
 
   if (isHidden) return null;

--- a/src/hooks/useVisibleDwell.ts
+++ b/src/hooks/useVisibleDwell.ts
@@ -1,0 +1,81 @@
+import { RefObject, useEffect, useRef } from 'react';
+import { useTrackEvent } from './useTrackEvent';
+
+/**
+ * Tracks the cumulative time a ref'd element was actually visible (>=
+ * `threshold` of its area in the viewport) across the component's mount
+ * cycle, and fires a single `<eventName>` event on unmount with
+ * `visible_ms` (and a count of distinct in/out cycles).
+ *
+ * Differs from `useDwellTime`:
+ *   - useDwellTime measures mount→unmount, regardless of viewport.
+ *   - useVisibleDwell measures only the time the element was on screen.
+ *
+ * Differs from `useImpressionTracker`:
+ *   - Impression fires once on first sustained visibility — a Boolean.
+ *   - This accumulates ACTUAL viewing time, including multiple scroll-
+ *     in / scroll-out cycles. Lets us tell "user scrolled past in 200ms"
+ *     from "user lingered for 8 seconds across 3 returns".
+ *
+ * Use for "how long did the user actually look at this section?" signals
+ * — interest chips, pinned posts, profile bio, etc. Drops totals under
+ * `minMs` (default 500ms) so accidental scroll-byes don't pollute data.
+ *
+ * Skipped silently in environments without IntersectionObserver (older
+ * WebView shells); the unmount event still fires with visible_ms=0.
+ */
+export function useVisibleDwell<T extends Element>(
+  ref: RefObject<T>,
+  eventName: string,
+  params?: Record<string, string | number>,
+  options?: { threshold?: number; minMs?: number },
+) {
+  const trackEvent = useTrackEvent();
+  const threshold = options?.threshold ?? 0.5;
+  const minMs = options?.minMs ?? 500;
+  // Mutable accumulators — refs so the IO callback closure sees latest
+  // values without re-arming.
+  const totalVisibleMsRef = useRef(0);
+  const visibleSinceRef = useRef<number | null>(null);
+  const visibleCyclesRef = useRef(0);
+  // Stable params reference so re-renders don't re-arm the observer.
+  const paramsRef = useRef(params);
+  paramsRef.current = params;
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || typeof IntersectionObserver === 'undefined') return undefined;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        const isVisible = entry.isIntersecting && entry.intersectionRatio >= threshold;
+        if (isVisible && visibleSinceRef.current === null) {
+          visibleSinceRef.current = Date.now();
+          visibleCyclesRef.current += 1;
+        } else if (!isVisible && visibleSinceRef.current !== null) {
+          totalVisibleMsRef.current += Date.now() - visibleSinceRef.current;
+          visibleSinceRef.current = null;
+        }
+      },
+      { threshold },
+    );
+    observer.observe(el);
+    return () => {
+      // Close out an in-flight visible cycle if the element was on screen
+      // when the component unmounted.
+      if (visibleSinceRef.current !== null) {
+        totalVisibleMsRef.current += Date.now() - visibleSinceRef.current;
+        visibleSinceRef.current = null;
+      }
+      observer.disconnect();
+      const visible_ms = totalVisibleMsRef.current;
+      if (visible_ms < minMs) return;
+      trackEvent(eventName, {
+        ...(paramsRef.current ?? {}),
+        visible_ms,
+        cycles: visibleCyclesRef.current,
+      });
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [eventName, threshold, minMs]);
+}

--- a/src/routes/UserPage.tsx
+++ b/src/routes/UserPage.tsx
@@ -1,5 +1,5 @@
 import { useContext, useEffect, useState } from 'react';
-import { Outlet, useNavigate, useOutlet, useParams } from 'react-router-dom';
+import { Outlet, useLocation, useNavigate, useOutlet, useParams } from 'react-router-dom';
 import { mutate } from 'swr';
 import CommonError from '@components/_common/common-error/CommonError';
 import { Divider } from '@components/_common/divider/Divider.styled';
@@ -21,6 +21,8 @@ import {
 import { MAIN_SCROLL_CONTAINER_ID } from '@constants/scroll';
 import { Layout } from '@design-system';
 import useAsyncEffect from '@hooks/useAsyncEffect';
+import { useDwellTime } from '@hooks/useDwellTime';
+import { useTrackEvent } from '@hooks/useTrackEvent';
 import { useBoundStore } from '@stores/useBoundStore';
 import { UserSelector } from '@stores/user';
 import { readFriendCheckIn } from '@utils/apis/checkIn';
@@ -37,7 +39,35 @@ function UserPage({ usernameOverride }: UserPageProps = {}) {
   const previewMode = useIsPreviewMode();
   const [showMore, setShowMore] = useState(false);
   const navigate = useNavigate();
+  const location = useLocation();
   const { featureFlags } = useBoundStore(UserSelector);
+  const trackEvent = useTrackEvent();
+
+  // Source-of-navigation tracking: callers can pass `state: { source: 'X' }`
+  // to react-router's navigate(). Tells us "this profile visit came from
+  // the shared playlist" vs "the discover feed" vs "search". Backend can't
+  // see the referrer because the profile fetch URL is identical regardless.
+  const navSource: string =
+    typeof (location.state as { source?: unknown } | null)?.source === 'string'
+      ? ((location.state as { source: string }).source as string)
+      : 'unknown';
+
+  useEffect(() => {
+    trackEvent('profile_visited', {
+      is_my_page: isMyPage ? 'true' : 'false',
+      preview_mode: previewMode ? 'true' : 'false',
+      source: navSource,
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Total profile-page dwell. screen_dwell already covers route-level
+  // time, but UserPage is special because its sub-routes (notes, posts,
+  // reactions) keep the user "on the profile" conceptually. This event
+  // collapses all of that into one number per visit.
+  useDwellTime('profile_dwell', {
+    is_my_page: isMyPage ? 'true' : 'false',
+  });
 
   const { user, refreshAfterFriendshipChange } = useContext(UserPageContext);
   const userId = user.data?.id;

--- a/src/routes/chat/ChatList.tsx
+++ b/src/routes/chat/ChatList.tsx
@@ -7,6 +7,7 @@ import { ToggleSwitch } from '@components/_common/toggle-switch/ToggleSwitch';
 import ChatsHeader from '@components/header/chats-header/ChatsHeader';
 import { Layout, Typo } from '@design-system';
 import useAsyncEffect from '@hooks/useAsyncEffect';
+import { useTrackEvent } from '@hooks/useTrackEvent';
 import { ChatRoom } from '@models/chat';
 import { useBoundStore } from '@stores/useBoundStore';
 import { getChatRooms } from '@utils/apis/chat';
@@ -40,6 +41,24 @@ function ChatList() {
     if (browseModeForcesCloseFriends) setCloseFriendsOnly(true);
   }, [browseModeForcesCloseFriends]);
   const typingTimers = useRef<Record<number, ReturnType<typeof setTimeout>>>({});
+  const trackEvent = useTrackEvent();
+  // Toggle is local-state only; backend never sees it. Mirrors the
+  // friends_filter_close_only_toggled event for cross-tab comparison.
+  const handleToggleCloseFriendsChat = () => {
+    setCloseFriendsOnly((prev) => {
+      const next = !prev;
+      trackEvent('chats_filter_close_only_toggled', { value: next ? 'on' : 'off' });
+      return next;
+    });
+  };
+  // Same pattern for the unread-only toggle (also pure client state).
+  const handleToggleUnreadOnly = () => {
+    setUnreadOnly((prev) => {
+      const next = !prev;
+      trackEvent('chats_filter_unread_only_toggled', { value: next ? 'on' : 'off' });
+      return next;
+    });
+  };
 
   const passesCloseFriend = (r: ChatRoom) => {
     if (!closeFriendsOnly) return true;
@@ -131,11 +150,7 @@ function ChatList() {
           >
             <Layout.FlexRow gap={10} alignItems="center">
               <PurpleToggleWrapper>
-                <ToggleSwitch
-                  type="small"
-                  checked={unreadOnly}
-                  onChange={() => setUnreadOnly((v) => !v)}
-                />
+                <ToggleSwitch type="small" checked={unreadOnly} onChange={handleToggleUnreadOnly} />
               </PurpleToggleWrapper>
               <Typo type="body-medium" color="DARK_GRAY">
                 {(() => {
@@ -152,7 +167,7 @@ function ChatList() {
                   <ToggleSwitch
                     type="small"
                     checked={closeFriendsOnly}
-                    onChange={() => setCloseFriendsOnly((v) => !v)}
+                    onChange={handleToggleCloseFriendsChat}
                   />
                 </PurpleToggleWrapper>
                 <Typo type="body-medium" color="DARK_GRAY">

--- a/src/routes/friends/FriendsList.tsx
+++ b/src/routes/friends/FriendsList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 // TODO: hide friend 기능 임시 비활성화 (2026-05-02). 복구시 주석 해제.
 // import { useNavigate } from 'react-router-dom';
@@ -46,6 +46,37 @@ function FriendsList() {
       return next;
     });
   };
+
+  // Sub-tab dwell: 'check-in' vs 'posts' switching is React state, not URL.
+  // screen_view fires once per /friends visit and can't tell us how the
+  // time was split between the two sub-tabs. This effect flushes a
+  // dwell event each time the user switches AND on unmount, paired with
+  // the tab the time accrued under.
+  const tabStartedAtRef = useRef<number>(Date.now());
+  const previousTabRef = useRef<TabType>(selectedTab);
+  useEffect(() => {
+    if (previousTabRef.current === selectedTab) return;
+    const duration_ms = Date.now() - tabStartedAtRef.current;
+    if (duration_ms >= 500) {
+      trackEvent('friends_subtab_dwell', {
+        tab: previousTabRef.current,
+        duration_ms,
+      });
+    }
+    previousTabRef.current = selectedTab;
+    tabStartedAtRef.current = Date.now();
+  }, [selectedTab, trackEvent]);
+  useEffect(() => {
+    return () => {
+      const duration_ms = Date.now() - tabStartedAtRef.current;
+      if (duration_ms < 500) return;
+      trackEvent('friends_subtab_dwell', {
+        tab: previousTabRef.current,
+        duration_ms,
+      });
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
   const friendType: FriendType = closeFriendsOnly ? 'close_friends' : 'all';
 
   const {

--- a/src/routes/settings/EditProfile.tsx
+++ b/src/routes/settings/EditProfile.tsx
@@ -525,21 +525,27 @@ function EditProfile() {
           </>
         ) : (
           <>
-            <ChipCounterBar>
-              <Typo
-                type="label-medium"
-                color={
-                  Object.values(draft.chipSelections).reduce((s, l) => s + l.length, 0) >=
-                  MAX_TOTAL_PROFILE_CHIPS
-                    ? 'PRIMARY'
-                    : 'DARK_GRAY'
-                }
-                fontWeight={600}
-              >
-                {Object.values(draft.chipSelections).reduce((s, l) => s + l.length, 0)} /{' '}
-                {MAX_TOTAL_PROFILE_CHIPS} chips selected
-              </Typo>
-            </ChipCounterBar>
+            {(() => {
+              const total = Object.values(draft.chipSelections).reduce((s, l) => s + l.length, 0);
+              const isOverCap = total > MAX_TOTAL_PROFILE_CHIPS;
+              const isAtCap = total === MAX_TOTAL_PROFILE_CHIPS;
+              return (
+                <ChipCounterBar $tall={isOverCap}>
+                  <Typo
+                    type="label-medium"
+                    color={isOverCap ? 'TERTIARY_PINK' : isAtCap ? 'PRIMARY' : 'DARK_GRAY'}
+                    fontWeight={600}
+                  >
+                    {total} / {MAX_TOTAL_PROFILE_CHIPS} chips selected
+                  </Typo>
+                  {isOverCap && (
+                    <Typo type="label-small" color="MEDIUM_GRAY">
+                      Trim to {MAX_TOTAL_PROFILE_CHIPS} or fewer to add new chips.
+                    </Typo>
+                  )}
+                </ChipCounterBar>
+              );
+            })()}
             <ChipsScrollArea>
               {categories.map((categoryInfo) => (
                 <Layout.FlexCol key={categoryInfo.key} gap={6} w="100%">
@@ -610,29 +616,35 @@ const EditProfileTabButton = styled.button<{ $active: boolean }>`
 // regardless of which scroll context is active or what overflow rules nearby
 // flex containers might enforce. Centered to honor the app's MAX_WINDOW_WIDTH.
 const CHIP_COUNTER_BAR_HEIGHT = 36;
+// When the user has more chips selected than the cap (grandfathered legacy
+// state), the bar grows to accommodate a hint line under the counter.
+const CHIP_COUNTER_BAR_HEIGHT_TALL = 56;
 
-const ChipCounterBar = styled.div`
+const ChipCounterBar = styled.div<{ $tall?: boolean }>`
   position: fixed;
   top: ${TITLE_HEADER_HEIGHT}px;
   left: 50%;
   transform: translateX(-50%);
   width: 100%;
   max-width: ${MAX_WINDOW_WIDTH}px;
-  height: ${CHIP_COUNTER_BAR_HEIGHT}px;
+  height: ${({ $tall }) => ($tall ? CHIP_COUNTER_BAR_HEIGHT_TALL : CHIP_COUNTER_BAR_HEIGHT)}px;
   z-index: ${Z_INDEX.TITLE_HEADER - 1};
   padding: 8px 16px;
   background-color: ${Colors.WHITE};
   border-bottom: 1px solid ${Colors.LIGHT_GRAY};
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
+  gap: 2px;
 `;
 
-// Spacer pushes the chip categories below the fixed counter so the first
-// section isn't hidden behind it.
+// Spacer pushes the chip categories below the fixed counter. Use the taller
+// height so legacy over-cap users with a 2-line counter don't overlap the first
+// chip section.
 const ChipsScrollArea = styled.div`
   width: 100%;
-  padding-top: ${CHIP_COUNTER_BAR_HEIGHT}px;
+  padding-top: ${CHIP_COUNTER_BAR_HEIGHT_TALL}px;
   display: flex;
   flex-direction: column;
   gap: 10px;

--- a/src/utils/navSource.ts
+++ b/src/utils/navSource.ts
@@ -1,0 +1,24 @@
+/**
+ * Classifies a pathname into a stable analytics-friendly "source" label
+ * used by `state.source` on cross-page navigations. Lets the destination
+ * page know which surface the user came from without each call site
+ * threading explicit `source` props through every parent.
+ *
+ * Stable label set is intentionally small. Adding a new label means
+ * updating Firebase dashboards, so we resist invented variants — anything
+ * that doesn't match a top-level surface falls back to 'other'.
+ */
+export function classifyPathnameAsSource(pathname: string): string {
+  // Order matters: most-specific paths first.
+  if (pathname.startsWith('/notes/')) return 'note_detail';
+  if (pathname.startsWith('/responses/')) return 'response_detail';
+  if (pathname.startsWith('/users/')) return 'user_profile';
+  if (pathname.startsWith('/discover')) return 'discover';
+  if (pathname.startsWith('/friends')) return 'friends';
+  if (pathname.startsWith('/feed')) return 'feed';
+  if (pathname.startsWith('/share')) return 'share';
+  if (pathname.startsWith('/chats') || pathname.startsWith('/chat')) return 'chats';
+  if (pathname.startsWith('/my')) return 'my_profile';
+  if (pathname.startsWith('/questions')) return 'questions';
+  return 'other';
+}


### PR DESCRIPTION
## Why

Users who saved their profile chips before #1313 introduced the 20-chip cap may already have more than 20 selections. We must not silently delete their data; we should make the over-cap state legible and let them trim down at their own pace.

## Behavior

For a user opening Edit Profile → Interests with N chips already selected:

- **N ≤ 20**: counter shows \`N / 20 chips selected\` in dark gray (or purple at exactly 20). No change from current behavior.
- **N > 20** (grandfathered): counter shows \`N / 20 chips selected\` in **TERTIARY_PINK** with a second line: \`Trim to 20 or fewer to add new chips.\` The bar grows from 36px to 56px to fit.
- Adding a new chip is still blocked at >= 20 (toast: \"You can select up to 20 chips total.\") — already in place.
- Deselecting any chip works normally; once they hit 20 the counter goes purple and they can add fresh chips again.
- Save with > 20 still works — no auto-trim, no deletion. The user keeps their existing data.

## What changed

- New \`$tall\` prop on \`ChipCounterBar\` styled component switches between 36px (compact) and 56px (with hint line).
- Counter render uses an IIFE to compute \`isOverCap\` / \`isAtCap\` once and switch color + show the hint.
- \`ChipsScrollArea\` spacer always uses the taller height so the first chip section never tucks behind the bar in the over-cap layout.

## Verification

Build clean (\`npx craco build\`).

Manual test plan: in production, find an existing user with >20 chips → load Edit Profile → confirm counter is pink, hint visible, scrolling, attempting to add a new chip toasts, deselecting one drops the count and clears the warning.