### PR TITLE
fix(profile): re-sync chip draft when myProfile/categories arrive late

### DIFF
--- a/src/routes/settings/EditProfile.tsx
+++ b/src/routes/settings/EditProfile.tsx
@@ -170,6 +170,36 @@ function EditProfile() {
     categoryVisibility: initialCategoryVisibility,
   });
 
+  // Re-sync chip selections when the source data arrives. Two async sources
+  // can be late: `myProfile.chips_by_category` (Zustand store) and `categories`
+  // (useChipCategories API). Without this, a user who lands on Edit Profile
+  // before either resolves would see ALL chips unselected — and tapping Save
+  // (or just toggling one new chip) would clobber their saved selections.
+  // Only re-sync when the draft is currently empty AND the backend has chips,
+  // so we don't trample edits-in-progress.
+  useEffect(() => {
+    const savedByCategory = myProfile?.chips_by_category ?? {};
+    const savedTotal = Object.values(savedByCategory).reduce(
+      (s, l) => s + (Array.isArray(l) ? l.length : 0),
+      0,
+    );
+    const draftTotal = Object.values(draft.chipSelections).reduce(
+      (s, l) => s + (Array.isArray(l) ? l.length : 0),
+      0,
+    );
+    if (draftTotal > 0 || savedTotal === 0) return;
+    const refreshed: Record<string, string[]> = {};
+    Object.entries(savedByCategory).forEach(([catKey, stored]) => {
+      if (!Array.isArray(stored)) return;
+      const cat = categories.find((c) => c.key === catKey);
+      refreshed[catKey] = stored.map(
+        (m) => cat?.chips.find((c) => normalizeChipText(c) === normalizeChipText(m)) || m,
+      );
+    });
+    setDraft((prev) => ({ ...prev, chipSelections: refreshed }));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [myProfile?.chips_by_category, categories.length]);
+
   const [usernameError, setUsernameError] = useState<string>();
 
   const inputRef = useRef<HTMLInputElement>(null);


### PR DESCRIPTION
## Why

Follow-up to #1328. That PR fixed the case where \`categories\` (from \`useChipCategories\`) arrived late — but the same race exists for \`myProfile.chips_by_category\` (from the Zustand user slice). When a user lands on Edit Profile fast enough that *either* source hasn't resolved, \`parseExistingChips()\` returns \`{}\`, the \`useState\` initializer locks that in, and chips render as unselected — making it look like they have to start fresh, when they're actually meant to be deselecting.

Combined with #1326 routing >20-chip users straight from their own profile into Edit Profile, this race fired often.

## What

Added a \`useEffect\` in \`EditProfile.tsx\` that watches \`myProfile?.chips_by_category\` and \`categories.length\`. If the draft is currently empty AND the backend has saved chips, re-build the draft from the saved data (normalizing chip casing against the now-loaded category options).

The guard \`draftTotal > 0\` prevents trampling edits-in-progress: once the user has touched anything, we never silently overwrite their draft.

## Verification

Build clean. Local: seeded adoor_1 with 6 chips across 5 categories (Instagram + Pinterest in Favorite Platform, TikTok in Least Favorite, Coding in Hobbies, Hip-Hop in Music, Lurker in Online Persona). Opened Edit Profile → counter shows \`6 / 20\`, all six chips render in their correct selected color in their respective category section. TikTok in Favorite Platform stays unselected (correct — user only has it as Least Favorite).