### PR TITLE
Fix chat badge for currently open conversation

### DIFF
--- a/src/routes/Root.tsx
+++ b/src/routes/Root.tsx
@@ -181,13 +181,33 @@ function Root() {
   const refreshUnreadCount = useCallback(() => {
     getMyProfile().catch(() => {});
   }, []);
+
+  const isViewingChatListUpdateRoom = useCallback(
+    (data: { opponent_id?: number; room_id?: number; is_group?: boolean }) => {
+      const oneOnOneMatch = location.pathname.match(/^\/users\/(\d+)\/chat\/?$/);
+      if (oneOnOneMatch && data.opponent_id === Number(oneOnOneMatch[1])) return true;
+
+      const groupMatch = location.pathname.match(/^\/chats\/group\/(\d+)\/?$/);
+      if (groupMatch && data.is_group && data.room_id === Number(groupMatch[1])) return true;
+
+      return false;
+    },
+    [location.pathname],
+  );
+
   const onChatListSocketUpdate = useCallback(
-    (data: { unread_count?: number }) => {
+    (data: {
+      unread_count?: number;
+      opponent_id?: number;
+      room_id?: number;
+      is_group?: boolean;
+    }) => {
       if (typeof data.unread_count === 'number') {
+        if (isViewingChatListUpdateRoom(data)) return;
         refreshUnreadCount();
       }
     },
-    [refreshUnreadCount],
+    [isViewingChatListUpdateRoom, refreshUnreadCount],
   );
   useChatListSocket(onChatListSocketUpdate);
 

--- a/src/routes/chat/Chat.tsx
+++ b/src/routes/chat/Chat.tsx
@@ -329,13 +329,11 @@ function Chat() {
         setMessages((prev) => insertChronologically(prev, { ...msg, is_read: true }));
         if (userId) {
           clearTimeout(markReadTimerRef.current);
-          markReadTimerRef.current = setTimeout(() => {
-            markMessagesRead(Number(userId)).catch(() => {});
-          }, 300);
+          markReadTimerRef.current = setTimeout(markRead, 300);
         }
       }
     },
-    [currentUser, userId],
+    [currentUser, markRead, userId],
   );
 
   // WebSocket: receive reaction updates

--- a/src/routes/chat/GroupChat.tsx
+++ b/src/routes/chat/GroupChat.tsx
@@ -47,6 +47,7 @@ function GroupChat() {
   const [prevScrollHeight, setPrevScrollHeight] = useState<number | undefined>();
   const justSentIdsRef = useRef<Set<number>>(new Set());
   const shouldPinToBottomRef = useRef<Set<number>>(new Set());
+  const markReadTimerRef = useRef<ReturnType<typeof setTimeout>>();
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [room, setRoom] = useState<ChatRoom>();
   const [nextUrl, setNextUrl] = useState<string | null>(null);
@@ -87,6 +88,9 @@ function GroupChat() {
   useEffect(() => {
     if (!roomId) return;
     fetchMessages(Number(roomId));
+    return () => {
+      clearTimeout(markReadTimerRef.current);
+    };
   }, [fetchMessages, roomId]);
 
   useEffect(() => {
@@ -208,7 +212,8 @@ function GroupChat() {
         });
         // Mark as read since user is viewing the room
         if (roomId) {
-          markGroupMessagesRead(Number(roomId)).catch(() => {});
+          clearTimeout(markReadTimerRef.current);
+          markReadTimerRef.current = setTimeout(markRead, 300);
         }
       }
     });
@@ -216,7 +221,7 @@ function GroupChat() {
     return () => {
       ws.close();
     };
-  }, [roomId, currentUser]);
+  }, [roomId, currentUser, markRead]);
 
   const sendTyping = useCallback(() => {
     const ws = socketRef.current;


### PR DESCRIPTION
## Summary
- skip global unread badge refresh when the chat-list socket update is for the currently open 1:1 or group chat
- reuse the existing mark-read flow after receiving messages in the active chat so profile state stays synced

## Test
- npm run build