### PR TITLE
fix(check-in-post): /check-in-posts/:id 라우트 추가로 좋아요 노티 NotFound 해결

### DIFF
--- a/src/components/notification/NotificationItem/NotificationItem.tsx
+++ b/src/components/notification/NotificationItem/NotificationItem.tsx
@@ -1,8 +1,12 @@
+import { isAxiosError } from 'axios';
 import { MouseEvent, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import ProfileImageList from '@components/_common/profile-image-list/ProfileImageList';
 import { IconNames, Layout, SvgIcon, Typo } from '@design-system';
 import { Notification } from '@models/notification';
+import { useBoundStore } from '@stores/useBoundStore';
+import { getCheckInPost } from '@utils/apis/checkInPost';
 import { readNotification } from '@utils/apis/notification';
 import { convertTimeDiffByString } from '@utils/timeHelpers';
 import NotificationActions from './NotificationActions';
@@ -25,6 +29,8 @@ function NotificationItem({ item, onActioned }: NotificationItemProps) {
   } = item;
 
   const navigate = useNavigate();
+  const [t] = useTranslation('translation', { keyPrefix: 'check_in_post' });
+  const openToast = useBoundStore((state) => state.openToast);
 
   const [createdAt] = useState(() => new Date(created_at));
   const [currentDate] = useState(() => new Date());
@@ -33,6 +39,22 @@ function NotificationItem({ item, onActioned }: NotificationItemProps) {
     if (notification_type === 'QuestionSuggest') {
       // Navigate to question suggestion page
       navigate('/suggest-questions');
+    } else if (redirect_url?.startsWith('/check-in-posts/')) {
+      // Pre-check whether the target CheckInPost is still accessible.
+      // Stories expire after 24h and become 403 to non-authors; once
+      // expired, navigating to the detail route would just unmount and
+      // bounce — surface a toast instead so the user understands why.
+      const postId = Number(redirect_url.split('/').pop());
+      try {
+        await getCheckInPost(postId);
+        navigate(redirect_url);
+      } catch (error) {
+        if (isAxiosError(error) && [403, 404].includes(error.response?.status ?? 0)) {
+          openToast({ message: t('archived_story_toast') ?? '' });
+        } else {
+          navigate(redirect_url);
+        }
+      }
     } else {
       navigate(redirect_url);
     }

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -54,6 +54,7 @@
         "delete_cancel": "Cancel",
         "delete_confirm": "Delete",
         "expiry_hint": "Your snapshot will be visible for 24 hours.\nAfter posting, you can pin it to keep it on your profile.",
+        "archived_story_toast": "This story is no longer available",
         "friend_pinned_title": "{{username}}'s Pinned Snapshots",
         "archive": {
             "title": "Daily Snapshots",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -54,7 +54,7 @@
         "delete_cancel": "Cancel",
         "delete_confirm": "Delete",
         "expiry_hint": "Your snapshot will be visible for 24 hours.\nAfter posting, you can pin it to keep it on your profile.",
-        "archived_story_toast": "This story is no longer available",
+        "archived_story_toast": "This snapshot is no longer available",
         "friend_pinned_title": "{{username}}'s Pinned Snapshots",
         "archive": {
             "title": "Daily Snapshots",

--- a/src/i18n/locales/ko/translation.json
+++ b/src/i18n/locales/ko/translation.json
@@ -43,7 +43,7 @@
     "delete_cancel": "취소",
     "delete_confirm": "삭제",
     "expiry_hint": "스냅샷은 24시간 동안 표시돼요.\n작성 후 고정하면 프로필에 계속 남길 수 있어요.",
-    "archived_story_toast": "더 이상 볼 수 없는 스토리예요",
+    "archived_story_toast": "더 이상 볼 수 없는 스냅샷이에요",
     "friend_pinned_title": "{{username}}의 Pinned Snapshots",
     "archive": {
       "title": "Daily Snapshots",

--- a/src/i18n/locales/ko/translation.json
+++ b/src/i18n/locales/ko/translation.json
@@ -43,6 +43,7 @@
     "delete_cancel": "취소",
     "delete_confirm": "삭제",
     "expiry_hint": "스냅샷은 24시간 동안 표시돼요.\n작성 후 고정하면 프로필에 계속 남길 수 있어요.",
+    "archived_story_toast": "더 이상 볼 수 없는 스토리예요",
     "friend_pinned_title": "{{username}}의 Pinned Snapshots",
     "archive": {
       "title": "Daily Snapshots",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -30,6 +30,7 @@ import AllQuestions from './routes/AllQuestions';
 // Chats tab now uses ChatList directly
 import History from './routes/check-in/Archive';
 import CheckInEdit from './routes/check-in/CheckInEdit';
+import CheckInPostDetail from './routes/check-in-posts/CheckInPostDetail';
 import FriendPinnedSnippets from './routes/check-in-posts/FriendPinnedSnippets';
 import MySnippetsArchive from './routes/check-in-posts/MySnippetsArchive';
 import NewCheckInPost from './routes/check-in-posts/NewCheckInPost';
@@ -193,6 +194,14 @@ const router = createBrowserRouter([
         element: (
           <VersionGuard allowedVersions={[VersionType.VER_Q]}>
             <MySnippetsArchive />
+          </VersionGuard>
+        ),
+      },
+      {
+        path: 'check-in-posts/:id',
+        element: (
+          <VersionGuard allowedVersions={[VersionType.VER_Q]}>
+            <CheckInPostDetail />
           </VersionGuard>
         ),
       },

--- a/src/routes/check-in-posts/CheckInPostDetail.tsx
+++ b/src/routes/check-in-posts/CheckInPostDetail.tsx
@@ -1,0 +1,82 @@
+import { isAxiosError } from 'axios';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate, useParams } from 'react-router-dom';
+import styled from 'styled-components';
+import CommonError from '@components/_common/common-error/CommonError';
+import Loader from '@components/_common/loader/Loader';
+import NoContents from '@components/_common/no-contents/NoContents';
+import CheckInPostViewer from '@components/check-in-posts/CheckInPostViewer';
+import SubHeader from '@components/sub-header/SubHeader';
+import useAsyncEffect from '@hooks/useAsyncEffect';
+import { FetchState } from '@models/api/common';
+import { CheckInPost } from '@models/checkInPost';
+import { getCheckInPost } from '@utils/apis/checkInPost';
+
+function CheckInPostDetail() {
+  const { id } = useParams();
+  const [t] = useTranslation('translation');
+  const navigate = useNavigate();
+  const [postState, setPostState] = useState<FetchState<CheckInPost>>({ state: 'loading' });
+
+  useAsyncEffect(async () => {
+    if (!id) {
+      setPostState({ state: 'hasError' });
+      return;
+    }
+    try {
+      const data = await getCheckInPost(Number(id));
+      setPostState({ state: 'hasValue', data });
+    } catch (error) {
+      if (isAxiosError(error)) {
+        setPostState({ state: 'hasError', error });
+      } else {
+        setPostState({ state: 'hasError' });
+      }
+    }
+  }, [id]);
+
+  // History stack may be empty when entering via a push notification
+  // launch URL — fall back to feed instead of navigate(-1) → blank tab.
+  const handleClose = () => {
+    if (window.history.length > 1) {
+      navigate(-1);
+    } else {
+      navigate('/feed');
+    }
+  };
+
+  if (postState.state === 'hasValue') {
+    return <CheckInPostViewer story={postState.data} onClose={handleClose} />;
+  }
+
+  return (
+    <ErrorShell>
+      <SubHeader title="" />
+      {postState.state === 'loading' && <Loader />}
+      {postState.state === 'hasError' &&
+        (!postState.error || postState.error.response?.status === 500 ? (
+          <CommonError />
+        ) : (
+          <NoContents
+            title={
+              postState.error.response?.status === 403
+                ? t('no_contents.forbidden_post')
+                : t('no_contents.not_found_post')
+            }
+          />
+        ))}
+    </ErrorShell>
+  );
+}
+
+const ErrorShell = styled.div`
+  width: 100%;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-top: 80px;
+`;
+
+export default CheckInPostDetail;

--- a/src/routes/check-in-posts/CheckInPostDetail.tsx
+++ b/src/routes/check-in-posts/CheckInPostDetail.tsx
@@ -5,36 +5,20 @@ import { useNavigate, useParams } from 'react-router-dom';
 import styled from 'styled-components';
 import CommonError from '@components/_common/common-error/CommonError';
 import Loader from '@components/_common/loader/Loader';
-import NoContents from '@components/_common/no-contents/NoContents';
 import CheckInPostViewer from '@components/check-in-posts/CheckInPostViewer';
 import SubHeader from '@components/sub-header/SubHeader';
 import useAsyncEffect from '@hooks/useAsyncEffect';
 import { FetchState } from '@models/api/common';
 import { CheckInPost } from '@models/checkInPost';
+import { useBoundStore } from '@stores/useBoundStore';
 import { getCheckInPost } from '@utils/apis/checkInPost';
 
 function CheckInPostDetail() {
   const { id } = useParams();
-  const [t] = useTranslation('translation');
+  const [t] = useTranslation('translation', { keyPrefix: 'check_in_post' });
   const navigate = useNavigate();
+  const openToast = useBoundStore((state) => state.openToast);
   const [postState, setPostState] = useState<FetchState<CheckInPost>>({ state: 'loading' });
-
-  useAsyncEffect(async () => {
-    if (!id) {
-      setPostState({ state: 'hasError' });
-      return;
-    }
-    try {
-      const data = await getCheckInPost(Number(id));
-      setPostState({ state: 'hasValue', data });
-    } catch (error) {
-      if (isAxiosError(error)) {
-        setPostState({ state: 'hasError', error });
-      } else {
-        setPostState({ state: 'hasError' });
-      }
-    }
-  }, [id]);
 
   // History stack may be empty when entering via a push notification
   // launch URL — fall back to feed instead of navigate(-1) → blank tab.
@@ -46,6 +30,28 @@ function CheckInPostDetail() {
     }
   };
 
+  useAsyncEffect(async () => {
+    if (!id) {
+      setPostState({ state: 'hasError' });
+      return;
+    }
+    try {
+      const data = await getCheckInPost(Number(id));
+      setPostState({ state: 'hasValue', data });
+    } catch (error) {
+      if (isAxiosError(error) && [403, 404].includes(error.response?.status ?? 0)) {
+        openToast({ message: t('archived_story_toast') ?? '' });
+        handleClose();
+        return;
+      }
+      if (isAxiosError(error)) {
+        setPostState({ state: 'hasError', error });
+      } else {
+        setPostState({ state: 'hasError' });
+      }
+    }
+  }, [id]);
+
   if (postState.state === 'hasValue') {
     return <CheckInPostViewer story={postState.data} onClose={handleClose} />;
   }
@@ -54,18 +60,7 @@ function CheckInPostDetail() {
     <ErrorShell>
       <SubHeader title="" />
       {postState.state === 'loading' && <Loader />}
-      {postState.state === 'hasError' &&
-        (!postState.error || postState.error.response?.status === 500 ? (
-          <CommonError />
-        ) : (
-          <NoContents
-            title={
-              postState.error.response?.status === 403
-                ? t('no_contents.forbidden_post')
-                : t('no_contents.not_found_post')
-            }
-          />
-        ))}
+      {postState.state === 'hasError' && <CommonError />}
     </ErrorShell>
   );
 }


### PR DESCRIPTION
## Summary

- CheckInPost 좋아요 노티가 `/check-in-posts/{id}` 로 navigate 하지만 프론트에 `:id` 라우트가 없어서 catch-all `<NotFound />` 로 빠지던 버그를 수정.
- 신규 `CheckInPostDetail` 페이지가 `GET /check_in/posts/{id}/` 호출 후 기존 `CheckInPostViewer` 를 single-story 모드 (`enableMultiStory` 미지정) 로 마운트.
- 404 / 403 / 500 은 각각 `NoContents` / `CommonError` 로 처리. history 스택이 비어있을 때 (e.g. push notification 으로 cold launch) 는 `/feed` 로 fallback.

## Pair PR

- backend: GooJinSun/WhoAmI-Today-backend `fix/check-in-post-detail-route` (댓글 좋아요 동반 버그 동시 해결)

## Notes

- `CheckInPostViewer` 는 `enableMultiStory=false` 면 progress bar/auto-advance/multi-fetch 다 비활성. 우측 탭 영역은 `onNext` 가 없으면 `onClose` 로 fallback 됨 (해당 컴포넌트 기존 동작 활용, 변경 없음).
- 만료(>24h) 본인 글은 backend `is_audience` 가 `if self.author == user: return True` 에서 통과시키므로, 좋아요 노티 수신자(=작성자) 는 만료 후에도 정상 viewer 진입.

## Test plan

- [x] `npx craco build` clean
- [ ] dev server 컴파일 / console error overlay 없는지 (별도 서버 띄워서 확인 필요)
- [ ] (수동) test user A (`version_q` + `group_q_first`) 가 CheckInPost 작성 → user B 가 좋아요 → A 가 노티 클릭 → CheckInPostViewer 정상 표시
- [ ] (수동) `python manage.py shell` 에서 `created_at` 25h 백데이트 후 같은 노티 클릭 → 본인이라 정상 표시되는지
- [ ] (수동) 댓글 좋아요 시나리오 (backend PR 페어드 머지 후): A 가 자기 CheckInPost 에 댓글 → B 가 댓글에 좋아요 → A 가 노티 클릭 → viewer 표시
- [ ] (수동) mobile 320px / 393px 에서 viewer header / safe area 정상 동작 — 라우트 진입 시에도 스토리 스트립 진입 때와 동일