### PR TITLE
fix(friend-request): 평가 모달 confirm 더블탭 중복 요청 방지

### DIFF
--- a/src/components/_common/friend-evaluation-modal/FriendEvaluationModal.tsx
+++ b/src/components/_common/friend-evaluation-modal/FriendEvaluationModal.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, MouseEvent, useEffect, useState } from 'react';
+import { ChangeEvent, MouseEvent, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { Layout, RadioButton, Typo } from '@design-system';
@@ -47,6 +47,8 @@ function FriendEvaluationModal({
   const [relationshipTypeDetail, setRelationshipTypeDetail] = useState('');
   const [showConfirmation, setShowConfirmation] = useState(false);
   const [pendingData, setPendingData] = useState<EvaluationData | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const isSubmittingRef = useRef(false);
 
   useEffect(() => {
     if (visible) {
@@ -80,9 +82,11 @@ function FriendEvaluationModal({
   };
 
   const handleConfirm = () => {
-    if (pendingData) {
-      onSubmit(pendingData);
-    }
+    if (isSubmittingRef.current) return;
+    if (!pendingData) return;
+    isSubmittingRef.current = true;
+    setIsSubmitting(true);
+    onSubmit(pendingData);
   };
 
   const handleBack = () => {
@@ -205,10 +209,19 @@ function FriendEvaluationModal({
         <S.ButtonContainer w="100%" justifyContent="space-evenly">
           {showConfirmation ? (
             <>
-              <S.Button onClick={handleBack} pv={11}>
+              <S.Button
+                onClick={isSubmitting ? undefined : handleBack}
+                pv={11}
+                style={{ opacity: isSubmitting ? 0.4 : 1 }}
+              >
                 <Typo type="button-medium">{t('back')}</Typo>
               </S.Button>
-              <S.Button onClick={handleConfirm} pv={11} hasBorderRight={false}>
+              <S.Button
+                onClick={isSubmitting ? undefined : handleConfirm}
+                pv={11}
+                hasBorderRight={false}
+                style={{ opacity: isSubmitting ? 0.4 : 1 }}
+              >
                 <Typo type="button-medium" color="PRIMARY">
                   {t('confirm')}
                 </Typo>


### PR DESCRIPTION
## Summary

- `FriendEvaluationModal`의 confirmation view에 있는 **Confirm 버튼이 in-flight 가드 없이** 노출되어 있어, 부모(`FriendStatus` / `NotificationActions`)가 `await requestFriend` / `acceptFriendRequest` 하는 동안 사용자가 다시 탭하면 같은 요청이 2~3번 발사됨 → backend에서 `already exists` 에러 + Slack alert 발생.
- `useRef`로 **동기 가드**(React 18 batching에도 안전), `useState`로 **시각적 disable**(opacity 0.4 + onClick 차단)을 추가.
- 모달은 친구 요청 / 수락 두 경로 모두에서 사용되는 단일 진입점이라, 한 곳만 막으면 양쪽 다 커버됨.
- 모달은 부모가 응답 후 `setEvaluationModalState(null)`로 unmount 하므로 별도 cleanup 불필요.

## Test plan

- [ ] 친구 검색 → 친구 요청 → 평가 작성 → Submit → Confirmation view에서 Confirm 빠르게 여러 번 탭 → 한 번만 POST 발사되는지 네트워크 탭에서 확인
- [ ] 알림 탭 → 받은 친구 요청 수락 → 평가 작성 → Submit → Confirm 빠르게 여러 번 탭 → 한 번만 발사되는지 확인
- [ ] Confirm 탭 후 Confirm/Back 버튼이 시각적으로 흐려지는지(opacity 0.4) 확인
- [ ] 정상 플로우(한 번만 탭) 시 기존과 동일하게 toast + 모달 unmount 동작 확인