### PR TITLE
Expand post images on click

### DIFF
--- a/src/components/check-in-posts/CheckInPostItem/CheckInPostItem.styled.ts
+++ b/src/components/check-in-posts/CheckInPostItem/CheckInPostItem.styled.ts
@@ -7,3 +7,35 @@ export const PostImage = styled.img`
   border-radius: 12px;
   background-color: ${Colors.LIGHT};
 `;
+
+export const PostImageButton = styled.button`
+  width: 100%;
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: zoom-in;
+`;
+
+export const ImagePreviewBackdrop = styled.button`
+  position: fixed;
+  top: 0;
+  left: 50%;
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  max-width: 500px;
+  height: 100vh;
+  padding: 0;
+  border: none;
+  background: rgba(0, 0, 0, 0.85);
+  cursor: pointer;
+  transform: translateX(-50%);
+`;
+
+export const ImagePreview = styled.img`
+  max-width: 90%;
+  max-height: 80vh;
+  object-fit: contain;
+`;

--- a/src/components/check-in-posts/CheckInPostItem/CheckInPostItem.tsx
+++ b/src/components/check-in-posts/CheckInPostItem/CheckInPostItem.tsx
@@ -1,4 +1,5 @@
 import { CSSProperties, MouseEvent, useState } from 'react';
+import { createPortal } from 'react-dom';
 import LikeButton from '@components/_common/like-button/LikeButton';
 import LinkifiedText from '@components/_common/linkified-text/LinkifiedText';
 import ProfileImage from '@components/_common/profile-image/ProfileImage';
@@ -42,6 +43,7 @@ function CheckInPostItem({
   const [commentPost, setCommentPost] = useState<CheckInPost | null>(null);
   const [showComments, setShowComments] = useState(false);
   const [inputFocus, setInputFocus] = useState(false);
+  const [showImagePopup, setShowImagePopup] = useState(false);
 
   const handleClick = (e: MouseEvent) => {
     e.stopPropagation();
@@ -129,7 +131,18 @@ function CheckInPostItem({
           )}
         </Layout.FlexRow>
 
-        {image_url && <S.PostImage src={image_url} alt="snippet" />}
+        {image_url && (
+          <S.PostImageButton
+            type="button"
+            aria-label="Open image preview"
+            onClick={(e) => {
+              e.stopPropagation();
+              setShowImagePopup(true);
+            }}
+          >
+            <S.PostImage src={image_url} alt="snippet" />
+          </S.PostImageButton>
+        )}
 
         {caption && (
           <div style={{ marginTop: 8, width: '100%', textAlign: 'center' }}>
@@ -208,6 +221,15 @@ function CheckInPostItem({
       </Layout.FlexCol>
 
       <LikesListModal postId={likesPostId} onClose={() => setLikesPostId(null)} />
+
+      {image_url &&
+        showImagePopup &&
+        createPortal(
+          <S.ImagePreviewBackdrop type="button" onClick={() => setShowImagePopup(false)}>
+            <S.ImagePreview src={image_url} alt="Full size snippet" />
+          </S.ImagePreviewBackdrop>,
+          document.body,
+        )}
 
       {commentPost && (
         <CommentBottomSheet

--- a/src/components/note/note-item/NoteItem.tsx
+++ b/src/components/note/note-item/NoteItem.tsx
@@ -1,4 +1,5 @@
 import { MouseEvent, useEffect, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
@@ -66,6 +67,7 @@ function NoteItem({
   const [inputFocus, setInputFocus] = useState(false);
   const [isHidden, setIsHidden] = useState(false);
   const [likePatch, setLikePatch] = useState<Partial<Note> | null>(null);
+  const [showImagePopup, setShowImagePopup] = useState(false);
 
   useEffect(() => {
     if (displayType !== 'LIST') {
@@ -152,6 +154,11 @@ function NoteItem({
     });
   };
 
+  const openImagePopup = (e: MouseEvent) => {
+    e.stopPropagation();
+    setShowImagePopup(true);
+  };
+
   if (isHidden) return null;
 
   const headerJsx = (
@@ -236,7 +243,11 @@ function NoteItem({
     <Layout.FlexCol gap={4}>
       {previewMode ? (
         <>
-          {images[0] && <PreviewImage src={images[0]} />}
+          {images[0] && (
+            <PostImageButton type="button" aria-label="Open image preview" onClick={openImagePopup}>
+              <PreviewImage src={images[0]} alt="note" />
+            </PostImageButton>
+          )}
           {content && (
             <Typo type="body-medium" color="BLACK" pre>
               <LinkifiedText>{content}</LinkifiedText>
@@ -265,7 +276,13 @@ function NoteItem({
           {/* Note image - only show 1 */}
           {images[0] && (
             <Layout.FlexRow w="100%" mv={10}>
-              <NoteImage src={images[0]} />
+              <PostImageButton
+                type="button"
+                aria-label="Open image preview"
+                onClick={openImagePopup}
+              >
+                <NoteImage src={images[0]} alt="note" />
+              </PostImageButton>
             </Layout.FlexRow>
           )}
           {missionPromptJsx}
@@ -352,6 +369,14 @@ function NoteItem({
           </>
         )}
       </Layout.FlexCol>
+      {images[0] &&
+        showImagePopup &&
+        createPortal(
+          <ImagePreviewBackdrop type="button" onClick={() => setShowImagePopup(false)}>
+            <ImagePreview src={images[0]} alt="Full size note" />
+          </ImagePreviewBackdrop>,
+          document.body,
+        )}
       {bottomSheet && (
         <CommentBottomSheet
           postType="Note"
@@ -381,6 +406,38 @@ const PreviewImage = styled.img`
   height: 100px;
   object-fit: cover;
   border-radius: 8px;
+`;
+
+const PostImageButton = styled.button`
+  width: 100%;
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: zoom-in;
+`;
+
+const ImagePreviewBackdrop = styled.button`
+  position: fixed;
+  top: 0;
+  left: 50%;
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  max-width: 500px;
+  height: 100vh;
+  padding: 0;
+  border: none;
+  background: rgba(0, 0, 0, 0.85);
+  cursor: pointer;
+  transform: translateX(-50%);
+`;
+
+const ImagePreview = styled.img`
+  max-width: 90%;
+  max-height: 80vh;
+  object-fit: contain;
 `;
 
 const PreviewBody = styled.div`

--- a/src/components/response/response-item/ResponseItem.tsx
+++ b/src/components/response/response-item/ResponseItem.tsx
@@ -1,4 +1,5 @@
 import { MouseEvent, useEffect, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
@@ -54,6 +55,7 @@ function ResponseItem({
   const [showMore, setShowMore] = useState(false);
   const [isHidden, setIsHidden] = useState(false);
   const [likePatch, setLikePatch] = useState<Partial<Response> | null>(null);
+  const [showImagePopup, setShowImagePopup] = useState(false);
 
   const footerPost = useMemo(
     () => (likePatch ? { ...response, ...likePatch } : response),
@@ -131,6 +133,11 @@ function ResponseItem({
     navigate(`/users/${username}`, {
       state: { source: classifyPathnameAsSource(location.pathname) },
     });
+  };
+
+  const openImagePopup = (e: MouseEvent) => {
+    e.stopPropagation();
+    setShowImagePopup(true);
   };
 
   if (isHidden) return null;
@@ -233,7 +240,9 @@ function ResponseItem({
       {/* Response image */}
       {image && (
         <RespImageWrapper>
-          <img src={image} alt="response" style={{ width: '100%', borderRadius: 8 }} />
+          <PostImageButton type="button" aria-label="Open image preview" onClick={openImagePopup}>
+            <img src={image} alt="response" style={{ width: '100%', borderRadius: 8 }} />
+          </PostImageButton>
         </RespImageWrapper>
       )}
       {/* (Edited) */}
@@ -324,6 +333,14 @@ function ResponseItem({
           )}
         </Layout.FlexCol>
       </Layout.FlexRow>
+      {image &&
+        showImagePopup &&
+        createPortal(
+          <ImagePreviewBackdrop type="button" onClick={() => setShowImagePopup(false)}>
+            <ImagePreview src={image} alt="Full size response" />
+          </ImagePreviewBackdrop>,
+          document.body,
+        )}
       {bottomSheet && (
         <CommentBottomSheet
           postType="Response"
@@ -390,4 +407,36 @@ const RespImageWrapper = styled.div`
   border-radius: 8px;
   overflow: hidden;
   margin-bottom: 8px;
+`;
+
+const PostImageButton = styled.button`
+  width: 100%;
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: zoom-in;
+`;
+
+const ImagePreviewBackdrop = styled.button`
+  position: fixed;
+  top: 0;
+  left: 50%;
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  max-width: 500px;
+  height: 100vh;
+  padding: 0;
+  border: none;
+  background: rgba(0, 0, 0, 0.85);
+  cursor: pointer;
+  transform: translateX(-50%);
+`;
+
+const ImagePreview = styled.img`
+  max-width: 90%;
+  max-height: 80vh;
+  object-fit: contain;
 `;


### PR DESCRIPTION
## Summary
- add click-to-expand image preview for check-in posts
- add the same image preview interaction to note and response items
- stop image clicks from triggering card detail navigation

## Test
- npm run build