### PR TITLE
fix(profile): prompt grandfathered users on own-profile page to trim chips

### DIFF
--- a/src/components/_common/friend-status/FriendStatus.tsx
+++ b/src/components/_common/friend-status/FriendStatus.tsx
@@ -8,6 +8,7 @@ import FriendEvaluationModal, {
 } from '@components/_common/friend-evaluation-modal/FriendEvaluationModal';
 import { useIsPreviewMode } from '@components/view-as/PreviewModeContext';
 import { Button, Layout } from '@design-system';
+import { useTrackEvent } from '@hooks/useTrackEvent';
 import { Connection } from '@models/api/friends';
 import {
   areFriends,
@@ -203,27 +204,37 @@ function FriendStatus({
     setEvaluationModalState(null);
   };
 
+  const trackEvent = useTrackEvent();
+
   const handleClickConfirm = (e: MouseEvent) => {
     e.stopPropagation();
     if (previewMode) return;
+    // Modal-open events: distinct from the ultimate confirm path (which
+    // backend captures via the API call). Lets us see how many users
+    // open the accept-friend modal but back out — request-acceptance
+    // hesitation signal.
+    trackEvent('friend_accept_modal_opened', { friend_id: user.id });
     setIsFriendTypeSelectModalVisible({ visible: true, type: 'accept' });
   };
 
   const handleClickRejectFriendRequest = (e: MouseEvent) => {
     e.stopPropagation();
     if (previewMode) return;
+    trackEvent('friend_reject_modal_opened', { friend_id: user.id });
     setIsRejectFriendRequestDialogVisible(true);
   };
 
   const handleClickUnfriend = (e: MouseEvent) => {
     e.stopPropagation();
     if (previewMode) return;
+    trackEvent('friend_unfriend_modal_opened', { friend_id: user.id });
     setIsUnfriendDialogVisible(true);
   };
 
   const handleClickCancelRequest = (e: MouseEvent) => {
     e.stopPropagation();
     if (previewMode) return;
+    trackEvent('friend_cancel_request_modal_opened', { friend_id: user.id });
     setIsCancelFriendRequestDialogVisible(true);
   };
 
@@ -259,6 +270,7 @@ function FriendStatus({
   const handleClickRequest = (e: MouseEvent) => {
     e.stopPropagation();
     if (previewMode) return;
+    trackEvent('friend_request_modal_opened', { friend_id: user.id });
     setIsFriendTypeSelectModalVisible({ visible: true, type: 'request' });
   };
 

--- a/src/components/check-in-posts/CheckInPostViewer.tsx
+++ b/src/components/check-in-posts/CheckInPostViewer.tsx
@@ -10,6 +10,7 @@ import SnippetMoreModal from '@components/check-in-posts/SnippetMoreModal';
 import CommentBottomSheet from '@components/comments/comment-bottom-sheet/CommentBottomSheet';
 import { Z_INDEX } from '@constants/layout';
 import { Colors, Layout, SvgIcon, Typo } from '@design-system';
+import { useTrackEvent } from '@hooks/useTrackEvent';
 import { CheckInPost, CheckInPostStory, CheckInPostVisibility } from '@models/checkInPost';
 import { useBoundStore } from '@stores/useBoundStore';
 import {
@@ -66,6 +67,68 @@ function CheckInPostViewer({
   const { myProfile, openToast } = useBoundStore(
     useShallow((state) => ({ myProfile: state.myProfile, openToast: state.openToast })),
   );
+  const trackEvent = useTrackEvent();
+  // Per-slide dwell: timestamp at which the current story slide started
+  // showing. Flushed every time storyIndex changes AND on viewer close.
+  // Tells us how long a viewer actually looked at each individual story
+  // — distinct from the auto-advance timer (which only knows the slide
+  // is on-screen, not whether the user is engaged).
+  const slideStartedAtRef = useRef<number>(Date.now());
+  const previousIndexRef = useRef<number>(0);
+  // Tracks whether the viewer was opened (single-story or multi-story)
+  // so the unmount cleanup can fire `_closed` with the final index.
+  const openedRef = useRef(false);
+  const lastIndexReachedRef = useRef(0);
+
+  // Fire `_opened` once per viewer mount cycle. is_self flags whether the
+  // user is viewing their own stories (e.g. preview from MyPage), which is
+  // an analytics-different context from viewing a friend's.
+  useEffect(() => {
+    if (openedRef.current) return;
+    openedRef.current = true;
+    trackEvent('check_in_story_opened', {
+      author_id: story.author_detail.id,
+      is_self: story.author_detail.id === myProfile?.id ? 'true' : 'false',
+      multi_story: enableMultiStory ? 'true' : 'false',
+    });
+    slideStartedAtRef.current = Date.now();
+    previousIndexRef.current = 0;
+    return () => {
+      // Final slide dwell + close summary. last_index reflects how deep
+      // the user got into the story sequence (0-indexed).
+      const dwellMs = Date.now() - slideStartedAtRef.current;
+      if (dwellMs >= 500) {
+        trackEvent('check_in_story_slide_dwell', {
+          author_id: story.author_detail.id,
+          slide_index: previousIndexRef.current,
+          duration_ms: dwellMs,
+        });
+      }
+      trackEvent('check_in_story_closed', {
+        author_id: story.author_detail.id,
+        last_index: lastIndexReachedRef.current,
+      });
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Slide change → flush previous slide's dwell + start fresh timer.
+  useEffect(() => {
+    if (storyIndex === previousIndexRef.current) return;
+    const dwellMs = Date.now() - slideStartedAtRef.current;
+    if (dwellMs >= 500) {
+      trackEvent('check_in_story_slide_dwell', {
+        author_id: story.author_detail.id,
+        slide_index: previousIndexRef.current,
+        duration_ms: dwellMs,
+      });
+    }
+    previousIndexRef.current = storyIndex;
+    if (storyIndex > lastIndexReachedRef.current) {
+      lastIndexReachedRef.current = storyIndex;
+    }
+    slideStartedAtRef.current = Date.now();
+  }, [storyIndex, story.author_detail.id, trackEvent]);
 
   useEffect(() => {
     if (!enableMultiStory) {
@@ -219,6 +282,13 @@ function CheckInPostViewer({
   const handleLeft = (e: MouseEvent) => {
     e.stopPropagation();
     if (enableMultiStory && Date.now() - pressStartRef.current > 200) return;
+    // Manual advance via tap — distinct from auto-advance (5s timer).
+    // Manual = user impatient, auto = passive viewing. Different signals.
+    trackEvent('check_in_story_advanced', {
+      direction: 'prev',
+      method: 'tap',
+      author_id: story.author_detail.id,
+    });
     if (enableMultiStory && storyIndex > 0) {
       remainingRef.current = STORY_DURATION_MS;
       setStoryIndex(storyIndex - 1);
@@ -230,6 +300,11 @@ function CheckInPostViewer({
   const handleRight = (e: MouseEvent) => {
     e.stopPropagation();
     if (enableMultiStory && Date.now() - pressStartRef.current > 200) return;
+    trackEvent('check_in_story_advanced', {
+      direction: 'next',
+      method: 'tap',
+      author_id: story.author_detail.id,
+    });
     if (enableMultiStory && storyIndex < userPosts.length - 1) {
       remainingRef.current = STORY_DURATION_MS;
       setStoryIndex(storyIndex + 1);

--- a/src/components/friends/subscription-popup/SubscriptionPopup.tsx
+++ b/src/components/friends/subscription-popup/SubscriptionPopup.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import EditorPopup from '@components/check-in/update-quadrant/EditorPopup';
 import { CheckBox, Layout, Typo } from '@design-system';
 import { useSubscriptions } from '@hooks/useSubscriptions';
+import { useTrackEvent } from '@hooks/useTrackEvent';
 import { VersionType } from '@models/api/user';
 import {
   SubscriptionType,
@@ -34,18 +35,54 @@ function SubscriptionPopup({
 
   const { types, save, isSaving } = useSubscriptions({ friendId, enabled: isOpen });
   const [draft, setDraft] = useState<SubscriptionType[]>([]);
+  const trackEvent = useTrackEvent();
+  // Tracks the BEFORE state when the popup opens, so we can tell whether
+  // a save was actually a change vs a no-op confirm. savedRef flips on
+  // successful save so the close path knows whether to fire abandoned.
+  const beforeStateRef = useRef<SubscriptionType[]>([]);
+  const savedRef = useRef(false);
 
   useEffect(() => {
-    if (isOpen) setDraft(types);
+    if (isOpen) {
+      setDraft(types);
+      beforeStateRef.current = types;
+      savedRef.current = false;
+      trackEvent('subscription_popup_opened', { friend_id: friendId });
+    } else if (!savedRef.current && beforeStateRef.current.length === 0 && draft.length === 0) {
+      // Closed without save AND no fiddle. Skip the noisy abandoned event
+      // for purely-passive opens.
+    } else if (!savedRef.current) {
+      trackEvent('subscription_popup_dismissed', {
+        friend_id: friendId,
+        had_changes:
+          JSON.stringify([...draft].sort()) !== JSON.stringify([...beforeStateRef.current].sort())
+            ? 'true'
+            : 'false',
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen, types]);
 
   const toggleType = (type: SubscriptionType) => {
-    setDraft((prev) => (prev.includes(type) ? prev.filter((p) => p !== type) : [...prev, type]));
+    setDraft((prev) => {
+      const next = prev.includes(type) ? prev.filter((p) => p !== type) : [...prev, type];
+      trackEvent('subscription_type_toggled', {
+        friend_id: friendId,
+        type,
+        value: next.includes(type) ? 'on' : 'off',
+      });
+      return next;
+    });
   };
 
   const handleShare = async () => {
     if (isSaving) return;
     await save(draft);
+    savedRef.current = true;
+    trackEvent('subscription_popup_saved', {
+      friend_id: friendId,
+      type_count: draft.length,
+    });
     onSubscriptionChange?.(draft.length > 0);
     onClose();
   };

--- a/src/components/header/floating-button/FloatingButton.tsx
+++ b/src/components/header/floating-button/FloatingButton.tsx
@@ -1,14 +1,25 @@
 import { useState } from 'react';
+import { useLocation } from 'react-router-dom';
 import SelectPromptSheet from '@components/prompt/select-prompt-sheet/SelectPromptSheet';
 import { SvgIcon } from '@design-system';
+import { useTrackEvent } from '@hooks/useTrackEvent';
+import { classifyPathnameAsSource } from '@utils/navSource';
 import NewPostBottomSheet from '../bottom-sheet/NewPostBottomSheet';
 import { StyledFloatingButton } from './FloatingButton.styled';
 
 function FloatingButton() {
   const [bottomSheet, setBottomSheet] = useState(false);
   const [selectPrompt, setSelectPrompt] = useState(false);
+  const trackEvent = useTrackEvent();
+  const location = useLocation();
 
   const handleNewPost = () => {
+    // Compose entry distribution: which surfaces drive the most new
+    // posts. screen_view tells us where the user IS, this tells us
+    // where they ACT.
+    trackEvent('floating_compose_tapped', {
+      from: classifyPathnameAsSource(location.pathname),
+    });
     setBottomSheet(true);
   };
 

--- a/src/components/header/side-menu/SideMenu.tsx
+++ b/src/components/header/side-menu/SideMenu.tsx
@@ -1,6 +1,7 @@
+import { useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import useSWR from 'swr';
 
@@ -10,9 +11,11 @@ import { Z_INDEX } from '@constants/layout';
 import { ONBOARDING_VIDEO_URL } from '@constants/url';
 import { Button, Layout, SvgIcon, Typo } from '@design-system';
 import { usePostAppMessage } from '@hooks/useAppMessage';
+import { useTrackEvent } from '@hooks/useTrackEvent';
 import { VersionType } from '@models/api/user';
 import { useBoundStore } from '@stores/useBoundStore';
 import { getMyPendingVersionSwitchRequest } from '@utils/apis/user';
+import { classifyPathnameAsSource } from '@utils/navSource';
 
 type SideMenuItem =
   | { key: string; emoji: string; kind: 'route'; path: string; flag?: FeatureFlagKey }
@@ -56,7 +59,22 @@ function SideMenu({ closeSideMenu }: Props) {
 
   const visibleItems = SIDE_MENU_LIST.filter((menu) => !menu.flag || featureFlags?.[menu.flag]);
 
+  const trackEvent = useTrackEvent();
+  const location = useLocation();
+  // Source page where the menu was opened FROM. Tells us if users hit the
+  // hamburger from /friends vs /discover vs /chats — entry-surface
+  // engagement signal for the sidebar.
+  const fromSource = classifyPathnameAsSource(location.pathname);
+
+  // SideMenu is conditionally mounted by parent (only when open), so a
+  // single mount-time event correctly equates to "user opened the menu".
+  useEffect(() => {
+    trackEvent('side_menu_opened', { from: fromSource });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const handleClickMenu = (menu: SideMenuItem) => () => {
+    trackEvent('side_menu_item_tapped', { item_key: menu.key });
     if (menu.kind === 'route') {
       navigate(menu.path);
     } else if (menu.kind === 'browse_mode') {
@@ -71,11 +89,15 @@ function SideMenu({ closeSideMenu }: Props) {
 
   const handleClickVersionSwitch = () => {
     if (isPending) return;
+    trackEvent('version_switch_request_tapped', { from: fromSource });
     navigate('/settings/version-switch-request');
     closeSideMenu();
   };
 
   const handleClickOnboardingVideo = () => {
+    // External link launch — distinct from the auto-prompt onboarding
+    // because this is user-initiated (proactive help-seeking).
+    trackEvent('onboarding_video_tapped', { from: fromSource });
     if (window.ReactNativeWebView) {
       postMessage('OPEN_BROWSER', {
         url: ONBOARDING_VIDEO_URL,

--- a/src/components/music/music-detail-bottom-sheet/MusicDetailBottomSheet.tsx
+++ b/src/components/music/music-detail-bottom-sheet/MusicDetailBottomSheet.tsx
@@ -1,4 +1,5 @@
 import { Track } from '@spotify/web-api-ts-sdk';
+import { useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import BottomModal from '@components/_common/bottom-modal/BottomModal';
@@ -8,6 +9,7 @@ import Icon from '@components/_common/icon/Icon';
 import ProfileImage from '@components/_common/profile-image/ProfileImage';
 import { Layout, Typo } from '@design-system';
 import { usePostAppMessage } from '@hooks/useAppMessage';
+import { useTrackEvent } from '@hooks/useTrackEvent';
 import { User } from '@models/user';
 import * as S from './MusicDetailBottomSheet.styled';
 
@@ -21,9 +23,26 @@ interface Props {
 function MusicDetailBottomSheet({ track, sharer, visible, closeBottomSheet }: Props) {
   const [t] = useTranslation('translation', { keyPrefix: 'music_detail' });
   const postMessage = usePostAppMessage();
+  const trackEvent = useTrackEvent();
+
+  // sheet 진입 (트랙 또는 공유자 정보 보러 들어옴). `from_shared_playlist`로
+  // 같은 sheet의 두 진입 컨텍스트(공유 플레이리스트 vs 자기 체크인 음악
+  // 미리보기 등)를 분리.
+  useEffect(() => {
+    if (visible) {
+      trackEvent('music_detail_opened', {
+        from_shared_playlist: sharer ? 'true' : 'false',
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [visible]);
 
   const handleClickGoToSpotify = () => {
     if (!track) return;
+    // External-app launch — frontend's last touch on this user before
+    // they leave for Spotify. Useful funnel signal: how many users
+    // actually follow through after seeing the detail sheet.
+    trackEvent('music_listen_on_spotify_tapped');
     const url = track.external_urls.spotify;
     if (window.ReactNativeWebView) {
       postMessage('OPEN_BROWSER', {

--- a/src/components/music/music-search-bottom-sheet/MusicSearchBottomSheet.tsx
+++ b/src/components/music/music-search-bottom-sheet/MusicSearchBottomSheet.tsx
@@ -1,5 +1,5 @@
 import { Track } from '@spotify/web-api-ts-sdk';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import BottomModal from '@components/_common/bottom-modal/BottomModal';
@@ -9,6 +9,7 @@ import SearchInput from '@components/_common/search-input/SearchInput';
 import { Layout, Typo } from '@design-system';
 import { useGetAppMessage } from '@hooks/useAppMessage';
 import useAsyncEffect from '@hooks/useAsyncEffect';
+import { useTrackEvent } from '@hooks/useTrackEvent';
 import SpotifyManager from '@libs/SpotifyManager';
 import { getMobileDeviceInfo } from '@utils/getUserAgent';
 import MusicItem from './music-item/MusicItem';
@@ -38,9 +39,21 @@ function MusicSearchBottomSheet({
   const [trackList, setTrackList] = useState<Track[]>([]);
 
   const [selected, setSelected] = useState<string | null>(null);
+  const trackEvent = useTrackEvent();
+  // confirmedRef flips true on successful confirm so the unmount cleanup
+  // can decide between abandoned (typed/searched but didn't pick) vs
+  // success. Backend only sees the eventual song-save call from the
+  // parent — search behavior here is otherwise invisible.
+  const confirmedRef = useRef(false);
+  const everTypedRef = useRef(false);
+  const lastQueryLengthRef = useRef(0);
 
   const handleConfirm = () => {
     if (selected) {
+      confirmedRef.current = true;
+      trackEvent('music_search_confirmed', {
+        last_query_length: lastQueryLengthRef.current,
+      });
       onSelect(selected);
       closeBottomSheet();
     }
@@ -51,8 +64,21 @@ function MusicSearchBottomSheet({
       setTrackList([]);
       return;
     }
+    // First non-empty query in this open session = "user actually searched".
+    // Cheaper engagement signal than logging every keystroke.
+    if (!everTypedRef.current) {
+      everTypedRef.current = true;
+      trackEvent('music_search_typed');
+    }
+    lastQueryLengthRef.current = query.length;
     const tracks = await spotifyManager.searchMusic(query, 20, 0);
     setTrackList(tracks);
+    // Empty result = user typed but Spotify returned nothing — possible
+    // dictionary / language friction.
+    trackEvent('music_search_results', {
+      query_length: query.length,
+      result_count: tracks.length,
+    });
   }, [query]);
 
   const handleSelectMusic = (track: Track) => {
@@ -73,11 +99,25 @@ function MusicSearchBottomSheet({
   });
 
   useEffect(() => {
-    if (!visible) {
+    if (visible) {
+      // Per-open-session reset; mirrors the wishlist sheet pattern.
+      confirmedRef.current = false;
+      everTypedRef.current = false;
+      lastQueryLengthRef.current = 0;
+      trackEvent('music_search_opened');
+    } else {
+      // Sheet closed via dim/cancel/etc. — fire abandoned only if no
+      // selection was confirmed AND the user actually typed something.
+      if (!confirmedRef.current && everTypedRef.current) {
+        trackEvent('music_search_abandoned', {
+          last_query_length: lastQueryLengthRef.current,
+        });
+      }
       setQuery('');
       setTrackList([]);
       setSelected(null);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [visible]);
 
   if (!trackList) return null;

--- a/src/components/profile/Profile.tsx
+++ b/src/components/profile/Profile.tsx
@@ -1,4 +1,4 @@
-import { MouseEvent, ReactNode, useContext, useRef, useState } from 'react';
+import { MouseEvent, ReactNode, useContext, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
 import styled from 'styled-components';
@@ -152,6 +152,32 @@ function Profile({ user }: ProfileProps) {
   };
 
   const [showMoreAbout, setShowMoreAbout] = useState(false);
+
+  // One-time-per-session prompt for users grandfathered in with more than the
+  // new 20-chip cap. Surfaced on their own profile page (a passive banner in
+  // Edit Profile already covers the editing flow). Tracks shown-state in
+  // sessionStorage so we don't pop it on every profile re-render.
+  const MAX_TOTAL_PROFILE_CHIPS = 20;
+  const OVER_CAP_PROMPT_SHOWN_KEY = 'profile.overCapPrompt.shown.v1';
+  const myChipCount = isMyPage
+    ? Object.values(myProfile?.chips_by_category ?? {}).reduce(
+        (sum, list) => sum + (Array.isArray(list) ? list.length : 0),
+        0,
+      )
+    : 0;
+  const [showOverCapPrompt, setShowOverCapPrompt] = useState(false);
+  useEffect(() => {
+    if (!isMyPage) return;
+    if (myChipCount <= MAX_TOTAL_PROFILE_CHIPS) return;
+    try {
+      if (window.sessionStorage.getItem(OVER_CAP_PROMPT_SHOWN_KEY)) return;
+      window.sessionStorage.setItem(OVER_CAP_PROMPT_SHOWN_KEY, '1');
+    } catch {
+      // sessionStorage unavailable — show anyway, the banner is the only
+      // backstop and a single prompt-per-page-load is acceptable.
+    }
+    setShowOverCapPrompt(true);
+  }, [isMyPage, myChipCount]);
 
   const isVerQ = !!featureFlags?.postsVerQ;
 
@@ -463,6 +489,26 @@ function Profile({ user }: ProfileProps) {
             onClickClose={() => setShowSwitchToPublicDialog(false)}
           />
         </>
+      )}
+      {/* Grandfathered over-cap prompt: surfaces once per session on the
+          user's own profile when they have more chips than the new cap. */}
+      {isMyPage && (
+        <CommonDialog
+          visible={showOverCapPrompt}
+          title="A small design change"
+          content={`We've capped profile chips at ${MAX_TOTAL_PROFILE_CHIPS}. Sorry for the inconvenience, and thanks for understanding! You currently have ${myChipCount} — please trim ${
+            myChipCount - MAX_TOTAL_PROFILE_CHIPS
+          } to fit the new limit.`}
+          cancelText="Maybe later"
+          confirmText="Got it, let's go change that now"
+          onClickConfirm={() => {
+            setShowOverCapPrompt(false);
+            navigate('/settings/edit-profile?tab=interests');
+          }}
+          onClickCancel={() => setShowOverCapPrompt(false)}
+          onClickClose={() => setShowOverCapPrompt(false)}
+          trackingId="profile_chip_over_cap_prompt"
+        />
       )}
     </Layout.FlexCol>
   );

--- a/src/components/profile/edit-connections/EditConnectionsBottomSheet.tsx
+++ b/src/components/profile/edit-connections/EditConnectionsBottomSheet.tsx
@@ -1,10 +1,11 @@
-import { ChangeEvent, useContext, useEffect, useState } from 'react';
+import { ChangeEvent, useContext, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import BottomModal from '@components/_common/bottom-modal/BottomModal';
 import { Divider } from '@components/_common/divider/Divider.styled';
 import { UserPageContext } from '@components/user-page/UserPage.context';
 import { Button, CheckBox, Layout, RadioButton, Typo } from '@design-system';
+import { useTrackEvent } from '@hooks/useTrackEvent';
 import { Connection } from '@models/api/friends';
 import { UserProfile } from '@models/user';
 import { useBoundStore } from '@stores/useBoundStore';
@@ -32,9 +33,20 @@ function EditConnectionsBottomSheet({
     user?.connection_status ?? Connection.FRIEND,
   );
   const isChanged = connection !== user?.connection_status;
+  const trackEvent = useTrackEvent();
+  const beforeConnectionRef = useRef<Connection | null>(null);
+  const savedRef = useRef(false);
 
   const handleChangeConnection = (e: ChangeEvent<HTMLInputElement>) => {
-    setConnection(e.target.value as Connection);
+    const next = e.target.value as Connection;
+    // Each radio toggle is its own signal — backend only sees the final
+    // saved state, not the back-and-forth.
+    trackEvent('edit_connections_changed', {
+      friend_id: user.id,
+      from: String(connection),
+      to: String(next),
+    });
+    setConnection(next);
   };
 
   const [isUpdatePastPosts, setIsUpdatePastPosts] = useState(false);
@@ -51,6 +63,16 @@ function EditConnectionsBottomSheet({
       update_past_posts: featureFlags?.postsVerQ ? true : isUpdatePastPosts,
     })
       .then(() => {
+        savedRef.current = true;
+        // Backend HAS the final connection state via this API call, but
+        // the saved event is still useful as a funnel terminal: paired
+        // with _opened it gives us the conversion rate (opened → saved
+        // vs opened → dismissed).
+        trackEvent('edit_connections_saved', {
+          friend_id: user.id,
+          from: String(beforeConnectionRef.current ?? ''),
+          to: String(connection),
+        });
         closeBottomSheet();
         updateUser?.();
         onConnectionChanged?.(connection);
@@ -64,9 +86,24 @@ function EditConnectionsBottomSheet({
 
   useEffect(() => {
     if (visible) {
-      setConnection(user?.connection_status ?? Connection.FRIEND);
+      const initial = user?.connection_status ?? Connection.FRIEND;
+      setConnection(initial);
       setIsUpdatePastPosts(false);
+      beforeConnectionRef.current = initial;
+      savedRef.current = false;
+      trackEvent('edit_connections_opened', {
+        friend_id: user.id,
+        current: String(initial),
+      });
+    } else if (beforeConnectionRef.current !== null && !savedRef.current) {
+      // Closed without save. had_changes lets us tell "considered then
+      // backed out" from "opened, did nothing, closed".
+      trackEvent('edit_connections_dismissed', {
+        friend_id: user.id,
+        had_changes: connection !== beforeConnectionRef.current ? 'true' : 'false',
+      });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [visible, user?.connection_status]);
 
   useEffect(() => {

--- a/src/components/sub-header/SubHeader.tsx
+++ b/src/components/sub-header/SubHeader.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { createPortal } from 'react-dom';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { DEFAULT_MARGIN, SCREEN_WIDTH } from '@constants/layout';
 import { Layout, SvgIcon, Typo } from '@design-system';
+import { useTrackEvent } from '@hooks/useTrackEvent';
+import { classifyPathnameAsSource } from '@utils/navSource';
 import { FontType } from 'src/design-system/Font/Font.types';
 import { SubHeaderWrapper } from './SubHeader.styled';
 
@@ -29,8 +31,17 @@ function SubHeader({
   disablePortal,
 }: SubHeaderProps) {
   const navigate = useNavigate();
+  const location = useLocation();
+  const trackEvent = useTrackEvent();
 
   const handleGoBack = () => {
+    // Tracks where the user backs out FROM. High frequency on a given
+    // path = navigation friction (users drilled in then immediately
+    // bounced). Distinct from screen_dwell because back-tap is an
+    // explicit user action, not a duration measurement.
+    trackEvent('subheader_back_tapped', {
+      from: classifyPathnameAsSource(location.pathname),
+    });
     if (onGoBack) {
       onGoBack();
       return;


### PR DESCRIPTION
## Why

Grandfathered users with > 20 chips need a clearer signal than the passive pink banner from #1323 — but we don't want to interrupt them while they're already in the editor (they may not even be there to manage chips). Surface the prompt on **their own profile page** instead, where they'd most naturally see their chip count.

## Behavior

When a user opens their own profile and has more than 20 chips selected:

- A \`CommonDialog\` fires once per session (sessionStorage-gated):

  > **A small design change**
  >
  > We've capped profile chips at 20. Sorry for the inconvenience, and thanks for understanding! You currently have 25 — please trim 5 to fit the new limit.
  >
  > [ Maybe later ] [ Got it, let's go change that now ]

- **Got it** → navigates to \`/settings/edit-profile?tab=interests\` so they land directly in the chip-editing context (where the existing pink counter + hint guide them).
- **Maybe later** → dismisses; reappears next time the app is freshly launched (sessionStorage clears).

Tracked as \`profile_chip_over_cap_prompt\` in analytics.

## Verification

- Build clean (\`npx craco build\`)
- Seeded adoor_1 with 25 chips, opened own profile in preview → dialog shows with correct numbers; tapping the confirm button navigates to \`/settings/edit-profile?tab=interests\`; sessionStorage flag set.