### PR TITLE
fix(check-in): popup confirm 무변경 시 share 스킵 + song clear 시 deactivate

### DIFF
--- a/src/components/check-in/update-quadrant/BatteryEditor.tsx
+++ b/src/components/check-in/update-quadrant/BatteryEditor.tsx
@@ -1,9 +1,10 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import VisibilityToggle from '@components/check-in/visibility-toggle/VisibilityToggle';
 import SocialBatteryChip from '@components/profile/social-batter-chip/SocialBatteryChip';
 import { Colors, Layout, SvgIcon, Typo } from '@design-system';
 import { ComponentVisibility, SocialBattery } from '@models/checkIn';
+import { useBoundStore } from '@stores/useBoundStore';
 import {
   getLastVisibility,
   setLastVisibility,
@@ -36,13 +37,24 @@ export default function BatteryEditor({
   const [draftVisibility, setDraftVisibility] = useState<ComponentVisibility>(
     () => getLastVisibility(VisibilityMemoryKeys.checkInBattery) ?? visibility,
   );
+  const openToast = useBoundStore((state) => state.openToast);
+
+  // Snapshot of value/visibility at popup open — used to skip the share
+  // entirely when the user taps Confirm without changing anything.
+  const initialValueRef = useRef<SocialBattery | null>(value);
+  const initialVisibilityRef = useRef<ComponentVisibility>(
+    getLastVisibility(VisibilityMemoryKeys.checkInBattery) ?? visibility,
+  );
 
   useEffect(() => {
     if (isOpen) {
-      setDraftValue(value);
       // Default to user's last picked visibility for this content type, falling
       // back to the parent-supplied default for the very first share.
-      setDraftVisibility(getLastVisibility(VisibilityMemoryKeys.checkInBattery) ?? visibility);
+      const initialVis = getLastVisibility(VisibilityMemoryKeys.checkInBattery) ?? visibility;
+      setDraftValue(value);
+      setDraftVisibility(initialVis);
+      initialValueRef.current = value;
+      initialVisibilityRef.current = initialVis;
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen]);
@@ -53,10 +65,18 @@ export default function BatteryEditor({
   }, []);
 
   const handleShare = useCallback(() => {
+    if (
+      draftValue === initialValueRef.current &&
+      draftVisibility === initialVisibilityRef.current
+    ) {
+      openToast({ message: 'No changes' });
+      onClose();
+      return;
+    }
     onChange(draftValue);
     onVisibilityChange(draftVisibility);
     onShare(draftValue, draftVisibility);
-  }, [draftValue, draftVisibility, onChange, onVisibilityChange, onShare]);
+  }, [draftValue, draftVisibility, onChange, onVisibilityChange, onShare, onClose, openToast]);
 
   return (
     <EditorPopup isOpen={isOpen} onClose={onClose} onShare={handleShare} title="Social Battery">

--- a/src/components/check-in/update-quadrant/MoodEditor.tsx
+++ b/src/components/check-in/update-quadrant/MoodEditor.tsx
@@ -53,6 +53,13 @@ export default function MoodEditor({
     () => getLastVisibility(VisibilityMemoryKeys.checkInMood) ?? visibility,
   );
 
+  // Snapshot of value/visibility at popup open — used to skip the share
+  // entirely when the user taps Confirm without changing anything.
+  const initialValueRef = useRef<string[]>(value);
+  const initialVisibilityRef = useRef<ComponentVisibility>(
+    getLastVisibility(VisibilityMemoryKeys.checkInMood) ?? visibility,
+  );
+
   const handleVisibilityChange = useCallback((v: ComponentVisibility) => {
     setDraftVisibility(v);
     setLastVisibility(VisibilityMemoryKeys.checkInMood, v);
@@ -60,8 +67,11 @@ export default function MoodEditor({
 
   useEffect(() => {
     if (isOpen) {
+      const initialVis = getLastVisibility(VisibilityMemoryKeys.checkInMood) ?? visibility;
       setDraftValue(value);
-      setDraftVisibility(getLastVisibility(VisibilityMemoryKeys.checkInMood) ?? visibility);
+      setDraftVisibility(initialVis);
+      initialValueRef.current = value;
+      initialVisibilityRef.current = initialVis;
     } else {
       setDraftValue(value);
     }
@@ -93,10 +103,18 @@ export default function MoodEditor({
   }, []);
 
   const handleShare = useCallback(() => {
+    const initial = initialValueRef.current;
+    const valueUnchanged =
+      draftValue.length === initial.length && draftValue.every((v, i) => v === initial[i]);
+    if (valueUnchanged && draftVisibility === initialVisibilityRef.current) {
+      openToast({ message: 'No changes' });
+      onClose();
+      return;
+    }
     onChange(draftValue);
     onVisibilityChange(draftVisibility);
     onShare(draftValue, draftVisibility);
-  }, [draftValue, draftVisibility, onChange, onVisibilityChange, onShare]);
+  }, [draftValue, draftVisibility, onChange, onVisibilityChange, onShare, onClose, openToast]);
 
   return (
     <EditorPopup isOpen={isOpen} onClose={onClose} onShare={handleShare} title="Mood">

--- a/src/components/check-in/update-quadrant/SongEditor.tsx
+++ b/src/components/check-in/update-quadrant/SongEditor.tsx
@@ -1,5 +1,5 @@
 import { Track } from '@spotify/web-api-ts-sdk';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import SearchInput from '@components/_common/search-input/SearchInput';
 import VisibilityToggle from '@components/check-in/visibility-toggle/VisibilityToggle';
 import MusicItem from '@components/music/music-search-bottom-sheet/music-item/MusicItem';
@@ -7,6 +7,7 @@ import { Layout, SvgIcon, Typo } from '@design-system';
 import useAsyncEffect from '@hooks/useAsyncEffect';
 import SpotifyManager from '@libs/SpotifyManager';
 import { ComponentVisibility } from '@models/checkIn';
+import { useBoundStore } from '@stores/useBoundStore';
 import {
   getLastVisibility,
   setLastVisibility,
@@ -42,6 +43,14 @@ export default function SongEditor({
   const [searchError, setSearchError] = useState('');
   const [currentTrack, setCurrentTrack] = useState<Track | null>(null);
   const spotifyManager = SpotifyManager.getInstance();
+  const openToast = useBoundStore((state) => state.openToast);
+
+  // Snapshot of value/visibility at popup open — used to skip the share
+  // entirely when the user taps Confirm without changing anything.
+  const initialTrackIdRef = useRef<string>(trackId);
+  const initialVisibilityRef = useRef<ComponentVisibility>(
+    getLastVisibility(VisibilityMemoryKeys.checkInSong) ?? visibility,
+  );
 
   const handleVisibilityChange = useCallback((v: ComponentVisibility) => {
     setDraftVisibility(v);
@@ -50,9 +59,12 @@ export default function SongEditor({
 
   useEffect(() => {
     if (isOpen) {
+      const initialVis = getLastVisibility(VisibilityMemoryKeys.checkInSong) ?? visibility;
       setDraftTrackId(trackId);
-      setDraftVisibility(getLastVisibility(VisibilityMemoryKeys.checkInSong) ?? visibility);
+      setDraftVisibility(initialVis);
       setQuery('');
+      initialTrackIdRef.current = trackId;
+      initialVisibilityRef.current = initialVis;
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen]);
@@ -91,10 +103,18 @@ export default function SongEditor({
   };
 
   const handleShare = useCallback(() => {
+    if (
+      draftTrackId === initialTrackIdRef.current &&
+      draftVisibility === initialVisibilityRef.current
+    ) {
+      openToast({ message: 'No changes' });
+      onClose();
+      return;
+    }
     onChange(draftTrackId);
     onVisibilityChange(draftVisibility);
     onShare(draftTrackId, draftVisibility);
-  }, [draftTrackId, draftVisibility, onChange, onVisibilityChange, onShare]);
+  }, [draftTrackId, draftVisibility, onChange, onVisibilityChange, onShare, onClose, openToast]);
 
   return (
     <EditorPopup isOpen={isOpen} onClose={onClose} onShare={handleShare} title="Song">

--- a/src/components/check-in/update-quadrant/ThoughtEditor.tsx
+++ b/src/components/check-in/update-quadrant/ThoughtEditor.tsx
@@ -1,8 +1,9 @@
-import { ChangeEvent, useCallback, useEffect, useState } from 'react';
+import { ChangeEvent, useCallback, useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import VisibilityToggle from '@components/check-in/visibility-toggle/VisibilityToggle';
 import { Colors, Layout, SvgIcon, Typo } from '@design-system';
 import { ComponentVisibility } from '@models/checkIn';
+import { useBoundStore } from '@stores/useBoundStore';
 import {
   getLastVisibility,
   setLastVisibility,
@@ -35,6 +36,14 @@ export default function ThoughtEditor({
   const [draftVisibility, setDraftVisibility] = useState<ComponentVisibility>(
     () => getLastVisibility(VisibilityMemoryKeys.checkInThought) ?? visibility,
   );
+  const openToast = useBoundStore((state) => state.openToast);
+
+  // Snapshot of value/visibility at popup open — used to skip the share
+  // entirely when the user taps Confirm without changing anything.
+  const initialValueRef = useRef<string>(value);
+  const initialVisibilityRef = useRef<ComponentVisibility>(
+    getLastVisibility(VisibilityMemoryKeys.checkInThought) ?? visibility,
+  );
 
   const handleVisibilityChange = useCallback((v: ComponentVisibility) => {
     setDraftVisibility(v);
@@ -43,8 +52,11 @@ export default function ThoughtEditor({
 
   useEffect(() => {
     if (isOpen) {
+      const initialVis = getLastVisibility(VisibilityMemoryKeys.checkInThought) ?? visibility;
       setDraftValue(value);
-      setDraftVisibility(getLastVisibility(VisibilityMemoryKeys.checkInThought) ?? visibility);
+      setDraftVisibility(initialVis);
+      initialValueRef.current = value;
+      initialVisibilityRef.current = initialVis;
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen]);
@@ -56,10 +68,18 @@ export default function ThoughtEditor({
   };
 
   const handleShare = useCallback(() => {
+    if (
+      draftValue === initialValueRef.current &&
+      draftVisibility === initialVisibilityRef.current
+    ) {
+      openToast({ message: 'No changes' });
+      onClose();
+      return;
+    }
     onChange(draftValue);
     onVisibilityChange(draftVisibility);
     onShare(draftValue, draftVisibility);
-  }, [draftValue, draftVisibility, onChange, onVisibilityChange, onShare]);
+  }, [draftValue, draftVisibility, onChange, onVisibilityChange, onShare, onClose, openToast]);
 
   return (
     <EditorPopup isOpen={isOpen} onClose={onClose} onShare={handleShare} title="Be Random">

--- a/src/routes/update/UpdateCheckin.tsx
+++ b/src/routes/update/UpdateCheckin.tsx
@@ -16,7 +16,7 @@ import useAsyncEffect from '@hooks/useAsyncEffect';
 import SpotifyManager from '@libs/SpotifyManager';
 import { ComponentVisibility, DEFAULT_VISIBILITY, SocialBattery } from '@models/checkIn';
 import { useBoundStore } from '@stores/useBoundStore';
-import { getActiveSong, postCheckIn, postSong } from '@utils/apis/checkIn';
+import { deactivateSong, getActiveSong, postCheckIn, postSong } from '@utils/apis/checkIn';
 import { MainScrollContainer } from '../Root';
 import {
   GridContainer,
@@ -240,10 +240,36 @@ export default function UpdateCheckin() {
   );
 
   const handleSongShare = useCallback(
-    (nextTrackId: string, nextSongVis: ComponentVisibility) => {
+    async (nextTrackId: string, nextSongVis: ComponentVisibility) => {
+      setActiveEditor(null);
+
+      // User cleared an active song — deactivate on backend so refresh
+      // doesn't bring it back. doSave's empty-trackId branch only skips
+      // postSong; the previously active song would otherwise persist.
+      const wasActive = !!stateRef.current.trackId;
+      if (!nextTrackId && wasActive) {
+        try {
+          const active = await getActiveSong();
+          if (active) {
+            await deactivateSong(active.id);
+          }
+          setTrackId('');
+          setSongVis(nextSongVis);
+          stateRef.current = {
+            ...stateRef.current,
+            trackId: '',
+            songVis: nextSongVis,
+          };
+          await fetchCheckIn();
+          openToast({ message: 'Removed' });
+        } catch {
+          openToast({ message: 'Failed to remove' });
+        }
+        return;
+      }
+
       setTrackId(nextTrackId);
       setSongVis(nextSongVis);
-      setActiveEditor(null);
       requestAnimationFrame(() => {
         const s = stateRef.current;
         stateRef.current = {
@@ -254,7 +280,7 @@ export default function UpdateCheckin() {
         doSave();
       });
     },
-    [doSave],
+    [doSave, fetchCheckIn, openToast],
   );
 
   return (


### PR DESCRIPTION
## Summary

체크인 popup 4종 (Song / Battery / Mood / Thought) 에서 Confirm 버튼이 잘못된 피드백/사이드이펙트를 일으키던 두 가지 동작을 수정합니다.

### 1. 변경 없이 Confirm → "Shared!" 가 misleading

기존: 사용자가 popup 열고 아무것도 안 만지고 Confirm 누르면 "Shared!" 토스트가 뜨고, Song 의 경우 `UpdateCheckin` 의 `initialTrackId` 비교가 stale 해서 (페이지 첫 로드 후 갱신 안 됨) 이전 곡이 매번 다시 `postSong` 으로 POST 됩니다.

수정: 각 에디터가 popup 열림 시점의 값/visibility 를 ref 에 스냅샷해두고, Confirm 시 둘 다 변경 없으면 `onShare` 호출 자체를 건너뛰고 "No changes" 토스트로 명시적 피드백합니다.

### 2. Song 을 비우고 Confirm 해도 backend 에 남음

기존: 현재 공유 중인 곡을 X 버튼으로 지운 뒤 Confirm 하면, 빈 `trackId` 가 `doSave` 의 falsy 체크 (`s.trackId && s.trackId !== initialTrackId`) 에 걸려 `postSong` 호출이 스킵됩니다. UI 는 비워진 것처럼 보이지만 새로고침하면 이전 곡이 그대로 돌아옵니다.

수정: `handleSongShare` 에서 `wasActive && nextTrackId === ''` 케이스를 별도 처리해 `getActiveSong` 으로 현재 곡 ID 조회 후 `deactivateSong` 호출, "Removed" 토스트 표시 후 `fetchCheckIn` 으로 상태 동기화합니다.

값/visibility 중 하나라도 바뀐 경우는 기존 share 플로우 그대로 진행됩니다.

### Note
Battery / Mood / Thought 의 "비우고 Confirm" 시나리오는 이 PR 에서 다루지 않습니다 — 해당 컴포넌트는 `postCheckIn` 으로 처리되며 backend 의 빈 값 처리 동작에 따라 결과가 달라집니다. 동일 패턴이 필요한지 확인되면 후속 PR 로 다룰 예정입니다.

## Test plan

- [ ] **Song no-change**: 곡 A 공유 중 → popup 열고 아무것도 안 만지고 Confirm → "No changes" 토스트, 새로고침해도 곡 A 유지, Network 탭에 `POST /check_in/song/` 발생 안 함
- [ ] **Song clear**: 곡 A 공유 중 → popup 열고 X 눌러 비우고 Confirm → "Removed" 토스트, 새로고침해도 곡 사라짐, `PATCH /check_in/song/{id}/` 호출 확인
- [ ] **Song change**: 곡 A 공유 중 → 곡 B 선택 → Confirm → "Shared!" 토스트, 곡 B 로 교체 확인
- [ ] **Visibility-only**: 곡 A 그대로, visibility 만 Public → Friends 변경 → Confirm → "Shared!" 토스트, song_visibility 갱신 확인
- [ ] **Battery / Mood / Thought no-change**: 각 popup 열고 변경 없이 Confirm → "No changes" 토스트
- [ ] **Battery / Mood / Thought 변경**: 값/visibility 변경 후 Confirm → "Shared!" 토스트 + 정상 저장
- [ ] 320px / 393px 뷰포트에서 popup 레이아웃 정상 표시