### PR TITLE
feat(nav): 하단 탭 재정렬 + Ver. W Daily Digest 탭

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,7 +141,7 @@ Text-only labels (Public | Friends | Close Friends | Only Me), `label-large` fon
 ### Other UI components
 - **Nudge buttons:** show per-component independently (not all-or-nothing). 4 types: battery, mood, thought, song.
 - **Ping/poke buttons:** dashed border + dark-gray text — NOT solid border + purple. Same 8px radius / 4px 8px padding.
-- **Bottom nav order:** Friends → Check-In → Share → Discover → Chats.
+- **Bottom nav order (Ver. W):** Friends → Daily Digest → Check-In → Share → Chats. "Daily Digest" is the Ver. W rename of the Discover tab — same `/discover` route + `discover_active/inactive` icon, label from `nav_tab.digest`. Ver. Q order: Friends (label/icon, `/feed` route) → Discover → Share → Chats → My.
 - **Check-In tab:** 2x2 grid, popup editors with "Share" button that auto-saves immediately (no global Save button).
 - **Share page:** single vertical scroll with Photo (TERTIARY_PINK gradient), Mission (purple gradient), Questions (SECONDARY bg). No tabs.
 - **Headers:** all should have notification bell + hamburger menu (including Chats, renamed from "Ping"). "Post" button text says "Share".

--- a/public/icons/share_active.svg
+++ b/public/icons/share_active.svg
@@ -1,4 +1,5 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <!-- Heart shape representing sharing/connection -->
-  <path d="M12 21.35L10.55 20.03C5.4 15.36 2 12.28 2 8.5C2 5.42 4.42 3 7.5 3C9.24 3 10.91 3.81 12 5.09C13.09 3.81 14.76 3 16.5 3C19.58 3 22 5.42 22 8.5C22 12.28 18.6 15.36 13.45 20.04L12 21.35Z" fill="#8700FF"/>
+  <rect x="3" y="3" width="18" height="18" rx="3" fill="#8700FF" stroke="#8700FF" stroke-width="2"/>
+  <line x1="12" y1="8" x2="12" y2="16" stroke="white" stroke-width="2" stroke-linecap="round"/>
+  <line x1="8" y1="12" x2="16" y2="12" stroke="white" stroke-width="2" stroke-linecap="round"/>
 </svg>

--- a/public/icons/share_inactive.svg
+++ b/public/icons/share_inactive.svg
@@ -1,4 +1,5 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <!-- Heart outline representing sharing/connection (inactive state) -->
-  <path d="M12 21.35L10.55 20.03C5.4 15.36 2 12.28 2 8.5C2 5.42 4.42 3 7.5 3C9.24 3 10.91 3.81 12 5.09C13.09 3.81 14.76 3 16.5 3C19.58 3 22 5.42 22 8.5C22 12.28 18.6 15.36 13.45 20.04L12 21.35Z" stroke="#D9D9D9" stroke-width="2" fill="none"/>
+  <rect x="3" y="3" width="18" height="18" rx="3" stroke="#D9D9D9" stroke-width="2"/>
+  <line x1="12" y1="8" x2="12" y2="16" stroke="#D9D9D9" stroke-width="2" stroke-linecap="round"/>
+  <line x1="8" y1="12" x2="16" y2="12" stroke="#D9D9D9" stroke-width="2" stroke-linecap="round"/>
 </svg>

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 import Icon from '@components/_common/icon/Icon';
 import SubHeader from '@components/sub-header/SubHeader';
+import { VersionType } from '@models/api/user';
 import { useBoundStore } from '@stores/useBoundStore';
 import CommonHeader from './common-header/CommonHeader';
 import FriendHeader from './friends-header/FriendsHeader';
@@ -21,7 +22,7 @@ function Header() {
     case '/feed':
       return (
         <CommonHeader
-          title={t('nav_tab.feed')}
+          title={t('nav_tab.friends')}
           extraActions={
             <Icon
               name="add_user"
@@ -31,8 +32,10 @@ function Header() {
           }
         />
       );
-    case '/discover':
-      return <CommonHeader title={t('header.discover')} />;
+    case '/discover': {
+      const isVerW = myProfile?.current_ver === VersionType.VER_W;
+      return <CommonHeader title={t(isVerW ? 'header.daily_digest' : 'header.discover')} />;
+    }
     case '/my':
       return <CommonHeader title={myProfile?.username || t('header.my')} />;
     case '/update':

--- a/src/components/tab/Tab.tsx
+++ b/src/components/tab/Tab.tsx
@@ -17,10 +17,33 @@ import {
 
 interface TabItemProps {
   to: string;
-  type: 'friends' | 'my' | 'share' | 'feed' | 'discover' | 'chats' | 'update' | 'questions';
+  type:
+    | 'friends'
+    | 'my'
+    | 'share'
+    | 'feed'
+    | 'discover'
+    | 'digest'
+    | 'chats'
+    | 'update'
+    | 'questions';
   size?: number;
   end?: boolean;
 }
+
+// `digest` is the Ver. W rename of the `discover` tab — same route, icon, and scroll slot
+// (only the label differs). Map other types to themselves.
+const TAB_BASE_TYPE: Record<TabItemProps['type'], Exclude<TabItemProps['type'], 'digest'>> = {
+  friends: 'friends',
+  my: 'my',
+  share: 'share',
+  feed: 'feed',
+  discover: 'discover',
+  digest: 'discover',
+  chats: 'chats',
+  update: 'update',
+  questions: 'questions',
+};
 
 function TabItem({ to, type, size = 48, end = false }: TabItemProps) {
   const [t] = useTranslation('translation', { keyPrefix: 'nav_tab' });
@@ -35,7 +58,7 @@ function TabItem({ to, type, size = 48, end = false }: TabItemProps) {
     const scrollEl = document.getElementById(MAIN_SCROLL_CONTAINER_ID);
     if (!scrollEl) return;
     scrollEl.scrollTo({ top: 0, behavior: 'smooth' });
-    resetScrollPosition(`${type}Page`);
+    resetScrollPosition(`${TAB_BASE_TYPE[type]}Page`);
   };
 
   return (
@@ -61,12 +84,12 @@ function TabItem({ to, type, size = 48, end = false }: TabItemProps) {
                 )}
                 <TabIconWrapper>
                   <SvgIcon
-                    name={`${type}_inactive`}
+                    name={`${TAB_BASE_TYPE[type]}_inactive`}
                     size={size}
                     className={resolvedActive ? 'hidden' : ''}
                   />
                   <SvgIcon
-                    name={`${type}_active`}
+                    name={`${TAB_BASE_TYPE[type]}_active`}
                     size={size}
                     className={resolvedActive ? '' : 'hidden'}
                   />
@@ -102,10 +125,10 @@ export default function Tab() {
     return (
       <TabWrapper data-preview-exempt $noShadow={isChatPage}>
         <Layout.FlexRow w="100%" justifyContent="space-evenly" alignItems="center" pt={4}>
-          {/* Ver. Q has a "feed" tab that maps to the friends slot conceptually; treat it as 'friends'. */}
-          {isTabAllowed('friends') && <TabItem to="/feed" type="feed" size={28} />}
-          {isTabAllowed('share') && <TabItem to="/share" type="share" size={28} />}
+          {/* Ver. Q's first tab maps to the friends slot — uses friends icon/label, route stays /feed. */}
+          {isTabAllowed('friends') && <TabItem to="/feed" type="friends" size={28} />}
           {isTabAllowed('discover') && <TabItem to="/discover" type="discover" size={28} />}
+          {isTabAllowed('share') && <TabItem to="/share" type="share" size={28} />}
           {isTabAllowed('chats') && <TabItem to="/chats" type="chats" size={28} />}
           {isTabAllowed('my') && <TabItem to="/my" type="my" size={28} />}
         </Layout.FlexRow>
@@ -119,9 +142,9 @@ export default function Tab() {
         {featureFlags?.friendList ? (
           <>
             {isTabAllowed('friends') && <TabItem to="/friends" type="friends" size={28} />}
+            {isTabAllowed('discover') && <TabItem to="/discover" type="digest" size={28} />}
             {isTabAllowed('update') && <TabItem to="/update" type="update" size={28} />}
             {isTabAllowed('share') && <TabItem to="/share" type="share" size={28} />}
-            {isTabAllowed('discover') && <TabItem to="/discover" type="discover" size={28} />}
           </>
         ) : featureFlags?.friendFeed ? (
           isTabAllowed('friends') && <TabItem to="/feed" type="friends" size={28} />

--- a/src/constants/browseMode.ts
+++ b/src/constants/browseMode.ts
@@ -11,9 +11,9 @@ import { SocialBattery } from '@models/checkIn';
  */
 export const ALL_BROWSE_MODE_TABS: BrowseModeTabKey[] = [
   'friends',
+  'discover',
   'update',
   'share',
-  'discover',
   'chats',
 ];
 
@@ -25,7 +25,7 @@ export const BUILT_IN_BROWSE_MODES: Record<BuiltInBrowseModeId, BuiltInBrowseMod
     emoji: '🤩',
     suggestedBattery: SocialBattery.fully_charged,
     config: {
-      tabs: ['friends', 'update', 'share', 'discover', 'chats'],
+      tabs: ['friends', 'discover', 'update', 'share', 'chats'],
       filters: {},
       sections: {},
     },
@@ -39,7 +39,7 @@ export const BUILT_IN_BROWSE_MODES: Record<BuiltInBrowseModeId, BuiltInBrowseMod
     config: {
       tabs: ['friends', 'update', 'share', 'chats'],
       filters: { friends_close_only: true },
-      sections: { hide_synthetic_discover_cards: true },
+      sections: { hide_synthetic_digest_cards: true },
     },
   },
   quiet: {
@@ -103,7 +103,7 @@ export const TAB_DURATION_OPTIONS: { value: number | undefined; i18nKey: string 
 export const CUSTOMIZE_TEMPLATES: CustomizeTemplate[] = [
   {
     id: 'no_discover',
-    i18nKey: 'no_discover',
+    i18nKey: 'no_digest',
     emoji: '👯',
     config: {
       tabs: ['friends', 'update', 'share', 'chats'],
@@ -121,7 +121,7 @@ export const CUSTOMIZE_TEMPLATES: CustomizeTemplate[] = [
   },
   {
     id: 'just_discover',
-    i18nKey: 'just_discover',
+    i18nKey: 'just_digest',
     emoji: '🔭',
     config: {
       tabs: ['discover'],
@@ -138,12 +138,12 @@ export const CUSTOMIZE_TEMPLATES: CustomizeTemplate[] = [
     i18nKey: 'digital_detox',
     emoji: '🌿',
     config: {
-      tabs: ['friends', 'update', 'share', 'discover', 'chats'],
+      tabs: ['friends', 'discover', 'update', 'share', 'chats'],
       filters: {},
       tab_durations: {
         friends: DIGITAL_DETOX_DEFAULT_MINUTES,
-        update: DIGITAL_DETOX_DEFAULT_MINUTES,
         discover: DIGITAL_DETOX_DEFAULT_MINUTES,
+        update: DIGITAL_DETOX_DEFAULT_MINUTES,
         chats: DIGITAL_DETOX_DEFAULT_MINUTES,
       },
     },

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -218,6 +218,7 @@
         "share": "Share",
         "feed": "Feed",
         "discover": "Discover",
+        "digest": "Digest",
         "update": "Check-In"
     },
     "version_guard": {
@@ -227,7 +228,8 @@
         "my": "My Profile",
         "questions": "Questions",
         "share": "Share",
-        "discover": "Daily Discover"
+        "discover": "Daily Discover",
+        "daily_digest": "Daily Digest"
     },
     "home": {
         "moment": {
@@ -1423,11 +1425,11 @@
         "modes": {
             "very_social": {
                 "name": "Fully Social",
-                "description": "See everything — Friends, Discover, Chats"
+                "description": "See everything — Friends, Daily Digest, Chats"
             },
             "selectively_social": {
                 "name": "Close Friends Only",
-                "description": "Close Friends Only filter activated, no Discover"
+                "description": "Close Friends Only filter activated, no Daily Digest"
             },
             "quiet": {
                 "name": "Just Here to Share",
@@ -1438,7 +1440,7 @@
             "friends": "Friends",
             "update": "Update",
             "share": "Share",
-            "discover": "Discover",
+            "discover": "Daily Digest",
             "chats": "Chats",
             "my": "My",
             "questions": "Questions"
@@ -1448,22 +1450,22 @@
             "chats_close_only": "Show close friends only on Chats"
         },
         "sections": {
-            "hide_synthetic_discover_cards": "Hide discovery suggestions",
+            "hide_synthetic_digest_cards": "Hide digest suggestions",
             "hide_ping_buttons": "Hide ping buttons",
             "hide_new_post_badge": "Hide \"New post\" badges"
         },
         "templates": {
-            "no_discover": {
-                "name": "All friends, no discover",
+            "no_digest": {
+                "name": "All friends, no daily digest",
                 "description": "Stay with people you know — no new friends today"
             },
             "just_chat": {
                 "name": "Just chat",
                 "description": "Replying to messages, nothing else"
             },
-            "just_discover": {
-                "name": "Just discover",
-                "description": "Find new connections and content only"
+            "just_digest": {
+                "name": "Just daily digest",
+                "description": "Browse today's daily digest only"
             },
             "digital_detox": {
                 "name": "Digital detox",

--- a/src/i18n/locales/ko/translation.json
+++ b/src/i18n/locales/ko/translation.json
@@ -218,6 +218,7 @@
     "share": "공유",
     "feed": "피드",
     "discover": "발견",
+    "digest": "다이제스트",
     "update": "체크인"
   },
   "version_guard": {
@@ -227,7 +228,8 @@
     "my": "내 프로필",
     "questions": "질문",
     "share": "공유",
-    "discover": "오늘의 발견"
+    "discover": "오늘의 발견",
+    "daily_digest": "오늘의 다이제스트"
   },
   "home": {
     "moment": {
@@ -1414,11 +1416,11 @@
     "modes": {
       "very_social": {
         "name": "다 보기",
-        "description": "모든 탭 보기 — 친구, Discover, Chats"
+        "description": "모든 탭 보기 — 친구, 다이제스트, 채팅"
       },
       "selectively_social": {
         "name": "친한 친구만",
-        "description": "Close Friends Only 필터 활성, Discover 없음"
+        "description": "Close Friends Only 필터 활성, 다이제스트 없음"
       },
       "quiet": {
         "name": "공유만",
@@ -1429,7 +1431,7 @@
       "friends": "친구",
       "update": "업데이트",
       "share": "공유",
-      "discover": "둘러보기",
+      "discover": "다이제스트",
       "chats": "채팅",
       "my": "마이",
       "questions": "질문"
@@ -1439,22 +1441,22 @@
       "chats_close_only": "채팅 탭에서 친한 친구만 보기"
     },
     "sections": {
-      "hide_synthetic_discover_cards": "둘러보기 추천 숨기기",
+      "hide_synthetic_digest_cards": "다이제스트 추천 숨기기",
       "hide_ping_buttons": "Ping 버튼 숨기기",
       "hide_new_post_badge": "\"New post\" 배지 숨기기"
     },
     "templates": {
-      "no_discover": {
-        "name": "친구는 보고, 둘러보기는 빼고",
+      "no_digest": {
+        "name": "친구는 보고, 다이제스트는 빼고",
         "description": "아는 친구들과만 — 오늘은 새 친구는 패스"
       },
       "just_chat": {
         "name": "채팅만",
         "description": "메시지 답장만, 다른 건 패스"
       },
-      "just_discover": {
-        "name": "둘러보기만",
-        "description": "새로운 사람과 콘텐츠만 보기"
+      "just_digest": {
+        "name": "다이제스트만",
+        "description": "오늘의 다이제스트만 보기"
       },
       "digital_detox": {
         "name": "디지털 디톡스",

--- a/src/models/browseMode.ts
+++ b/src/models/browseMode.ts
@@ -26,8 +26,8 @@ export type BrowseModeFilters = {
 };
 
 export type BrowseModeSections = {
-  /** Hide synthetic Discover-style cards from the friends feed (mission prompts, profile suggestions, etc.). */
-  hide_synthetic_discover_cards?: boolean;
+  /** Hide synthetic daily-digest-style cards from the friends feed (mission prompts, profile suggestions, etc.). */
+  hide_synthetic_digest_cards?: boolean;
   /** Hide ping/poke buttons on friend cards. */
   hide_ping_buttons?: boolean;
   /** Hide the "New post" badges. */

--- a/src/routes/discover/Discover.tsx
+++ b/src/routes/discover/Discover.tsx
@@ -231,8 +231,8 @@ function Discover() {
     return result;
   }, [discoverData, profileSuggestionCard, surveyResultsCard, usernameSuggestionCard]);
 
-  // If the active browse mode says to hide synthetic discover cards, drop them here.
-  const hideSyntheticCards = !!activeBrowseMode?.config.sections.hide_synthetic_discover_cards;
+  // If the active browse mode says to hide synthetic digest cards, drop them here.
+  const hideSyntheticCards = !!activeBrowseMode?.config.sections.hide_synthetic_digest_cards;
 
   // Client-side filtering by category
   const filterItem = useCallback(


### PR DESCRIPTION
## Summary
- Ver. W 하단 탭 순서를 `Friends → Daily Digest → Check-In → Share → Chats` 로 재정렬
- Ver. W 의 `/discover` 탭 라벨을 "Digest" / "다이제스트" 로, 페이지 헤더를 "Daily Digest" / "오늘의 다이제스트" 로 리브랜딩 (route 는 `/discover` 그대로)
- Ver. Q 하단 탭 순서를 `Friends → Discover → Share → Chats → My` 로 재정렬, 첫 탭은 라벨/아이콘만 친구로 바꾸고 라우트는 `/feed` 유지
- Browse mode 텍스트(설명/탭/템플릿)도 daily digest 표기로 통일

## 주요 변경
**탭 컴포넌트**
- `Tab.tsx`: `'digest'` 타입 추가, `TAB_BASE_TYPE` 매핑으로 `discover_active/inactive` 아이콘과 `discoverPage` 스크롤 슬롯 재사용. Ver. W / Ver. Q 양쪽 탭 순서 변경.
- `Header.tsx`: `/discover` 헤더 Ver. W 분기 (`header.daily_digest`), `/feed` 헤더 라벨 `nav_tab.friends` 로 통일.

**i18n**
- 신규: `nav_tab.digest` ("Digest"/"다이제스트"), `header.daily_digest` ("Daily Digest"/"오늘의 다이제스트")
- 기존 보존: `nav_tab.discover`, `header.discover`, `discover_banner.*`, `no_contents.discover` (Ver. Q 에서 사용)
- 정비: `browse_mode.modes.*.description`, `browse_mode.tabs.discover` 값, `browse_mode.sections.hide_synthetic_digest_cards` 키/값, `browse_mode.templates.no_digest`/`just_digest` 키/값
  - `browse_mode.tabs.X` 키는 `BrowseModeTabKey` 와 1:1 매핑이라 키 이름은 `discover` 유지, 값만 "Daily Digest" 로 변경

**Browse mode 내부**
- `BrowseModeSections.hide_synthetic_discover_cards` → `hide_synthetic_digest_cards` (TS 필드 + constant + Discover.tsx 단일 사용처 일괄 갱신)
- `CUSTOMIZE_TEMPLATES.i18nKey`: `no_discover` → `no_digest`, `just_discover` → `just_digest` (저장 프리셋 호환을 위해 `id` 는 `no_discover`/`just_discover` 그대로 유지)
- `ALL_BROWSE_MODE_TABS` / `very_social.config.tabs` / `digital_detox` 탭 순서를 새 하단 nav 순서에 맞춤

## 의도적으로 변경하지 않은 것
- 라우트 경로 `/discover`, `/feed` (외부 링크/딥링크/scroll/filter 키 영향 큼)
- Ver. Q 의 `/discover` 라벨/헤더 — Daily Digest 리브랜딩은 Ver. W 전용
- `CUSTOMIZE_TEMPLATES[*].id`, `Discover.tsx` 의 `DISCOVER_FILTER_KEY`/`'discoverPage'`/`'discover_scroll'` (저장된 사용자 상태 키)

## Test plan
- [ ] Ver. W 시드 계정 (`current_ver === 'version_w'`, `user_group === 'group_w_first'`) 로 로그인
  - [ ] 하단 탭 5개 순서 `Friends / Digest / Check-In / Share / Chats` 확인 (320px / 393px)
  - [ ] Digest 자리 아이콘이 기존 discover 아이콘인지 확인
  - [ ] `/discover` 진입 시 헤더 "Daily Digest" / "오늘의 다이제스트"
  - [ ] 햄버거 메뉴 → Browse Mode → 모드/탭/템플릿 시트에서 daily digest 문구 노출
  - [ ] `selectively_social` 모드 활성 → discover 카드 추천 숨기기 동작 정상
- [ ] Ver. Q 시드 계정으로 로그인
  - [ ] 하단 탭 5개 순서 `Friends / Discover / Share / Chats / My` 확인 (320px / 393px)
  - [ ] 첫 탭이 친구 아이콘 + "Friends"/"친구" 라벨, 클릭 시 `/feed` 이동
  - [ ] `/discover` 헤더는 "Daily Discover" / "오늘의 발견" 그대로
- [ ] `npx craco build` 클린 통과
- [ ] dev server 콘솔에 missing i18n key 경고 없음