### PR TITLE
Enable check-in reactions on friend profiles

### DIFF
--- a/src/components/check-in/CheckIn.tsx
+++ b/src/components/check-in/CheckIn.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import CheckInHistoryChip from '@components/check-in/archive/CheckInArchiveChip';
+import CheckInDetailBottomSheet from '@components/check-in/check-in-detail-bottom-sheet/CheckInDetailBottomSheet';
 import FriendPinnedChip from '@components/friends/friend-pinned-chip/FriendPinnedChip';
 import SpotifyMusic from '@components/music/spotify-music/SpotifyMusic';
 import MoodPlaceholder from '@components/profile/placeholders/MoodPlaceholder';
@@ -12,6 +13,8 @@ import { useIsPreviewMode } from '@components/view-as/PreviewModeContext';
 import { Layout, Typo } from '@design-system';
 import useAsyncEffect from '@hooks/useAsyncEffect';
 import { useFriendPinnedCount } from '@hooks/useFriendPinnedCount';
+import { useTrackEvent } from '@hooks/useTrackEvent';
+import { Connection } from '@models/api/friends';
 import { MyProfile } from '@models/api/user';
 import { CheckInBase } from '@models/checkIn';
 import { UserProfile } from '@models/user';
@@ -25,6 +28,7 @@ interface CheckInProps {
 
 function CheckIn({ user }: CheckInProps) {
   const [t] = useTranslation('translation', { keyPrefix: 'user_page.check_in' });
+  const trackEvent = useTrackEvent();
   const {
     myProfile,
     checkIn: initialCheckIn,
@@ -41,6 +45,9 @@ function CheckIn({ user }: CheckInProps) {
   const [checkIn, setCheckIn] = useState<CheckInBase | null | undefined>(
     isMyPage ? initialCheckIn : user.check_in,
   );
+  const [checkInDetailFocus, setCheckInDetailFocus] = useState<
+    'battery' | 'mood' | 'thought' | 'song' | null
+  >(null);
   // Per-component visibility is enforced on the API; render payload as returned.
   const { social_battery, track_id, mood, thought } = checkIn || {};
   // Backend redacts mood to `[]` (truthy) when viewer lacks visibility — normalize to length-checked list.
@@ -54,6 +61,23 @@ function CheckIn({ user }: CheckInProps) {
 
   const handleClickEditCheckIn = () => {
     return navigate('/update');
+  };
+
+  const handleClickCheckInComponent = (component: 'battery' | 'mood' | 'thought' | 'song') => {
+    if (isMyPage) {
+      handleClickEditCheckIn();
+      return;
+    }
+    if (!checkIn?.id) return;
+    trackEvent('friend_check_in_component_opened', {
+      component,
+      friend_id: user.id,
+      is_close_friend:
+        'connection_status' in user && user.connection_status === Connection.CLOSE_FRIEND
+          ? 'true'
+          : 'false',
+    });
+    setCheckInDetailFocus(component);
   };
 
   useAsyncEffect(async () => {
@@ -88,10 +112,7 @@ function CheckIn({ user }: CheckInProps) {
             {social_battery ? (
               <SocialBatteryChip
                 socialBattery={social_battery}
-                onClick={() => {
-                  if (!isMyPage) return;
-                  handleClickEditCheckIn();
-                }}
+                onClick={() => handleClickCheckInComponent('battery')}
               />
             ) : (
               isMyPage && <SocialBatteryPlaceholder />
@@ -100,13 +121,9 @@ function CheckIn({ user }: CheckInProps) {
             {track_id ? (
               <SpotifyMusic
                 track={track_id}
-                useDetailBottomSheet={!isMyPage}
                 useAlbumImg
                 fontType="label-large"
-                onClick={() => {
-                  if (!isMyPage) return;
-                  handleClickEditCheckIn();
-                }}
+                onClick={() => handleClickCheckInComponent('song')}
               />
             ) : (
               isMyPage && <MusicPlaceholder />
@@ -125,11 +142,8 @@ function CheckIn({ user }: CheckInProps) {
                   ph={8}
                   pv={4}
                   rounded={8}
-                  style={{ flexShrink: 0 }}
-                  onClick={() => {
-                    if (!isMyPage) return;
-                    handleClickEditCheckIn();
-                  }}
+                  style={{ flexShrink: 0, cursor: 'pointer' }}
+                  onClick={() => handleClickCheckInComponent('mood')}
                 >
                   {moodList.map((emoji) => (
                     <span key={emoji} style={{ fontSize: 16, lineHeight: 1 }}>
@@ -154,11 +168,8 @@ function CheckIn({ user }: CheckInProps) {
                   ph={8}
                   pv={4}
                   rounded={8}
-                  style={{ minWidth: 0, maxWidth: '100%' }}
-                  onClick={() => {
-                    if (!isMyPage) return;
-                    handleClickEditCheckIn();
-                  }}
+                  style={{ minWidth: 0, maxWidth: '100%', cursor: 'pointer' }}
+                  onClick={() => handleClickCheckInComponent('thought')}
                 >
                   <span style={{ fontSize: 14, lineHeight: 1 }} aria-hidden>
                     🤪
@@ -188,6 +199,18 @@ function CheckIn({ user }: CheckInProps) {
             )
           )}
         </Layout.FlexRow>
+        <CheckInDetailBottomSheet
+          visible={!!checkInDetailFocus}
+          closeBottomSheet={() => setCheckInDetailFocus(null)}
+          focusComponent={checkInDetailFocus}
+          checkInId={checkIn?.id}
+          username={'username' in user ? user.username : undefined}
+          profileImage={user.profile_image}
+          socialBattery={social_battery}
+          mood={moodList}
+          description={thought}
+          trackId={track_id}
+        />
       </>
     </Layout.FlexCol>
   );

--- a/src/components/check-in/update-quadrant/EditorPopup.tsx
+++ b/src/components/check-in/update-quadrant/EditorPopup.tsx
@@ -55,6 +55,7 @@ function EditorPopup({
   };
 
   const handleOverlayClick = (e: MouseEvent<HTMLDivElement>) => {
+    e.stopPropagation();
     if (Date.now() < suppressBackdropCloseUntilRef.current) {
       shouldCloseFromBackdropRef.current = false;
       console.log('[EditorPopup] ignore overlay click (suppressed)', { title });

--- a/src/components/friends/friend-item-with-updates/FriendItemWithUpdates.tsx
+++ b/src/components/friends/friend-item-with-updates/FriendItemWithUpdates.tsx
@@ -143,7 +143,7 @@ function FriendItemWithUpdates({
   const showUpdateBadge = showCheckInSection && hasUpdate;
   const showNewBadge = tabMode === 'posts' && hasNewPost;
 
-  const moodArray: string[] = Array.isArray(mood) ? mood : mood ? [mood] : [];
+  const moodArray: string[] = (Array.isArray(mood) ? mood : mood ? [mood] : []).filter(Boolean);
   const hasMood = moodArray.length > 0;
   const hasThought = !!thought;
   const hasBattery = !!social_battery && Object.values(SocialBattery).includes(social_battery);

--- a/src/components/friends/friend-profile-accordion-item/FriendProfileAccordionItem.tsx
+++ b/src/components/friends/friend-profile-accordion-item/FriendProfileAccordionItem.tsx
@@ -82,7 +82,7 @@ function FriendProfileAccordionItem({
     (user.unread_post_cnt ?? 0) > 0 ||
     (user.recent_posts ?? []).some((p) => !p.current_user_read);
 
-  const moodArray: string[] = Array.isArray(mood) ? mood : mood ? [mood] : [];
+  const moodArray: string[] = (Array.isArray(mood) ? mood : mood ? [mood] : []).filter(Boolean);
   const hasMood = moodArray.length > 0;
   const hasThought = !!thought;
   const hasBattery = !!social_battery && Object.values(SocialBattery).includes(social_battery);

--- a/src/components/friends/friend-profile-accordion-item/FriendProfileAccordionItem.tsx
+++ b/src/components/friends/friend-profile-accordion-item/FriendProfileAccordionItem.tsx
@@ -128,6 +128,10 @@ function FriendProfileAccordionItem({
     setShowSubscriptionPopup(true);
   };
 
+  const handleClickCollapsedRow = () => {
+    onToggleExpand();
+  };
+
   const handleToggle = (e: MouseEvent) => {
     e.stopPropagation();
     onToggleExpand();
@@ -136,7 +140,12 @@ function FriendProfileAccordionItem({
   return (
     <AccordionContainer $isMyCard={isMyCard} ph={16} pv={12} gap={0} rounded={12}>
       {/* Collapsed Row: always visible */}
-      <CollapsedRow gap={6} justifyContent="space-between">
+      <CollapsedRow
+        gap={6}
+        justifyContent="space-between"
+        onClick={handleClickCollapsedRow}
+        style={{ cursor: 'pointer' }}
+      >
         <Layout.FlexRow alignItems="center" gap={6} style={{ flex: 1, minWidth: 0 }}>
           {/* Profile + Username + Connection badge */}
           <Layout.FlexRow

--- a/src/components/friends/friend-profile-accordion-item/FriendProfileAccordionItem.tsx
+++ b/src/components/friends/friend-profile-accordion-item/FriendProfileAccordionItem.tsx
@@ -92,6 +92,10 @@ function FriendProfileAccordionItem({
 
   // --- handlers ---
   const openCheckInDetail = (component: 'battery' | 'mood' | 'thought' | 'song') => {
+    if (isMyCard) {
+      navigate('/update');
+      return;
+    }
     trackEvent('friend_check_in_component_opened', {
       component,
       friend_id: id,

--- a/src/routes/chat/ChatList.tsx
+++ b/src/routes/chat/ChatList.tsx
@@ -21,6 +21,16 @@ const PurpleToggleWrapper = styled.div`
   }
 `;
 
+const CHAT_PREVIEW_LINES = 2;
+
+const ChatPreviewText = styled(Typo)`
+  min-height: calc(12px * 1.4 * ${CHAT_PREVIEW_LINES});
+`;
+
+const GroupMemberCountText = styled(Typo)`
+  flex-shrink: 0;
+`;
+
 function ChatList() {
   const navigate = useNavigate();
   const currentUser = useBoundStore((state) => state.myProfile);
@@ -287,26 +297,41 @@ function ChatList() {
                   <ProfileImage imageUrl={room.opponent?.profile_image} size={44} />
                 )}
                 <Layout.FlexCol style={{ flex: 1, minWidth: 0 }}>
-                  <Layout.FlexRow gap={6} alignItems="center">
-                    <Typo type="title-medium" color="BLACK">
+                  <Layout.FlexRow gap={6} alignItems="center" style={{ minWidth: 0 }}>
+                    <Typo type="title-medium" color="BLACK" numberOfLines={1}>
                       {roomName}
                     </Typo>
                     {room.is_group && !renderAsWitBotDM && room.members_detail && (
-                      <Typo type="label-small" color="MEDIUM_GRAY">
+                      <GroupMemberCountText type="label-small" color="MEDIUM_GRAY">
                         ({room.members_detail.length})
-                      </Typo>
+                      </GroupMemberCountText>
                     )}
                   </Layout.FlexRow>
                   {isTyping ? (
-                    <Typo type="body-small" color="PRIMARY">
+                    <ChatPreviewText
+                      type="body-small"
+                      color="PRIMARY"
+                      numberOfLines={CHAT_PREVIEW_LINES}
+                    >
                       typing...
-                    </Typo>
+                    </ChatPreviewText>
+                  ) : room.last_message ? (
+                    <ChatPreviewText
+                      type="body-small"
+                      color="MEDIUM_GRAY"
+                      numberOfLines={CHAT_PREVIEW_LINES}
+                    >
+                      {room.last_message}
+                    </ChatPreviewText>
                   ) : (
-                    room.last_message && (
-                      <Typo type="body-small" color="MEDIUM_GRAY">
-                        {room.last_message}
-                      </Typo>
-                    )
+                    <ChatPreviewText
+                      type="body-small"
+                      color="MEDIUM_GRAY"
+                      numberOfLines={CHAT_PREVIEW_LINES}
+                      aria-hidden
+                    >
+                      {' '}
+                    </ChatPreviewText>
                   )}
                 </Layout.FlexCol>
                 {room.unread_count > 0 && (


### PR DESCRIPTION
## Summary
- Open the shared check-in detail reaction sheet from friend profile check-in components
- Keep own-profile check-in clicks routed to edit check-in
- Track friend check-in component opens consistently with the friends tab

## Verification
- yarn eslint src/components/check-in/CheckIn.tsx
- yarn build

Note: yarn tsc --noEmit is currently blocked by existing @spotify/web-api-ts-sdk declaration syntax incompatibility with the repo TypeScript version.