### PR TITLE
Ver.Q 게시글 좋아요 UI·q/user 라우팅·상세 API·낙관적 업데이트

### DIFF
--- a/src/components/_common/like-button/LikeButton.tsx
+++ b/src/components/_common/like-button/LikeButton.tsx
@@ -12,7 +12,11 @@ interface LikeButtonProps {
   m?: number;
   iconSize: number;
   outerSize?: number;
+  /** Align icon inside the hit box; `start` avoids dead space before trailing footer text. */
+  iconAlign?: 'center' | 'start';
   refresh?: () => void;
+  /** Called after a successful like/unlike so parents can optimistically update counts before `refresh` finishes. */
+  onLikeUpdated?: (liked: boolean, likeId: number | null) => void;
 }
 
 function LikeButton({
@@ -22,7 +26,9 @@ function LikeButton({
   iconSize,
   m = 6,
   outerSize = 48,
+  iconAlign = 'center',
   refresh,
+  onLikeUpdated,
 }: LikeButtonProps) {
   const [t] = useTranslation('translation');
   const { openToast } = useBoundStore((state) => ({
@@ -50,6 +56,7 @@ function LikeButton({
         },
       );
       setLikeId(like_id);
+      onLikeUpdated?.(true, like_id);
       openToast({ message: t('likes.toast_liked') });
       refresh?.();
     } catch (error) {
@@ -70,6 +77,7 @@ function LikeButton({
         });
       });
       setLikeId(null);
+      onLikeUpdated?.(false, null);
       openToast({ message: t('likes.toast_unliked') });
       refresh?.();
     } catch (error) {
@@ -86,7 +94,12 @@ function LikeButton({
   };
 
   return (
-    <Layout.FlexRow alignItems="center" w={outerSize} h={outerSize} justifyContent="center">
+    <Layout.FlexRow
+      alignItems="center"
+      w={outerSize}
+      h={outerSize}
+      justifyContent={iconAlign === 'start' ? 'flex-start' : 'center'}
+    >
       {postId && (
         <S.IconButton type="button" m={m} onClick={toggleLike} size={iconSize} disabled={isLoading}>
           <SvgIcon name={likeId ? 'like_filled' : 'like'} size={iconSize} />

--- a/src/components/_common/post-footer/PostFooterLikeOnly.tsx
+++ b/src/components/_common/post-footer/PostFooterLikeOnly.tsx
@@ -1,5 +1,7 @@
 import { MouseEvent } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import ProfileImage from '@components/_common/profile-image/ProfileImage';
 import { Layout, Typo } from '@design-system';
 import { Note, POST_DP_TYPE, POST_TYPE, Response } from '@models/post';
 import Icon from '../icon/Icon';
@@ -11,6 +13,7 @@ type PostFooterLikeOnlyProps = {
   showComments: () => void;
   setInputFocus: () => void;
   refresh?: () => void;
+  onLikeUpdated?: (liked: boolean, likeId: number | null) => void;
 };
 
 function PostFooterLikeOnly({
@@ -19,11 +22,27 @@ function PostFooterLikeOnly({
   showComments,
   setInputFocus,
   refresh,
+  onLikeUpdated,
 }: PostFooterLikeOnlyProps) {
-  const { comment_count, current_user_like_id } = post;
+  const navigate = useNavigate();
+  const { comment_count, current_user_like_id, like_count, like_user_sample } = post;
   const [t] = useTranslation('translation', {
     keyPrefix: post.type === POST_TYPE.RESPONSE ? 'responses' : 'notes',
   });
+
+  const navigateToLikes = (e: MouseEvent) => {
+    e.stopPropagation();
+    if (post.type === POST_TYPE.RESPONSE) {
+      navigate(`/responses/${post.id}/likes`);
+    } else {
+      navigate(`/notes/${post.id}/likes`);
+    }
+  };
+
+  const navigateToUser = (e: MouseEvent, username: string) => {
+    e.stopPropagation();
+    navigate(`/users/${username}`);
+  };
 
   const handleClickCommentText = (e: MouseEvent) => {
     e.stopPropagation();
@@ -36,8 +55,11 @@ function PostFooterLikeOnly({
     setInputFocus();
   };
 
+  const sampleUsers = like_user_sample ?? [];
+  const showLikeMeta = typeof like_count === 'number' ? like_count > 0 : (like_count ?? 0) > 0;
+
   return (
-    <Layout.FlexRow
+    <Layout.FlexCol
       gap={8}
       w="100%"
       style={{
@@ -45,34 +67,83 @@ function PostFooterLikeOnly({
         flexShrink: 0,
         marginTop: 'auto',
       }}
-      alignItems="center"
     >
-      <LikeButton
-        postType={post.type === POST_TYPE.RESPONSE ? 'Response' : 'Note'}
-        postId={post.id}
-        currentUserLikeId={current_user_like_id}
-        iconSize={23}
-        refresh={refresh}
-      />
-      {displayType === 'LIST' && (
-        <Layout.FlexRow w={48} h={48} alignItems="center" justifyContent="center">
-          <Icon name="add_comment" size={23} onClick={handleClickCommentIcon} />
+      <Layout.FlexRow
+        gap={12}
+        w="100%"
+        alignItems="center"
+        justifyContent="space-between"
+        style={{ flexWrap: 'wrap' }}
+      >
+        {/* 하트 바로 오른쪽: 좋아요 수 → 샘플 프로필(최대 3) */}
+        <Layout.FlexRow gap={0} alignItems="center" style={{ flexWrap: 'nowrap', minWidth: 0 }}>
+          <LikeButton
+            postType={post.type === POST_TYPE.RESPONSE ? 'Response' : 'Note'}
+            postId={post.id}
+            currentUserLikeId={current_user_like_id}
+            iconSize={23}
+            iconAlign="start"
+            m={3}
+            outerSize={30}
+            refresh={refresh}
+            onLikeUpdated={onLikeUpdated}
+          />
+          {showLikeMeta && (
+            <button type="button" onClick={navigateToLikes}>
+              <Typo type="label-large" color="BLACK" underline>
+                {like_count} {t('likes')}
+              </Typo>
+            </button>
+          )}
+          {sampleUsers.length > 0 && (
+            <Layout.FlexRow alignItems="center" ml={4}>
+              {sampleUsers.slice(0, SAMPLE_AVATAR_COUNT).map((user, index) => (
+                <Layout.FlexRow
+                  key={user.username}
+                  ml={index === 0 ? 0 : -AVATAR_OVERLAP}
+                  z={SAMPLE_AVATAR_COUNT - index}
+                  style={{ position: 'relative' }}
+                >
+                  <button
+                    type="button"
+                    onClick={(e) => navigateToUser(e, user.username)}
+                    aria-label={user.username}
+                  >
+                    <ProfileImage
+                      imageUrl={user.profile_image}
+                      username={user.username}
+                      size={26}
+                    />
+                  </button>
+                </Layout.FlexRow>
+              ))}
+            </Layout.FlexRow>
+          )}
         </Layout.FlexRow>
-      )}
-      {!!comment_count && (
-        <Layout.FlexRow>
-          <button
-            type="button"
-            onClick={displayType === 'LIST' ? handleClickCommentText : undefined}
-          >
-            <Typo type="label-large" color="BLACK" underline>
-              {comment_count ?? 0} {t('comments')}
-            </Typo>
-          </button>
+
+        <Layout.FlexRow gap={8} alignItems="center">
+          {displayType === 'LIST' && (
+            <Layout.FlexRow w={48} h={48} alignItems="center" justifyContent="center">
+              <Icon name="add_comment" size={23} onClick={handleClickCommentIcon} />
+            </Layout.FlexRow>
+          )}
+          {!!comment_count && (
+            <button
+              type="button"
+              onClick={displayType === 'LIST' ? handleClickCommentText : undefined}
+            >
+              <Typo type="label-large" color="BLACK" underline>
+                {comment_count ?? 0} {t('comments')}
+              </Typo>
+            </button>
+          )}
         </Layout.FlexRow>
-      )}
-    </Layout.FlexRow>
+      </Layout.FlexRow>
+    </Layout.FlexCol>
   );
 }
+
+const SAMPLE_AVATAR_COUNT = 3;
+const AVATAR_OVERLAP = 10;
 
 export default PostFooterLikeOnly;

--- a/src/components/note/note-item/NoteItem.tsx
+++ b/src/components/note/note-item/NoteItem.tsx
@@ -1,4 +1,4 @@
-import { MouseEvent, useState } from 'react';
+import { MouseEvent, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
@@ -16,7 +16,9 @@ import { Layout, SvgIcon, Typo } from '@design-system';
 import { Note, POST_DP_TYPE, ShareType } from '@models/post';
 import { useBoundStore } from '@stores/useBoundStore';
 import { UserSelector } from '@stores/user';
+import { isPostsVerQClient } from '@utils/apis/userApiPrefix';
 import { classifyPathnameAsSource } from '@utils/navSource';
+import { applyLikeUserSampleOptimistic } from '@utils/optimisticLikeUserSample';
 import { convertTimeDiffByString } from '@utils/timeHelpers';
 import { NoteImage } from '../note-image/NoteImage.styled';
 
@@ -53,12 +55,35 @@ function NoteItem({
   const isMissionPost = share_type === ShareType.MISSION;
   const navigate = useNavigate();
   const location = useLocation();
-  const { featureFlags } = useBoundStore(UserSelector);
+  const { featureFlags, myProfile } = useBoundStore(UserSelector);
+  const postsVerQUi = isPostsVerQClient(featureFlags?.postsVerQ, myProfile?.current_ver);
 
   const [bottomSheet, setBottomSheet] = useState<boolean>(false);
   const [showMore, setShowMore] = useState(false);
   const [inputFocus, setInputFocus] = useState(false);
   const [isHidden, setIsHidden] = useState(false);
+  const [likePatch, setLikePatch] = useState<Partial<Note> | null>(null);
+
+  const footerPost = useMemo(
+    () => (likePatch ? { ...note, ...likePatch } : note),
+    [note, likePatch],
+  );
+
+  useEffect(() => {
+    setLikePatch(null);
+  }, [note.id, note.like_count, note.current_user_like_id]);
+
+  const handleLikeUpdated = (liked: boolean, likeId: number | null) => {
+    setLikePatch((prev) => {
+      const base = { ...note, ...prev };
+      const c = base.like_count ?? 0;
+      return {
+        current_user_like_id: likeId,
+        like_count: liked ? c + 1 : Math.max(0, c - 1),
+        like_user_sample: applyLikeUserSampleOptimistic(base.like_user_sample, liked, myProfile),
+      };
+    });
+  };
 
   const { emojiPickerTarget, setEmojiPickerTarget } = useBoundStore((state) => ({
     emojiPickerTarget: state.emojiPickerTarget,
@@ -147,7 +172,7 @@ function NoteItem({
                 mutualFriendCount={author_detail.mutual_friend_count ?? 0}
                 mutualInterestCount={author_detail.mutual_interest_count ?? 0}
                 mutualPersonaCount={author_detail.mutual_persona_count ?? 0}
-                hideTraits={featureFlags?.postsVerQ}
+                hideTraits={postsVerQUi}
               />
             )}
           </Layout.FlexRow>
@@ -227,13 +252,14 @@ function NoteItem({
     </Layout.FlexCol>
   );
 
-  const footerJsx = featureFlags?.postsVerQ ? (
+  const footerJsx = postsVerQUi ? (
     <PostFooterLikeOnly
-      post={note}
+      post={footerPost}
       showComments={() => setBottomSheet(true)}
       setInputFocus={() => setInputFocus(true)}
       displayType={displayType}
       refresh={refresh}
+      onLikeUpdated={handleLikeUpdated}
     />
   ) : featureFlags?.friendList ? (
     <PostFooter

--- a/src/components/note/note-section/NoteSection.tsx
+++ b/src/components/note/note-section/NoteSection.tsx
@@ -13,6 +13,7 @@ import { NoteFeedItem, POST_TYPE } from '@models/post';
 import { useBoundStore } from '@stores/useBoundStore';
 import { UserSelector } from '@stores/user';
 import { readUserAllNotes } from '@utils/apis/user';
+import { userListApiPrefixForViewer } from '@utils/apis/userApiPrefix';
 import { withViewAs } from '@utils/apis/withViewAs';
 import NoteItem from '../note-item/NoteItem';
 import NoteLoader from '../note-loader/NoteLoader';
@@ -37,8 +38,6 @@ function NoteSection({ username }: NoteSectionProps) {
     return navigate('/notes/new');
   };
 
-  const isDefault = !!featureFlags?.friendFeed;
-
   const {
     targetRef,
     data: notes,
@@ -47,7 +46,10 @@ function NoteSection({ username }: NoteSectionProps) {
     mutate: refetchNotes,
   } = useSWRInfiniteScroll<NoteFeedItem>({
     key: withViewAs(
-      `/user/${encodeURIComponent(username || 'me')}/notes/${isDefault ? 'default' : ''}`,
+      `${userListApiPrefixForViewer(
+        featureFlags?.postsVerQ,
+        myProfile?.current_ver,
+      )}user/${encodeURIComponent(username || 'me')}/notes/`,
       { viewAs, viewAsUser },
     ),
   });

--- a/src/components/post/AllPostSection.tsx
+++ b/src/components/post/AllPostSection.tsx
@@ -12,7 +12,10 @@ import { useViewAs, useViewAsUser } from '@components/view-as/PreviewModeContext
 import { Layout } from '@design-system';
 import { useSWRInfiniteScroll } from '@hooks/useSWRInfiniteScroll';
 import { AllPostFeedItem, POST_TYPE } from '@models/post';
+import { useBoundStore } from '@stores/useBoundStore';
+import { UserSelector } from '@stores/user';
 import { readUserAllNotes, readUserAllResponses } from '@utils/apis/user';
+import { userListApiPrefixForViewer } from '@utils/apis/userApiPrefix';
 import { withViewAs } from '@utils/apis/withViewAs';
 
 type AllPostSectionProps = {
@@ -23,6 +26,7 @@ type AllPostSectionProps = {
 function AllPostSection({ username }: AllPostSectionProps) {
   const [t] = useTranslation('translation');
   const { user } = useContext(UserPageContext);
+  const { featureFlags, myProfile } = useBoundStore(UserSelector);
   const areFriends = user?.data?.are_friends === true;
   const isMyPage = !username;
   const viewAs = useViewAs();
@@ -35,10 +39,16 @@ function AllPostSection({ username }: AllPostSectionProps) {
     isLoadingMore: isPostsLoadingMore,
     mutate: refetchPosts,
   } = useSWRInfiniteScroll<AllPostFeedItem>({
-    key: withViewAs(`/user/${encodeURIComponent(username || 'me')}/all-posts/`, {
-      viewAs,
-      viewAsUser,
-    }),
+    key: withViewAs(
+      `${userListApiPrefixForViewer(
+        featureFlags?.postsVerQ,
+        myProfile?.current_ver,
+      )}user/${encodeURIComponent(username || 'me')}/all-posts/`,
+      {
+        viewAs,
+        viewAsUser,
+      },
+    ),
   });
 
   const { noteId, responseId } = useParams();

--- a/src/components/response/response-item/ResponseItem.tsx
+++ b/src/components/response/response-item/ResponseItem.tsx
@@ -1,4 +1,4 @@
-import { MouseEvent, useEffect, useState } from 'react';
+import { MouseEvent, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
@@ -16,7 +16,9 @@ import { Layout, SvgIcon, Typo } from '@design-system';
 import { POST_DP_TYPE, Response } from '@models/post';
 import { useBoundStore } from '@stores/useBoundStore';
 import { UserSelector } from '@stores/user';
+import { isPostsVerQClient } from '@utils/apis/userApiPrefix';
 import { classifyPathnameAsSource } from '@utils/navSource';
+import { applyLikeUserSampleOptimistic } from '@utils/optimisticLikeUserSample';
 import { convertTimeDiffByString } from '@utils/timeHelpers';
 import QuestionItem from '../question-item/QuestionItem';
 
@@ -51,12 +53,35 @@ function ResponseItem({
   const [inputFocus, setInputFocus] = useState(false);
   const [showMore, setShowMore] = useState(false);
   const [isHidden, setIsHidden] = useState(false);
+  const [likePatch, setLikePatch] = useState<Partial<Response> | null>(null);
+
+  const footerPost = useMemo(
+    () => (likePatch ? { ...response, ...likePatch } : response),
+    [response, likePatch],
+  );
+
+  useEffect(() => {
+    setLikePatch(null);
+  }, [response.id, response.like_count, response.current_user_like_id]);
 
   const { emojiPickerTarget, setEmojiPickerTarget } = useBoundStore((state) => ({
     emojiPickerTarget: state.emojiPickerTarget,
     setEmojiPickerTarget: state.setEmojiPickerTarget,
   }));
-  const { featureFlags } = useBoundStore(UserSelector);
+  const { featureFlags, myProfile } = useBoundStore(UserSelector);
+  const postsVerQUi = isPostsVerQClient(featureFlags?.postsVerQ, myProfile?.current_ver);
+
+  const handleLikeUpdated = (liked: boolean, likeId: number | null) => {
+    setLikePatch((prev) => {
+      const base = { ...response, ...prev };
+      const c = base.like_count ?? 0;
+      return {
+        current_user_like_id: likeId,
+        like_count: liked ? c + 1 : Math.max(0, c - 1),
+        like_user_sample: applyLikeUserSampleOptimistic(base.like_user_sample, liked, myProfile),
+      };
+    });
+  };
 
   const navigate = useNavigate();
   const location = useLocation();
@@ -144,7 +169,7 @@ function ResponseItem({
                 mutualFriendCount={author_detail.mutual_friend_count ?? 0}
                 mutualInterestCount={author_detail.mutual_interest_count ?? 0}
                 mutualPersonaCount={author_detail.mutual_persona_count ?? 0}
-                hideTraits={featureFlags?.postsVerQ}
+                hideTraits={postsVerQUi}
               />
             )}
           </Layout.FlexRow>
@@ -226,13 +251,14 @@ function ResponseItem({
       <QuestionItem question={question} disableNavigation={disableQuestionNavigation} />
     ) : null;
 
-  const footerJsx = featureFlags?.postsVerQ ? (
+  const footerJsx = postsVerQUi ? (
     <PostFooterLikeOnly
-      post={response}
+      post={footerPost}
       showComments={() => setBottomSheet(true)}
       setInputFocus={() => setInputFocus(true)}
       displayType={displayType}
       refresh={refresh}
+      onLikeUpdated={handleLikeUpdated}
     />
   ) : (
     <PostFooter

--- a/src/components/user-page/UserPage.context.tsx
+++ b/src/components/user-page/UserPage.context.tsx
@@ -9,6 +9,7 @@ import { UserProfile } from '@models/user';
 import { useBoundStore } from '@stores/useBoundStore';
 import { UserSelector } from '@stores/user';
 import { getUserProfile } from '@utils/apis/user';
+import { userListApiPrefixForViewer } from '@utils/apis/userApiPrefix';
 
 interface Props {
   children?: ReactNode | ReactNode[];
@@ -30,7 +31,7 @@ export function UserPageContextProvider({ children, usernameOverride }: Props) {
   const username = usernameOverride ?? params.username;
   const viewAs = useViewAs();
   const viewAsUser = useViewAsUser();
-  const { featureFlags } = useBoundStore(useShallow(UserSelector));
+  const { featureFlags, myProfile } = useBoundStore(useShallow(UserSelector));
   const useAllPosts = !!featureFlags?.questionResponseFeature;
 
   const [user, setUser] = useState<FetchState<UserProfile>>({ state: 'loading' });
@@ -57,11 +58,12 @@ export function UserPageContextProvider({ children, usernameOverride }: Props) {
       return;
     }
     const encoded = encodeURIComponent(username);
+    const p = userListApiPrefixForViewer(featureFlags?.postsVerQ, myProfile?.current_ver);
     await Promise.all([
       updateUser(),
-      mutate(useAllPosts ? `/user/${encoded}/all-posts/` : `/user/${encoded}/notes/`),
+      mutate(`${p}user/${encoded}/${useAllPosts ? 'all-posts/' : 'notes/'}`),
     ]);
-  }, [username, useAllPosts, updateUser]);
+  }, [username, useAllPosts, updateUser, featureFlags?.postsVerQ, myProfile?.current_ver]);
 
   const value = useMemo(
     () => ({

--- a/src/routes/My.tsx
+++ b/src/routes/My.tsx
@@ -13,6 +13,7 @@ import { useRestoreScrollPosition } from '@hooks/useRestoreScrollPosition';
 import { useBoundStore } from '@stores/useBoundStore';
 import { UserSelector } from '@stores/user';
 import { getMe, getMyProfile } from '@utils/apis/my';
+import { userListApiPrefixForViewer } from '@utils/apis/userApiPrefix';
 import { MainScrollContainer } from './Root';
 
 function My() {
@@ -31,12 +32,23 @@ function My() {
   }, []);
 
   const handleRefresh = useCallback(async () => {
+    const p = userListApiPrefixForViewer(featureFlags?.postsVerQ, myProfile?.current_ver);
     if (featureFlags?.questionResponseFeature) {
-      await Promise.all([mutate('/user/me/all-posts/'), fetchCheckIn(), getMe(), getMyProfile()]);
+      await Promise.all([
+        mutate(`${p}user/me/all-posts/`),
+        fetchCheckIn(),
+        getMe(),
+        getMyProfile(),
+      ]);
     } else {
-      await Promise.all([mutate('/user/me/notes/'), fetchCheckIn(), getMe(), getMyProfile()]);
+      await Promise.all([mutate(`${p}user/me/notes/`), fetchCheckIn(), getMe(), getMyProfile()]);
     }
-  }, [featureFlags?.questionResponseFeature, fetchCheckIn]);
+  }, [
+    featureFlags?.questionResponseFeature,
+    featureFlags?.postsVerQ,
+    myProfile?.current_ver,
+    fetchCheckIn,
+  ]);
 
   const { scrollRef } = useRestoreScrollPosition('myPage');
 

--- a/src/routes/UserPage.tsx
+++ b/src/routes/UserPage.tsx
@@ -26,6 +26,7 @@ import { useTrackEvent } from '@hooks/useTrackEvent';
 import { useBoundStore } from '@stores/useBoundStore';
 import { UserSelector } from '@stores/user';
 import { readFriendCheckIn } from '@utils/apis/checkIn';
+import { userListApiPrefixForViewer } from '@utils/apis/userApiPrefix';
 
 interface UserPageProps {
   usernameOverride?: string;
@@ -96,11 +97,12 @@ function UserPage({ usernameOverride }: UserPageProps = {}) {
     if (!username) return;
 
     const encodedUsername = encodeURIComponent(username);
+    const p = userListApiPrefixForViewer(featureFlags?.postsVerQ, myProfile?.current_ver);
 
     if (featureFlags?.questionResponseFeature) {
-      await Promise.all([mutate(`/user/${encodedUsername}/all-posts/`)]);
+      await Promise.all([mutate(`${p}user/${encodedUsername}/all-posts/`)]);
     } else {
-      await Promise.all([mutate(`/user/${encodedUsername}/notes/`)]);
+      await Promise.all([mutate(`${p}user/${encodedUsername}/notes/`)]);
     }
   };
 

--- a/src/routes/friends/FriendNewPosts.tsx
+++ b/src/routes/friends/FriendNewPosts.tsx
@@ -8,7 +8,10 @@ import NoteLoader from '@components/note/note-loader/NoteLoader';
 import ResponseItem from '@components/response/response-item/ResponseItem';
 import SubHeader from '@components/sub-header/SubHeader';
 import { Layout, Typo } from '@design-system';
+import { useBoundStore } from '@stores/useBoundStore';
+import { UserSelector } from '@stores/user';
 import axiosInstance from '@utils/apis/axios';
+import { userListApiPrefixForViewer } from '@utils/apis/userApiPrefix';
 import { MainScrollContainer } from '../Root';
 
 interface UnreadPost {
@@ -22,6 +25,8 @@ function FriendNewPosts() {
   const [posts, setPosts] = useState<UnreadPost[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const { mutate: globalMutate } = useSWRConfig();
+  const { featureFlags, myProfile } = useBoundStore(UserSelector);
+  const p = userListApiPrefixForViewer(featureFlags?.postsVerQ, myProfile?.current_ver);
 
   const fetchPosts = async () => {
     if (!username) return;
@@ -36,7 +41,7 @@ function FriendNewPosts() {
       } else {
         // Fall back to all posts from this user (most recent)
         const { data: allPosts } = await axiosInstance.get<{ results: UnreadPost[] }>(
-          `/user/${username}/all-posts/?page=1`,
+          `${p}user/${username}/all-posts/?page=1`,
         );
         setPosts((allPosts.results ?? allPosts) as UnreadPost[]);
       }

--- a/src/routes/friends/FriendsFeed.tsx
+++ b/src/routes/friends/FriendsFeed.tsx
@@ -15,6 +15,7 @@ import { AllPostFeedItem, POST_TYPE } from '@models/post';
 import { useBoundStore } from '@stores/useBoundStore';
 import { UserSelector } from '@stores/user';
 import { getMe } from '@utils/apis/my';
+import { isPostsVerQClient } from '@utils/apis/userApiPrefix';
 import { MainScrollContainer } from 'src/routes/Root';
 
 function FriendsFeed() {
@@ -26,7 +27,10 @@ function FriendsFeed() {
     myProfile: state.myProfile,
     fetchCheckIn: state.fetchCheckIn,
   }));
-  const { featureFlags } = useBoundStore(UserSelector);
+  const { featureFlags, myProfile } = useBoundStore(UserSelector);
+  const friendFeedKey = isPostsVerQClient(featureFlags?.postsVerQ, myProfile?.current_ver)
+    ? '/q/user/feed/'
+    : '/user/feed/full';
 
   const {
     targetRef,
@@ -35,7 +39,7 @@ function FriendsFeed() {
     isLoadingMore: isFeedItemsLoadingMore,
     mutate: refetchFeed,
   } = useSWRInfiniteScroll<AllPostFeedItem>({
-    key: `/user/feed/full`,
+    key: friendFeedKey,
   });
 
   const handleRefresh = useCallback(async () => {

--- a/src/routes/notes/AllNotes.tsx
+++ b/src/routes/notes/AllNotes.tsx
@@ -11,7 +11,9 @@ import { Layout } from '@design-system';
 import useInfiniteScroll from '@hooks/useInfiniteScroll';
 import { Note, NoteFeedItem, POST_TYPE } from '@models/post';
 import { useBoundStore } from '@stores/useBoundStore';
+import { UserSelector } from '@stores/user';
 import { getMyNotes } from '@utils/apis/my';
+import { userListApiPrefixForViewer } from '@utils/apis/userApiPrefix';
 
 const expandNoteFeedItems = (items: NoteFeedItem[]): Note[] =>
   items.flatMap((item) => (item.type === POST_TYPE.MISSION_GROUP ? item.attempts : [item]));
@@ -19,7 +21,8 @@ const expandNoteFeedItems = (items: NoteFeedItem[]): Note[] =>
 function AllNotes() {
   const [t] = useTranslation('translation');
   const { username } = useParams();
-  const { myProfile } = useBoundStore((state) => ({ myProfile: state.myProfile }));
+  const { myProfile, featureFlags } = useBoundStore(UserSelector);
+  const listPrefix = userListApiPrefixForViewer(featureFlags?.postsVerQ, myProfile?.current_ver);
 
   const [noteList, setNoteList] = useState<Note[]>([]);
   const [nextPage, setNextPage] = useState<string | null | undefined>(undefined);
@@ -30,7 +33,7 @@ function AllNotes() {
   });
 
   const fetchNotes = async (page: string | null) => {
-    const { results, next } = await getMyNotes(page);
+    const { results, next } = await getMyNotes(page, listPrefix);
     if (!results) return;
     setNextPage(next);
     setNoteList([...noteList, ...expandNoteFeedItems(results)]);

--- a/src/routes/notes/NoteDetail.tsx
+++ b/src/routes/notes/NoteDetail.tsx
@@ -16,7 +16,8 @@ import { FetchState } from '@models/api/common';
 import { Note } from '@models/post';
 import { useBoundStore } from '@stores/useBoundStore';
 import { UserSelector } from '@stores/user';
-import { getNoteDetail, getNoteDetailDefault } from '@utils/apis/note';
+import { getNoteDetail } from '@utils/apis/note';
+import { userListApiPrefixForViewer } from '@utils/apis/userApiPrefix';
 import { MainScrollContainer } from '../Root';
 
 export function NoteDetail() {
@@ -25,9 +26,7 @@ export function NoteDetail() {
   const [t] = useTranslation('translation');
   const navigate = useNavigate();
   const location = useLocation();
-  const { featureFlags } = useBoundStore(UserSelector);
-
-  const { myProfile } = useBoundStore((state) => ({ myProfile: state.myProfile }));
+  const { featureFlags, myProfile } = useBoundStore(UserSelector);
   const [noteDetail, setNoteDetail] = useState<FetchState<Note>>({ state: 'loading' });
   const [reload, setReload] = useState<boolean>(false);
   const [inputFocus, setInputFocus] = useState(false);
@@ -40,10 +39,9 @@ export function NoteDetail() {
 
   useAsyncEffect(async () => {
     if (!noteId) return;
+    const notesPrefix = userListApiPrefixForViewer(featureFlags?.postsVerQ, myProfile?.current_ver);
     try {
-      const data = featureFlags?.friendList
-        ? await getNoteDetail(Number(noteId))
-        : await getNoteDetailDefault(Number(noteId));
+      const data = await getNoteDetail(Number(noteId), notesPrefix);
       setNoteDetail({ state: 'hasValue', data });
       if (reload) {
         setReload(false);
@@ -55,7 +53,7 @@ export function NoteDetail() {
       }
       setNoteDetail({ state: 'hasError' });
     }
-  }, [noteId, reload]);
+  }, [noteId, reload, featureFlags?.postsVerQ, myProfile?.current_ver]);
 
   const isNew = location.state === 'new' || location.state?.new;
   const fromShare = location.state?.fromShare;

--- a/src/routes/responses/ResponseDetail.tsx
+++ b/src/routes/responses/ResponseDetail.tsx
@@ -14,7 +14,9 @@ import useAsyncEffect from '@hooks/useAsyncEffect';
 import { FetchState } from '@models/api/common';
 import { Response } from '@models/post';
 import { useBoundStore } from '@stores/useBoundStore';
+import { UserSelector } from '@stores/user';
 import { getResponse } from '@utils/apis/responses';
+import { userListApiPrefixForViewer } from '@utils/apis/userApiPrefix';
 import { MainScrollContainer } from '../Root';
 
 function ResponseDetail() {
@@ -24,15 +26,16 @@ function ResponseDetail() {
   const navigate = useNavigate();
   const location = useLocation();
 
-  const { myProfile } = useBoundStore((state) => ({ myProfile: state.myProfile }));
+  const { myProfile, featureFlags } = useBoundStore(UserSelector);
   const [responseDetail, setResponseDetail] = useState<FetchState<Response>>({ state: 'loading' });
   const [reload, setReload] = useState<boolean>(false);
   const [inputFocus, setInputFocus] = useState(false);
 
   useAsyncEffect(async () => {
     if (!responseId) return;
+    const qnaPrefix = userListApiPrefixForViewer(featureFlags?.postsVerQ, myProfile?.current_ver);
     try {
-      const data = await getResponse(Number(responseId));
+      const data = await getResponse(Number(responseId), qnaPrefix);
       setResponseDetail({ state: 'hasValue', data });
       if (reload) {
         setReload(false);
@@ -44,7 +47,7 @@ function ResponseDetail() {
       }
       setResponseDetail({ state: 'hasError' });
     }
-  }, [responseId, reload]);
+  }, [responseId, reload, featureFlags?.postsVerQ, myProfile?.current_ver]);
 
   const handleGoBack = () => {
     navigate('/my');

--- a/src/utils/apis/my.ts
+++ b/src/utils/apis/my.ts
@@ -148,10 +148,11 @@ export const getMyResponses = async (page: string | null) => {
   return data;
 };
 
-export const getMyNotes = async (page: string | null) => {
+/** @param userListPrefix `q/` when the viewer is Ver.Q so `/api/q/user/me/notes/` is used. */
+export const getMyNotes = async (page: string | null, userListPrefix = '') => {
   const requestPage = page ? page.split('page=')[1] : null;
   const { data } = await axios.get<PaginationResponse<NoteFeedItem[]>>(
-    `/user/me/notes/${!requestPage ? '' : `?page=${requestPage}`}`,
+    `${userListPrefix}user/me/notes/${!requestPage ? '' : `?page=${requestPage}`}`,
   );
   return data;
 };
@@ -164,10 +165,11 @@ export const getResponseRequests = async (page: string | null) => {
   return data;
 };
 
-export const getMyAllPosts = async (page: string | null) => {
+/** @param userListPrefix `q/` when the viewer is Ver.Q so `/api/q/user/me/all-posts/` is used. */
+export const getMyAllPosts = async (page: string | null, userListPrefix = '') => {
   const requestPage = page ? page.split('page=')[1] : null;
   const { data } = await axios.get<PaginationResponse<AllPostFeedItem[]>>(
-    `/user/me/all-posts/${!requestPage ? '' : `?page=${requestPage}`}`,
+    `${userListPrefix}user/me/all-posts/${!requestPage ? '' : `?page=${requestPage}`}`,
   );
   return data;
 };

--- a/src/utils/apis/note.ts
+++ b/src/utils/apis/note.ts
@@ -11,19 +11,9 @@ export const getNoteList = async (page: string | null) => {
   return data;
 };
 
-export const getNoteDetail = async (noteId: number) => {
-  const { data } = await axios.get<Note>(`/notes/${noteId}/`);
-  const { id, current_user_read } = data;
-
-  if (!current_user_read) {
-    readNote([id]);
-  }
-
-  return data;
-};
-
-export const getNoteDetailDefault = async (noteId: number) => {
-  const { data } = await axios.get<Note>(`/notes/${noteId}/`);
+/** @param notesApiPrefix `q/` so `/api/q/notes/<id>/` uses Q serializers (likes fields) for Ver.Q viewers */
+export const getNoteDetail = async (noteId: number, notesApiPrefix = '') => {
+  const { data } = await axios.get<Note>(`${notesApiPrefix}notes/${noteId}/`);
   const { id, current_user_read } = data;
 
   if (!current_user_read) {

--- a/src/utils/apis/responses.ts
+++ b/src/utils/apis/responses.ts
@@ -39,8 +39,11 @@ export const getCommentsOfResponse = async (responseId: number, page: string | n
   return data;
 };
 
-export const getResponse = async (responseId: number | string | undefined) => {
-  const { data } = await axios.get<GetResponseDetailResponse>(`/qna/responses/${responseId}/`);
+/** @param qnaApiPrefix `q/` so `/api/q/qna/responses/<id>/` uses Q serializers for Ver.Q viewers */
+export const getResponse = async (responseId: number | string | undefined, qnaApiPrefix = '') => {
+  const { data } = await axios.get<GetResponseDetailResponse>(
+    `${qnaApiPrefix}qna/responses/${responseId}/`,
+  );
   const { id, current_user_read } = data;
 
   if (!current_user_read) {

--- a/src/utils/apis/userApiPrefix.ts
+++ b/src/utils/apis/userApiPrefix.ts
@@ -1,0 +1,24 @@
+import { VersionType } from '@models/api/user';
+
+/** Ver.Q 프로필 노트/올포스트 목록은 `/api/q/user/` 아래에서 Q 시리얼라이저를 씁니다. */
+export function userListApiPrefix(postsVerQ?: boolean): string {
+  return postsVerQ ? 'q/' : '';
+}
+
+/**
+ * Ver.Q 게시글 UI와 `/api/q/user/` 목록 URL: `featureFlags.postsVerQ`만 보면 첫 페인트에서 비어 있을 수 있어
+ * `myProfile.current_ver`으로도 판별합니다.
+ */
+export function isPostsVerQClient(
+  postsVerQFlag: boolean | undefined,
+  currentVer: VersionType | string | undefined | null,
+): boolean {
+  return !!postsVerQFlag || currentVer === VersionType.VER_Q || currentVer === 'version_q';
+}
+
+export function userListApiPrefixForViewer(
+  postsVerQ: boolean | undefined,
+  currentVer: VersionType | string | undefined | null,
+): string {
+  return isPostsVerQClient(postsVerQ, currentVer) ? 'q/' : '';
+}

--- a/src/utils/optimisticLikeUserSample.ts
+++ b/src/utils/optimisticLikeUserSample.ts
@@ -1,0 +1,43 @@
+import { MyProfile } from '@models/api/user';
+import { User } from '@models/user';
+
+const SAMPLE_CAP = 3;
+
+function userFromMyProfile(p: MyProfile): User {
+  return {
+    id: p.id,
+    username: p.username,
+    profile_image: p.profile_image ?? null,
+    profile_pic: p.profile_pic,
+    url: p.url,
+    bio: p.bio,
+    pronouns: p.pronouns,
+    connection_status: p.connection_status,
+    user_interests: p.user_interests ?? [],
+    user_personas: p.user_personas ?? [],
+  };
+}
+
+/** Optimistically prepend/remove the current user in `like_user_sample` when toggling like (Ver.Q footer avatars). */
+export function applyLikeUserSampleOptimistic(
+  previous: User[] | undefined,
+  liked: boolean,
+  myProfile: MyProfile | null | undefined,
+): User[] {
+  if (!myProfile?.username) {
+    return [...(previous ?? [])];
+  }
+
+  const uname = myProfile.username;
+
+  if (!liked) {
+    return (previous ?? []).filter((u) => u.username !== uname);
+  }
+
+  const list = [...(previous ?? [])];
+  if (list.some((u) => u.username === uname)) {
+    return list;
+  }
+
+  return [userFromMyProfile(myProfile), ...list].slice(0, SAMPLE_CAP);
+}


### PR DESCRIPTION
## 요약
Ver.Q에서 게시글 좋아요 수·샘플 프로필이 목록/상세에서 일관되게 보이도록 하고, 뷰어 기준 `/api/q/user/`, `/api/q/notes/`, `/api/q/qna/`를 사용합니다.

## 포함 내용
- `userApiPrefix.ts`: `isPostsVerQClient`, `userListApiPrefixForViewer` (플래그 + `current_ver`)
- 프로필·내 게시물·친구 피드 등 SWR/axios 경로에 `q/` 프리픽스
- **상세**: `NoteDetail` / `ResponseDetail`에서 Ver.Q 뷰어는 `q/notes/`, `q/qna/responses/` 조회
- **PostFooterLikeOnly**: 좋아요 수·프로필(최대 3)·하트 레이아웃
- **낙관적 업데이트**: 좋아요 직후 수·`like_user_sample`(내 프로필) 즉시 반영
- **NoteSection**: 제거된 `/notes/default` 요청 제거
- `LikeButton`: `onLikeUpdated`, 푸터용 컴팩트 정렬

## 관련
백엔드 PR(좋아요 목록 API)과 함께 배포 시 동작 확인 권장.

## 테스트
- [ ] Ver.Q 계정: My/프로필/피드에서 좋아요 수·아바타·상세 동일
- [ ] 좋아요 토글 시 숫자·내 얼굴 즉시 반영

Made with [Cursor](https://cursor.com)