### PR TITLE
perf(chat): consume bot_replies inline from postChatMessage response

### DIFF
--- a/src/models/chat.ts
+++ b/src/models/chat.ts
@@ -97,6 +97,12 @@ export interface ChatMessage extends Omit<InputChatMessage, 'parent'> {
 
 export interface PostChatMessageRes extends ChatMessage {
   unread_count: number;
+  /**
+   * For wit_bot 1-on-1 rooms only: the bot's reply messages created
+   * synchronously by the engine inside the same POST. Backend ships them
+   * inline so the client doesn't have to wait for a WebSocket hop.
+   */
+  bot_replies?: ChatMessage[];
 }
 
 export interface RefinedChatMessage extends ChatMessage {

--- a/src/routes/chat/Chat.tsx
+++ b/src/routes/chat/Chat.tsx
@@ -208,7 +208,16 @@ function Chat() {
   const handleMessageSent = (newMsg: PostChatMessageRes) => {
     justSentIdsRef.current.add(newMsg.id);
     setPrevScrollHeight(scrollRef.current?.clientHeight);
-    setMessages((prev) => insertChronologically(prev, newMsg));
+    setMessages((prev) => {
+      let next = insertChronologically(prev, newMsg);
+      // wit_bot fast path: bot replies ride back inline so we render them
+      // immediately instead of waiting for a WS round-trip.
+      newMsg.bot_replies?.forEach((reply) => {
+        next = insertChronologically(next, { ...reply, is_read: true });
+        justSentIdsRef.current.add(reply.id);
+      });
+      return next;
+    });
   };
 
   const handleBotButtonClick = useCallback(


### PR DESCRIPTION
## Summary
Pairs with the backend wit_bot fast path. When the user posts to a wit_bot 1-on-1, the backend now returns the bot's reply inside the same response instead of pushing it over WebSocket. \`handleMessageSent\` inserts each \`bot_reply\` chronologically right after the user's message, so the bubbles render together at ~300ms (no more REST-vs-WS race).

\`ChatMessage\` gains \`chat_room_id\` (already used by the auto-navigate flow on "Call in the admin"); \`PostChatMessageRes\` gains optional \`bot_replies\`.

## Test plan
- [x] \`craco build\` clean
- [x] Browser-verified: 12 button taps in a row → 9 unique replies (good variety from the 14-line backend pool); user msg + bot reply land together at ~300ms
- [x] Auto-navigate to /chats/group/<id> on "Call in the admin" still works
- [x] Existing chat WS path for non-wit_bot rooms unchanged

Paired with backend PR.