### PR TITLE
Share 탭 아이콘을 연필로 변경

### DIFF
--- a/public/icons/share_active.svg
+++ b/public/icons/share_active.svg
@@ -1,5 +1,8 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <rect x="3" y="3" width="18" height="18" rx="3" fill="#8700FF" stroke="#8700FF" stroke-width="2"/>
-  <line x1="12" y1="8" x2="12" y2="16" stroke="white" stroke-width="2" stroke-linecap="round"/>
-  <line x1="8" y1="12" x2="16" y2="12" stroke="white" stroke-width="2" stroke-linecap="round"/>
+  <g transform="translate(12 12) scale(1.55) translate(-12 -12)">
+    <path
+      d="M16.2755 10.2313L13.7386 7.7243L14.5743 6.88863C14.8031 6.65982 15.0843 6.54541 15.4177 6.54541C15.7512 6.54541 16.0321 6.65982 16.2606 6.88863L17.0962 7.7243C17.325 7.95311 17.4444 8.22928 17.4544 8.55281C17.4643 8.87633 17.3549 9.1523 17.1261 9.38072L16.2755 10.2313ZM15.41 11.1117L9.08275 17.439H6.5459V14.9021L12.8731 8.57489L15.41 11.1117Z"
+      fill="#8700FF"
+    />
+  </g>
 </svg>

--- a/public/icons/share_inactive.svg
+++ b/public/icons/share_inactive.svg
@@ -1,5 +1,8 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <rect x="3" y="3" width="18" height="18" rx="3" stroke="#D9D9D9" stroke-width="2"/>
-  <line x1="12" y1="8" x2="12" y2="16" stroke="#D9D9D9" stroke-width="2" stroke-linecap="round"/>
-  <line x1="8" y1="12" x2="16" y2="12" stroke="#D9D9D9" stroke-width="2" stroke-linecap="round"/>
+  <g transform="translate(12 12) scale(1.55) translate(-12 -12)">
+    <path
+      d="M16.2755 10.2313L13.7386 7.7243L14.5743 6.88863C14.8031 6.65982 15.0843 6.54541 15.4177 6.54541C15.7512 6.54541 16.0321 6.65982 16.2606 6.88863L17.0962 7.7243C17.325 7.95311 17.4444 8.22928 17.4544 8.55281C17.4643 8.87633 17.3549 9.1523 17.1261 9.38072L16.2755 10.2313ZM15.41 11.1117L9.08275 17.439H6.5459V14.9021L12.8731 8.57489L15.41 11.1117Z"
+      fill="#D9D9D9"
+    />
+  </g>
 </svg>


### PR DESCRIPTION
Ver. Q(`checkInPosts`)과 Ver. W 레이아웃 모두 Share 탭이 동일하게 `share_inactive` / `share_active` SVG를 사용하므로, 두 모드에서 같은 연필 아이콘이 표시됩니다.

- `public/icons/share_inactive.svg`, `share_active.svg`: 플러스 박스 → 연필 실루엣, 비활성 `#D9D9D9` / 활성 `#8700FF`
- 뷰박스 중심 기준 scale(1.55)로 다른 탭 대비 가독성 확보

Made with [Cursor](https://cursor.com)