### PR TITLE
fix(profile): prevent chip wipe race when categories not loaded

### DIFF
--- a/src/components/browse-mode/BrowseModeSessionPrompt.tsx
+++ b/src/components/browse-mode/BrowseModeSessionPrompt.tsx
@@ -22,6 +22,7 @@ import { postCheckIn } from '@utils/apis/checkIn';
 import { writeLastPickedAt, writeSnoozeUntilEndOfDay } from '@utils/browseModeActiveSession';
 import { HiddenModeKey, readHiddenModes, writeHiddenModes } from '@utils/browseModeHiddenModes';
 import { saveLastPickedMode } from '@utils/browseModeLastPick';
+import { getLastVisibility, VisibilityMemoryKeys } from '@utils/visibilityMemory';
 import BrowseModeCustomizeSheet from './BrowseModeCustomizeSheet';
 import BrowseModeStepMode, { ModeChoice } from './BrowseModeStepMode';
 import BrowseModeWishlistSheet from './BrowseModeWishlistSheet';
@@ -261,6 +262,55 @@ function BrowseModeSessionPrompt({
     [t, openCustomize],
   );
 
+  // Side-effect helper: write `targetBattery` back to the user's CheckIn so
+  // the in-app battery chip and the home tab's friend-card battery match the
+  // mode the user just picked. Critical detail — the `battery_visibility`
+  // sent here MUST follow the user's last-used visibility for the battery
+  // component (read from localStorage). Earlier we hardcoded
+  // `DEFAULT_VISIBILITY.battery` which silently overwrote the user's
+  // preference (e.g. they were sharing battery to close-friends-only and
+  // picking a mode flipped it back to friends).
+  //
+  // The "no existing checkIn" branch creates a fresh check-in so the
+  // server has a row to attach the battery to. Mood / thought / song
+  // remain empty / default so we don't fabricate data the user didn't
+  // intend to share.
+  const syncBatteryToCheckIn = useCallback(
+    async (targetBattery: SocialBattery): Promise<SocialBattery | null> => {
+      const targetBatteryVisibility =
+        getLastVisibility(VisibilityMemoryKeys.checkInBattery) ?? DEFAULT_VISIBILITY.battery;
+      try {
+        if (checkIn) {
+          await postCheckIn({
+            ...checkIn,
+            social_battery: targetBattery,
+            battery_visibility: targetBatteryVisibility,
+          });
+        } else {
+          await postCheckIn({
+            social_battery: targetBattery,
+            mood: [],
+            thought: '',
+            track_id: '',
+            visibility: [ComponentVisibility.FRIENDS],
+            battery_visibility: targetBatteryVisibility,
+            mood_visibility: DEFAULT_VISIBILITY.mood,
+            song_visibility: DEFAULT_VISIBILITY.song,
+            thought_visibility: DEFAULT_VISIBILITY.thought,
+          });
+        }
+        await fetchCheckIn();
+        return targetBattery;
+      } catch {
+        // Sync failures are non-fatal — the mode pick still applies. Surface
+        // by returning null so the caller can suppress the "battery synced"
+        // toast variant.
+        return null;
+      }
+    },
+    [checkIn, fetchCheckIn],
+  );
+
   const applyMode = useCallback(
     async (
       mode: ActiveBrowseMode,
@@ -323,39 +373,8 @@ function BrowseModeSessionPrompt({
       }
       trackEvent('browse_mode_picked', eventParams);
 
-      let batteryApplied: SocialBattery | null = null;
-      if (syncBattery && suggestedBattery) {
-        try {
-          // Existing check-in → spread it whole and override social_battery
-          // (preserves the user's actual visibility, mood, thought, etc.).
-          // No check-in yet → create a fresh one with empty content fields
-          // and DEFAULT_VISIBILITY values; only the battery carries
-          // meaningful content. Backend requires `visibility` on create,
-          // so we always pass it.
-          if (checkIn) {
-            await postCheckIn({
-              ...checkIn,
-              social_battery: suggestedBattery,
-            });
-          } else {
-            await postCheckIn({
-              social_battery: suggestedBattery,
-              mood: [],
-              thought: '',
-              track_id: '',
-              visibility: [ComponentVisibility.FRIENDS],
-              battery_visibility: DEFAULT_VISIBILITY.battery,
-              mood_visibility: DEFAULT_VISIBILITY.mood,
-              song_visibility: DEFAULT_VISIBILITY.song,
-              thought_visibility: DEFAULT_VISIBILITY.thought,
-            });
-          }
-          await fetchCheckIn();
-          batteryApplied = suggestedBattery;
-        } catch {
-          // Sync is best-effort — don't block mode activation on a battery write failure.
-        }
-      }
+      const batteryApplied =
+        syncBattery && suggestedBattery ? await syncBatteryToCheckIn(suggestedBattery) : null;
 
       if (!keepPickerOpen) onFinish();
 
@@ -389,11 +408,10 @@ function BrowseModeSessionPrompt({
       }
     },
     [
-      checkIn,
-      fetchCheckIn,
       myProfile?.id,
       onFinish,
       openToast,
+      syncBatteryToCheckIn,
       trackEvent,
       setActiveBuiltIn,
       setActiveCustom,
@@ -504,17 +522,34 @@ function BrowseModeSessionPrompt({
       }
       pickedInSessionRef.current = true;
       customizeOutcomeRef.current = 'applied';
+      // Mirror applyMode's battery sync: when the user has the sync toggle on
+      // and the snapshot has a default battery, write it back to their
+      // CheckIn so the apply-without-saving path doesn't silently diverge
+      // from the saved-preset path. Same visibility-from-last-pick rule.
+      const batteryApplied =
+        syncBattery && snapshot.default_battery
+          ? await syncBatteryToCheckIn(snapshot.default_battery)
+          : null;
       // Pick log + Firebase event (best-effort, mirrors applyMode).
       logBrowseModePick({ kind: 'apply_without_saving' });
       trackEvent('browse_mode_picked', {
         kind: 'apply_without_saving',
         keep_picker_open: 'false',
-        battery_synced: 'false',
+        battery_synced: batteryApplied ? 'true' : 'false',
         skip_today: skipToday ? 'true' : 'false',
       });
       onFinish();
     },
-    [closeCustomize, editingPreset?.id, myProfile?.id, onFinish, skipToday, trackEvent],
+    [
+      closeCustomize,
+      editingPreset?.id,
+      myProfile?.id,
+      onFinish,
+      skipToday,
+      syncBattery,
+      syncBatteryToCheckIn,
+      trackEvent,
+    ],
   );
 
   const handleConfirmDelete = useCallback(async () => {

--- a/src/routes/settings/EditProfile.tsx
+++ b/src/routes/settings/EditProfile.tsx
@@ -92,16 +92,23 @@ function EditProfile() {
   // favorite_platform and least_favorite_platform, or "Night Owl" in both basic_identities
   // and as_a_friend) would resolve to ALL matching categories — visible to users as
   // a chip wrongly selected in every category. Read from chips_by_category instead.
+  //
+  // CRITICAL: iterate the user's actual saved data (chipsByCategory), NOT the
+  // categories list. The categories list is fetched async via useChipCategories
+  // and may be empty on initial render. If we iterate it here, the draft starts
+  // empty, and a user who taps Done before noticing wipes ALL their saved chips
+  // because handleClickSave unconditionally calls updateChipsByCategory(draft.chipSelections).
   const parseExistingChips = () => {
     const chipsByCategory = myProfile?.chips_by_category ?? {};
     const result: Record<string, string[]> = {};
 
-    categories.forEach((cat) => {
-      const stored = chipsByCategory[cat.key] ?? [];
-      // Map each stored chip to its canonical-cased option, falling back to the stored
-      // text (so chips removed from the option list still render as user-selected).
-      result[cat.key] = stored.map(
-        (m) => cat.chips.find((c) => normalizeChipText(c) === normalizeChipText(m)) || m,
+    Object.entries(chipsByCategory).forEach(([catKey, stored]) => {
+      if (!Array.isArray(stored)) return;
+      // If category metadata is loaded, normalize chip casing against the
+      // canonical option list; otherwise pass the saved text through verbatim.
+      const cat = categories.find((c) => c.key === catKey);
+      result[catKey] = stored.map(
+        (m) => cat?.chips.find((c) => normalizeChipText(c) === normalizeChipText(m)) || m,
       );
     });
 
@@ -357,9 +364,29 @@ function EditProfile() {
   const handleClickSave = async () => {
     if (!myProfile || isSaving) return;
 
+    // Guard against the chip-wipe race: if the categories list never loaded
+    // AND the user has saved chips on the backend that aren't reflected in
+    // the draft (because the draft was initialized before the data arrived),
+    // skip the chip save. Better to no-op than to silently wipe their data.
+    const draftChipCount = Object.values(draft.chipSelections).reduce(
+      (s, l) => s + (Array.isArray(l) ? l.length : 0),
+      0,
+    );
+    const savedChipCount = Object.values(myProfile.chips_by_category ?? {}).reduce(
+      (s, l) => s + (Array.isArray(l) ? l.length : 0),
+      0,
+    );
+    const safeToSaveChips = !(draftChipCount === 0 && savedChipCount > 0);
+
     setIsSaving(true);
     try {
-      await updateChipsByCategory(draft.chipSelections);
+      if (safeToSaveChips) {
+        await updateChipsByCategory(draft.chipSelections);
+      } else {
+        openToast({
+          message: "Couldn't load your chips — try again in a moment.",
+        });
+      }
     } catch {
       // Chip save failed, continue with profile save
     }


### PR DESCRIPTION
## The bug

Users reported their saved profile chips getting wiped on save. Root cause is a race in \`EditProfile.tsx\` that has been there a while but only got triggered loudly after #1326 started routing grandfathered (>20 chip) users *into* Edit Profile via a dialog.

\`parseExistingChips()\` iterated \`categories\` (from \`useChipCategories()\`, fetched async). When a user lands on Edit Profile faster than the categories list resolves, that loop runs over an empty array and the resulting \`draft.chipSelections\` is \`{}\`. \`useState\` only honors the initial value once, so once the draft is empty it stays empty even after categories load.

\`handleClickSave\` then unconditionally fires \`updateChipsByCategory(draft.chipSelections)\` with \`{}\`, which the backend treats as \"replace all interests with this empty dict\" and wipes every saved chip.

The window was fast enough on most devices that this rarely fired in practice. After #1326, more grandfathered users started getting routed straight to Edit Profile mid-load, and the race won often enough to be reproducible at scale.

## Fixes (in this PR)

1. **\`parseExistingChips\` now iterates \`Object.entries(chipsByCategory)\`** — the user's saved data — instead of the categories list. The chips are preserved verbatim if categories haven't loaded yet, and normalized to canonical casing once they have. The draft can no longer start empty when there's saved data.

2. **Save guard in \`handleClickSave\`** — if \`draft.chipSelections\` is empty *and* the backend has saved chips, we skip the chip save entirely and toast \`\"Couldn't load your chips — try again in a moment.\"\` Treat this as a defense-in-depth backstop in case any other code path leaves the draft empty.

## What this can NOT do

This stops *future* losses. It does not restore chips already wiped — that data is gone. If you want, we can pull the daily DB backup and write a one-off script to restore missing \`Interest\` rows for affected users.

## Verification

Build clean (\`npx craco build\`).

Local repro: seeded adoor_1 with 16 chips across categories, opened Edit Profile → counter immediately shows \`16 / 20 chips selected\` (previously could show \`0 / 20\` when categories race lost). Tapped Done → chips persisted.