### PR TITLE
Fix friend feed check-in updates

### DIFF
--- a/src/components/friends/check-in-update-card/CheckInUpdateCard.styled.ts
+++ b/src/components/friends/check-in-update-card/CheckInUpdateCard.styled.ts
@@ -6,11 +6,21 @@ export const CardContainer = styled(Layout.FlexCol)`
   border-left: 3px solid ${Colors.PRIMARY};
   border-radius: 0 12px 12px 0;
   padding: 10px 12px;
-  cursor: pointer;
   width: 100%;
   box-sizing: border-box;
 `;
 
 export const ComponentContent = styled(Layout.FlexRow)`
   padding: 4px 0;
+`;
+
+export const ClickableArea = styled.div`
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+
+  &:focus-visible {
+    outline: 2px solid ${Colors.PRIMARY};
+    outline-offset: 2px;
+    border-radius: 8px;
+  }
 `;

--- a/src/components/friends/check-in-update-card/CheckInUpdateCard.tsx
+++ b/src/components/friends/check-in-update-card/CheckInUpdateCard.tsx
@@ -1,3 +1,4 @@
+import { KeyboardEvent } from 'react';
 import EmojiItem from '@components/_common/emoji-item/EmojiItem';
 import ProfileImage from '@components/_common/profile-image/ProfileImage';
 import SpotifyMusic from '@components/music/spotify-music/SpotifyMusic';
@@ -5,7 +6,7 @@ import SocialBatteryChip from '@components/profile/social-batter-chip/SocialBatt
 import { Layout, Typo } from '@design-system';
 import { SocialBattery } from '@models/checkIn';
 import { convertTimeDiffByString } from '@utils/timeHelpers';
-import { CardContainer, ComponentContent } from './CheckInUpdateCard.styled';
+import { CardContainer, ClickableArea, ComponentContent } from './CheckInUpdateCard.styled';
 
 type CheckInComponent = 'battery' | 'mood' | 'thought' | 'song';
 
@@ -17,7 +18,8 @@ interface Props {
   socialBattery?: SocialBattery | null;
   trackId?: string;
   timestamp: string;
-  onClick?: () => void;
+  onProfileClick?: () => void;
+  onComponentClick?: () => void;
 }
 
 const COMPONENT_LABELS: Record<CheckInComponent, string> = {
@@ -35,78 +37,102 @@ function CheckInUpdateCard({
   socialBattery,
   trackId,
   timestamp,
-  onClick,
+  onProfileClick,
+  onComponentClick,
 }: Props) {
   const moodArray: string[] = component === 'mood' && content ? content.split(',') : [];
 
+  const handleKeyDown = (handler?: () => void) => (event: KeyboardEvent<HTMLDivElement>) => {
+    if (!handler) return;
+    if (event.key !== 'Enter' && event.key !== ' ') return;
+    event.preventDefault();
+    handler();
+  };
+
   return (
-    <CardContainer gap={6} onClick={onClick} w="100%">
+    <CardContainer gap={6} w="100%">
       {/* Header: profile + "username updated their mood" + timestamp */}
-      <Layout.FlexRow w="100%" alignItems="center" gap={8}>
-        <ProfileImage imageUrl={profileImage} username={username} size={28} />
-        <Layout.FlexCol style={{ flex: 1, minWidth: 0 }}>
-          <Layout.FlexRow alignItems="center" gap={4} style={{ flexWrap: 'wrap' }}>
-            <Typo type="label-large" fontWeight={600}>
-              {username}
+      <ClickableArea
+        role="button"
+        tabIndex={0}
+        aria-label={`Open ${username}'s profile`}
+        onClick={onProfileClick}
+        onKeyDown={handleKeyDown(onProfileClick)}
+      >
+        <Layout.FlexRow w="100%" alignItems="center" gap={8}>
+          <ProfileImage imageUrl={profileImage} username={username} size={28} />
+          <Layout.FlexCol style={{ flex: 1, minWidth: 0 }}>
+            <Layout.FlexRow alignItems="center" gap={4} style={{ flexWrap: 'wrap' }}>
+              <Typo type="label-large" fontWeight={600}>
+                {username}
+              </Typo>
+              <Typo type="label-medium" color="MEDIUM_GRAY">
+                updated their {COMPONENT_LABELS[component]}
+              </Typo>
+            </Layout.FlexRow>
+            <Typo type="label-small" color="MEDIUM_GRAY">
+              {convertTimeDiffByString({ day: new Date(timestamp) })}
             </Typo>
-            <Typo type="label-medium" color="MEDIUM_GRAY">
-              updated their {COMPONENT_LABELS[component]}
-            </Typo>
-          </Layout.FlexRow>
-          <Typo type="label-small" color="MEDIUM_GRAY">
-            {convertTimeDiffByString({ day: new Date(timestamp) })}
-          </Typo>
-        </Layout.FlexCol>
-      </Layout.FlexRow>
+          </Layout.FlexCol>
+        </Layout.FlexRow>
+      </ClickableArea>
 
       {/* Content */}
-      <ComponentContent alignItems="center" gap={4}>
-        {component === 'battery' && socialBattery && (
-          <SocialBatteryChip socialBattery={socialBattery} compact />
-        )}
-        {component === 'mood' && moodArray.length > 0 && (
-          <Layout.FlexRow alignItems="center" gap={0}>
-            {moodArray.map((emoji, idx) => {
-              const dupeCount = moodArray.slice(0, idx).filter((e) => e === emoji).length;
-              return (
-                <EmojiItem
-                  key={`${emoji}${dupeCount}`}
-                  emojiString={emoji.trim()}
-                  size={20}
-                  ml={idx > 0 ? -4 : undefined}
-                  z={5 - idx}
-                  bgColor="TRANSPARENT"
-                  outline="TRANSPARENT"
-                />
-              );
-            })}
-          </Layout.FlexRow>
-        )}
-        {component === 'thought' && content && (
-          <Layout.FlexRow
-            bgColor="WHITE"
-            pv={4}
-            ph={8}
-            gap={4}
-            outline="LIGHT_GRAY"
-            alignItems="center"
-            rounded={8}
-            style={{ alignSelf: 'flex-start' }}
-          >
-            <span style={{ fontSize: 14, lineHeight: 1 }} aria-hidden>
-              🤪
-            </span>
-            <Typo type="label-large" numberOfLines={2}>
-              {content}
-            </Typo>
-          </Layout.FlexRow>
-        )}
-        {component === 'song' && trackId && (
-          <Layout.FlexRow w="100%" style={{ minWidth: 0, overflow: 'hidden' }}>
-            <SpotifyMusic track={trackId} useAlbumImg fontType="label-large" />
-          </Layout.FlexRow>
-        )}
-      </ComponentContent>
+      <ClickableArea
+        role="button"
+        tabIndex={0}
+        aria-label={`React to ${username}'s ${COMPONENT_LABELS[component]} update`}
+        onClick={onComponentClick}
+        onKeyDown={handleKeyDown(onComponentClick)}
+      >
+        <ComponentContent alignItems="center" gap={4}>
+          {component === 'battery' && socialBattery && (
+            <SocialBatteryChip socialBattery={socialBattery} compact />
+          )}
+          {component === 'mood' && moodArray.length > 0 && (
+            <Layout.FlexRow alignItems="center" gap={0}>
+              {moodArray.map((emoji, idx) => {
+                const dupeCount = moodArray.slice(0, idx).filter((e) => e === emoji).length;
+                return (
+                  <EmojiItem
+                    key={`${emoji}${dupeCount}`}
+                    emojiString={emoji.trim()}
+                    size={20}
+                    ml={idx > 0 ? -4 : undefined}
+                    z={5 - idx}
+                    bgColor="TRANSPARENT"
+                    outline="TRANSPARENT"
+                  />
+                );
+              })}
+            </Layout.FlexRow>
+          )}
+          {component === 'thought' && content && (
+            <Layout.FlexRow
+              bgColor="WHITE"
+              pv={4}
+              ph={8}
+              gap={4}
+              outline="LIGHT_GRAY"
+              alignItems="center"
+              rounded={8}
+              style={{ alignSelf: 'flex-start' }}
+            >
+              <span style={{ fontSize: 14, lineHeight: 1 }} aria-hidden>
+                🤪
+              </span>
+              <Typo type="label-large" numberOfLines={2}>
+                {content}
+              </Typo>
+            </Layout.FlexRow>
+          )}
+          {component === 'song' && trackId && (
+            <Layout.FlexRow w="100%" style={{ minWidth: 0, overflow: 'hidden' }}>
+              <SpotifyMusic track={trackId} useAlbumImg fontType="label-large" />
+            </Layout.FlexRow>
+          )}
+        </ComponentContent>
+      </ClickableArea>
     </CardContainer>
   );
 }

--- a/src/components/friends/friends-timeline-feed/FriendsTimelineFeed.tsx
+++ b/src/components/friends/friends-timeline-feed/FriendsTimelineFeed.tsx
@@ -1,7 +1,9 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
 import Loader from '@components/_common/loader/Loader';
 import NoContents from '@components/_common/no-contents/NoContents';
+import CheckInDetailBottomSheet from '@components/check-in/check-in-detail-bottom-sheet/CheckInDetailBottomSheet';
 import CheckInUpdateCard from '@components/friends/check-in-update-card/CheckInUpdateCard';
 import MissionGroupItem from '@components/note/mission-group-item/MissionGroupItem';
 import NoteItem from '@components/note/note-item/NoteItem';
@@ -20,6 +22,7 @@ interface Props {
 
 interface CheckInUpdateItem {
   key: string;
+  checkInId: number;
   username: string;
   profileImage: string | null;
   component: 'battery' | 'mood' | 'thought' | 'song';
@@ -31,8 +34,12 @@ interface CheckInUpdateItem {
 
 function FriendsTimelineFeed({ closeFriendsOnly }: Props) {
   const [t] = useTranslation('translation');
+  const navigate = useNavigate();
+  const [selectedCheckInUpdate, setSelectedCheckInUpdate] = useState<CheckInUpdateItem | null>(
+    null,
+  );
 
-  const friendType: FriendType = closeFriendsOnly ? 'close_friends' : 'all';
+  const friendType: FriendType = closeFriendsOnly ? 'close_friends' : 'check_in_updates';
   const { allFriends } = useInfiniteFetchFriends({ type: friendType });
 
   const {
@@ -49,64 +56,70 @@ function FriendsTimelineFeed({ closeFriendsOnly }: Props) {
   const checkInUpdates = useMemo(() => {
     const friends = (allFriends ?? [])
       .flatMap(({ results }) => results ?? [])
-      .filter((u) => !u.is_hidden && !u.current_user_read_check_in);
+      .filter((u) => {
+        if (u.is_hidden) return false;
+        if (!closeFriendsOnly) return true;
+        return u.connection_status === Connection.CLOSE_FRIEND;
+      });
 
     const updates: CheckInUpdateItem[] = [];
-    const now = new Date().toISOString();
-
     friends.forEach((friend) => {
       const updated = new Set(friend.recently_updated_check_in ?? []);
       if (updated.size === 0) return;
 
       const thought = (friend as any).thought ?? '';
 
-      if (updated.has('battery') && friend.social_battery) {
+      if (updated.has('battery') && friend.social_battery && friend.battery_updated_at) {
         updates.push({
           key: `ci-battery-${friend.id}`,
+          checkInId: friend.check_in_id!,
           username: friend.username,
           profileImage: friend.profile_image,
           component: 'battery',
           content: friend.social_battery,
           socialBattery: friend.social_battery,
-          timestamp: friend.battery_updated_at || now,
+          timestamp: friend.battery_updated_at,
         });
       }
-      if (updated.has('mood') && friend.mood) {
+      if (updated.has('mood') && friend.mood && friend.mood_updated_at) {
         const moodStr = Array.isArray(friend.mood) ? friend.mood.join(',') : friend.mood;
         updates.push({
           key: `ci-mood-${friend.id}`,
+          checkInId: friend.check_in_id!,
           username: friend.username,
           profileImage: friend.profile_image,
           component: 'mood',
           content: moodStr,
-          timestamp: friend.mood_updated_at || now,
+          timestamp: friend.mood_updated_at,
         });
       }
-      if (updated.has('thought') && thought) {
+      if (updated.has('thought') && thought && friend.thought_updated_at) {
         updates.push({
           key: `ci-thought-${friend.id}`,
+          checkInId: friend.check_in_id!,
           username: friend.username,
           profileImage: friend.profile_image,
           component: 'thought',
           content: thought,
-          timestamp: friend.thought_updated_at || now,
+          timestamp: friend.thought_updated_at,
         });
       }
-      if (updated.has('song') && friend.track_id) {
+      if (updated.has('song') && friend.track_id && friend.song_updated_at) {
         updates.push({
           key: `ci-song-${friend.id}`,
+          checkInId: friend.check_in_id!,
           username: friend.username,
           profileImage: friend.profile_image,
           component: 'song',
           content: '',
           trackId: friend.track_id,
-          timestamp: friend.song_updated_at || now,
+          timestamp: friend.song_updated_at,
         });
       }
     });
 
     return updates;
-  }, [allFriends]);
+  }, [allFriends, closeFriendsOnly]);
 
   // Filter feed items to close friends when checkbox is on
   const filteredFeedItems = useMemo(() => {
@@ -187,6 +200,10 @@ function FriendsTimelineFeed({ closeFriendsOnly }: Props) {
                   socialBattery={update.socialBattery}
                   trackId={update.trackId}
                   timestamp={update.timestamp}
+                  onProfileClick={() =>
+                    navigate(`/users/${update.username}`, { state: { source: 'friends_feed' } })
+                  }
+                  onComponentClick={() => setSelectedCheckInUpdate(update)}
                 />
               );
             }
@@ -197,6 +214,28 @@ function FriendsTimelineFeed({ closeFriendsOnly }: Props) {
             <Layout.FlexRow w="100%" h={40}>
               <Loader />
             </Layout.FlexRow>
+          )}
+          {selectedCheckInUpdate && (
+            <CheckInDetailBottomSheet
+              visible={!!selectedCheckInUpdate}
+              closeBottomSheet={() => setSelectedCheckInUpdate(null)}
+              focusComponent={selectedCheckInUpdate.component}
+              checkInId={selectedCheckInUpdate.checkInId}
+              username={selectedCheckInUpdate.username}
+              profileImage={selectedCheckInUpdate.profileImage}
+              socialBattery={selectedCheckInUpdate.socialBattery}
+              trackId={selectedCheckInUpdate.trackId}
+              mood={
+                selectedCheckInUpdate.component === 'mood'
+                  ? selectedCheckInUpdate.content.split(',').filter(Boolean)
+                  : undefined
+              }
+              description={
+                selectedCheckInUpdate.component === 'thought'
+                  ? selectedCheckInUpdate.content
+                  : undefined
+              }
+            />
           )}
         </Layout.FlexCol>
       ) : (

--- a/src/hooks/useInfiniteFetchFriends.ts
+++ b/src/hooks/useInfiniteFetchFriends.ts
@@ -1,5 +1,10 @@
 import { useSWRInfiniteScroll } from '@hooks/useSWRInfiniteScroll';
-import { Connection, GetUpdatedProfileResponse, UpdatedProfile } from '@models/api/friends';
+import {
+  Connection,
+  FriendType,
+  GetUpdatedProfileResponse,
+  UpdatedProfile,
+} from '@models/api/friends';
 
 interface BreakFriendsParams {
   type: 'break_friends';
@@ -27,7 +32,7 @@ export type UpdateFriendListParams =
   | MarkReadParams;
 
 interface UseInfiniteFetchFriendsParams {
-  type?: 'all' | 'close_friends' | 'hidden';
+  type?: FriendType | 'hidden';
 }
 
 const useInfiniteFetchFriends = ({ type: friendType }: UseInfiniteFetchFriendsParams) => {

--- a/src/models/api/friends.ts
+++ b/src/models/api/friends.ts
@@ -49,4 +49,4 @@ export enum Connection {
   CLOSE_FRIEND = 'close_friend',
 }
 
-export type FriendType = 'all' | 'close_friends';
+export type FriendType = 'all' | 'close_friends' | 'check_in_updates';

--- a/src/routes/friends/FriendsList.tsx
+++ b/src/routes/friends/FriendsList.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useSearchParams } from 'react-router-dom';
 import styled from 'styled-components';
 import Divider from '@components/_common/divider/Divider';
 import PullToRefresh from '@components/_common/pull-to-refresh/PullToRefresh';
@@ -25,7 +26,9 @@ type TabType = 'people' | 'feed';
 
 function FriendsList() {
   const [t] = useTranslation('translation');
-  const [selectedTab, setSelectedTab] = useState<TabType>('people');
+  const [searchParams, setSearchParams] = useSearchParams();
+  const initialTab: TabType = searchParams.get('tab') === 'feed' ? 'feed' : 'people';
+  const [selectedTab, setSelectedTab] = useState<TabType>(initialTab);
   const [expandedFriendId, setExpandedFriendId] = useState<number | null>(null);
 
   // Browse mode can prefill the close-friends-only filter when "Just my people" is active.
@@ -38,6 +41,27 @@ function FriendsList() {
     if (browseModeForcesCloseFriends) setCloseFriendsOnly(true);
   }, [browseModeForcesCloseFriends]);
   const trackEvent = useTrackEvent();
+
+  useEffect(() => {
+    const nextTab: TabType = searchParams.get('tab') === 'feed' ? 'feed' : 'people';
+    setSelectedTab(nextTab);
+  }, [searchParams]);
+
+  const handleSelectTab = useCallback(
+    (tab: TabType) => {
+      setSelectedTab(tab);
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          next.set('tab', tab);
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
   const handleToggleCloseFriends = () => {
     setCloseFriendsOnly((prev) => {
       const next = !prev;
@@ -267,7 +291,7 @@ function FriendsList() {
             <Layout.FlexRow gap={16} flex={1}>
               <TabButton
                 $active={selectedTab === 'people'}
-                onClick={() => setSelectedTab('people')}
+                onClick={() => handleSelectTab('people')}
               >
                 <SvgIcon
                   name={selectedTab === 'people' ? 'friends_active' : 'friends_inactive'}
@@ -275,7 +299,7 @@ function FriendsList() {
                 />
                 People
               </TabButton>
-              <TabButton $active={selectedTab === 'feed'} onClick={() => setSelectedTab('feed')}>
+              <TabButton $active={selectedTab === 'feed'} onClick={() => handleSelectTab('feed')}>
                 <SvgIcon
                   name={selectedTab === 'feed' ? 'feed_active' : 'feed_inactive'}
                   size={18}


### PR DESCRIPTION
## Summary
- Render friend Feed check-in update cards from the check-in updates friend query
- Open the check-in reaction popup from update cards
- Keep close-friends filtering behavior for Feed

## Side effects checked
- Scope is limited to Friends Feed check-in update cards and the shared friend-list hook type.
- Existing People/Hidden/Edit friends flows keep using their existing query types.

## Verification
- npx eslint src/components/friends/friends-timeline-feed/FriendsTimelineFeed.tsx src/hooks/useInfiniteFetchFriends.ts src/models/api/friends.ts