### PR TITLE
fix(chat): preserve newlines + dynamic compose-height so last message isn't covered

### DIFF
--- a/src/components/chat/chat-message-item/ChatMessageItem.tsx
+++ b/src/components/chat/chat-message-item/ChatMessageItem.tsx
@@ -235,7 +235,10 @@ function ChatMessageItem({
           <Typo type="body-medium">{ChatEmojiDict[emoji as ChatEmojiType]}</Typo>
         )}
         {content && (
-          <Typo type="body-large" color="BLACK">
+          // `pre` keeps newlines from the input intact. StyledFont sets
+          // `white-space: normal` by default, which would collapse \n into
+          // a single space and turn multi-line messages into one blurb.
+          <Typo type="body-large" color="BLACK" pre>
             <LinkifiedText>{content}</LinkifiedText>
           </Typo>
         )}
@@ -253,7 +256,7 @@ function ChatMessageItem({
           <Typo type="label-small" color="MEDIUM_GRAY">
             {parent_preview.sender.username}
           </Typo>
-          <Typo type="body-small" color="BLACK">
+          <Typo type="body-small" color="BLACK" pre>
             {parent_preview.content ||
               (parent_preview.emoji && ChatEmojiDict[parent_preview.emoji as ChatEmojiType]) ||
               ''}

--- a/src/routes/chat/Chat.tsx
+++ b/src/routes/chat/Chat.tsx
@@ -130,19 +130,26 @@ function Chat() {
   // Track the live compose-input height. Announcement compose is much taller
   // than regular chat (~162px baseline, can grow to 360px+) and grows further
   // when the user types multi-line. Without this the bottom of the chat gets
-  // covered by the compose box and the last message looks truncated. Re-runs
-  // when `username` changes (announcement vs. regular swaps the compose
-  // component); ResizeObserver handles textarea autosize within a session.
+  // covered by the compose box and the last message looks truncated.
+  //
+  // ChatMessageInput's root is `position: fixed`, which means our wrapping div
+  // has 0 flow height. Observe the fixed child (firstElementChild) instead:
+  // it has a real getBoundingClientRect even though it doesn't take flow.
+  // Re-runs when `username` changes (announcement vs. regular swaps the
+  // compose component); ResizeObserver handles textarea autosize within a
+  // session.
   useEffect(() => {
-    const el = composeWrapperRef.current;
-    if (!el) return undefined;
+    const wrapper = composeWrapperRef.current;
+    if (!wrapper) return undefined;
+    const target = wrapper.firstElementChild as HTMLElement | null;
+    if (!target) return undefined;
     const update = () => {
-      const h = el.getBoundingClientRect().height;
+      const h = target.getBoundingClientRect().height;
       if (h > 0) setComposeHeight(h);
     };
     update();
     const ro = new ResizeObserver(update);
-    ro.observe(el);
+    ro.observe(target);
     return () => ro.disconnect();
   }, [username]);
 

--- a/src/routes/chat/Chat.tsx
+++ b/src/routes/chat/Chat.tsx
@@ -52,10 +52,17 @@ function Chat() {
   const [t] = useTranslation('translation', { keyPrefix: 'chat' });
 
   const scrollRef = useRef<HTMLDivElement>(null);
+  const composeWrapperRef = useRef<HTMLDivElement>(null);
   const [prevScrollHeight, setPrevScrollHeight] = useState<number | undefined>();
   const justSentIdsRef = useRef<Set<number>>(new Set());
   const shouldPinToBottomRef = useRef<Set<number>>(new Set());
   const markReadTimerRef = useRef<ReturnType<typeof setTimeout>>();
+  // Track the live compose-input height. Defaults to the regular-chat
+  // constant; ResizeObserver below updates it to match the actual rendered
+  // height (announcement compose is ~162px and grows as the user types
+  // multi-line). The messages container's bottom margin uses this so the
+  // last bubble never gets covered by the compose box.
+  const [composeHeight, setComposeHeight] = useState<number>(CHAT_MESSAGE_INPUT_HEIGHT);
 
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [username, setUsername] = useState<string>('');
@@ -119,6 +126,25 @@ function Chat() {
       clearTimeout(markReadTimerRef.current);
     };
   }, [fetchMessages, userId]);
+
+  // Track the live compose-input height. Announcement compose is much taller
+  // than regular chat (~162px baseline, can grow to 360px+) and grows further
+  // when the user types multi-line. Without this the bottom of the chat gets
+  // covered by the compose box and the last message looks truncated. Re-runs
+  // when `username` changes (announcement vs. regular swaps the compose
+  // component); ResizeObserver handles textarea autosize within a session.
+  useEffect(() => {
+    const el = composeWrapperRef.current;
+    if (!el) return undefined;
+    const update = () => {
+      const h = el.getBoundingClientRect().height;
+      if (h > 0) setComposeHeight(h);
+    };
+    update();
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [username]);
 
   // Scroll to target message or pin to bottom on first load
   useEffect(() => {
@@ -352,12 +378,7 @@ function Chat() {
           </Layout.FlexCol>
         )}
         {!firstLoad && refinedMessages.length > 0 && (
-          <Layout.FlexCol
-            w="100%"
-            gap={15}
-            p={10}
-            mb={showRequestBar ? 110 : CHAT_MESSAGE_INPUT_HEIGHT}
-          >
+          <Layout.FlexCol w="100%" gap={15} p={10} mb={showRequestBar ? 110 : composeHeight}>
             <div ref={targetRef} />
             {isLoading && <Loader />}
             {refinedMessages.map((message) => (
@@ -396,15 +417,17 @@ function Chat() {
           onCancelled={() => setSentChatRequest(false)}
         />
       ) : (
-        <ChatMessageInput
-          userId={Number(userId)}
-          replyTarget={replyTarget}
-          onClearReply={() => setReplyTarget(null)}
-          onMessageSent={handleMessageSent}
-          onTyping={sendTyping}
-          typingText={isOpponentTyping ? `${username} is typing...` : null}
-          isAnnouncement={username === 'Announcements'}
-        />
+        <div ref={composeWrapperRef}>
+          <ChatMessageInput
+            userId={Number(userId)}
+            replyTarget={replyTarget}
+            onClearReply={() => setReplyTarget(null)}
+            onMessageSent={handleMessageSent}
+            onTyping={sendTyping}
+            typingText={isOpponentTyping ? `${username} is typing...` : null}
+            isAnnouncement={username === 'Announcements'}
+          />
+        </div>
       )}
     </MainScrollContainer>
   );


### PR DESCRIPTION
## Summary
Two coupled rendering bugs in chat messages:

### 1. Newlines collapsed on render
Multi-line messages (especially announcements where Enter inserts a newline) rendered as a single "blurb" — newlines collapsed into spaces.

**Root cause:** the chat bubble has \`white-space: pre-wrap\` on its outer container, but the inner \`<Typo>\` (StyledFont) explicitly overrides with \`white-space: normal\` unless given the \`pre\` prop. The override beat the inherited pre-wrap.

**Fix:** add \`pre\` to the two \`<Typo>\` instances that render user-authored content in [\`ChatMessageItem.tsx\`](WhoamI-Today-frontend/src/components/chat/chat-message-item/ChatMessageItem.tsx) — main message content and reply preview.

### 2. Last message hidden behind compose box
The chat messages container reserved a fixed 65px bottom margin for the compose input. Regular chat compose is ~65px so this worked, but announcements compose is ~162px (4-row textarea + Post Announcement button) and can grow to 360px+ as the user types. The mismatch hid up to ~100-300px of the latest message behind the compose box.

**Root cause:** the existing fixed margin (\`CHAT_MESSAGE_INPUT_HEIGHT = 65\`) didn't account for the announcement compose's extra height. A naive ResizeObserver on a wrapping \`<div>\` around \`ChatMessageInput\` returned 0 because \`ChatMessageInput\`'s root is \`Layout.Fixed\` (position: fixed) — the wrapping div has 0 flow height.

**Fix in [\`Chat.tsx\`](WhoamI-Today-frontend/src/routes/chat/Chat.tsx):**
- Wrap \`ChatMessageInput\` in a ref'd div
- Observe \`wrapper.firstElementChild\` (the fixed-positioned compose root) instead of the wrapping div
- Feed live measurement into the messages container's \`mb\`
- ResizeObserver handles textarea autosize within a session; the dep on \`username\` re-attaches when the compose component swaps (announcement vs. regular)

## Test plan
- [x] \`craco build\` clean
- [x] Verified DOM geometry: messages container marginBottom = **162px** (was stuck at 65), 3-line bubble height = 128px (newlines preserved), bubble bottom 729 vs compose top 871 → 142px clear, **overlap = 0**
- [x] No console errors after fresh dev server compile

Applies to **every chat message** (1-on-1, group, escalated wit_bot, wit_admin/announcements) since they all flow through the same \`ChatMessageItem\` and \`Chat\` components.