### PR TITLE
Fix friends profile recent post UI

### DIFF
--- a/src/components/_common/post-footer/PostFooter.tsx
+++ b/src/components/_common/post-footer/PostFooter.tsx
@@ -125,6 +125,8 @@ function PostFooter({ post, displayType = 'LIST', showComments, setInputFocus }:
     setSampleUserList(like_reaction_user_sample);
   }, [like_reaction_user_sample]);
 
+  const canOpenCommentsInline = displayType !== 'DETAIL';
+
   return (
     <Layout.FlexRow
       gap={8}
@@ -138,7 +140,7 @@ function PostFooter({ post, displayType = 'LIST', showComments, setInputFocus }:
     >
       <Layout.FlexRow alignItems="center">
         <EmojiButton onClick={handleClickEmojiButton} />
-        {displayType === 'LIST' && (
+        {canOpenCommentsInline && (
           <Layout.FlexRow w={48} h={48} alignItems="center" justifyContent="center">
             <Icon name="add_comment" size={23} onClick={handleClickCommentIcon} />
           </Layout.FlexRow>
@@ -153,7 +155,7 @@ function PostFooter({ post, displayType = 'LIST', showComments, setInputFocus }:
         <Layout.FlexRow>
           <button
             type="button"
-            onClick={displayType === 'LIST' ? handleClickCommentText : undefined}
+            onClick={canOpenCommentsInline ? handleClickCommentText : undefined}
           >
             <Typo type="label-large" color="BLACK" underline>
               {comment_count ?? 0} {t('comments')}

--- a/src/components/_common/post-footer/PostFooterDefault.tsx
+++ b/src/components/_common/post-footer/PostFooterDefault.tsx
@@ -36,10 +36,12 @@ function PostFooterDefault({
     setInputFocus();
   };
 
+  const canOpenCommentsInline = displayType !== 'DETAIL';
+
   return (
     <Layout.FlexRow gap={8} alignItems="center" style={{ flexShrink: 0, marginTop: 'auto' }}>
       <Layout.FlexRow gap={8} alignItems="center">
-        {displayType === 'LIST' && (
+        {canOpenCommentsInline && (
           <Icon name="add_comment" size={23} onClick={handleClickCommentIcon} />
         )}
       </Layout.FlexRow>
@@ -47,7 +49,7 @@ function PostFooterDefault({
         <Layout.FlexRow>
           <button
             type="button"
-            onClick={displayType === 'LIST' ? handleClickCommentText : undefined}
+            onClick={canOpenCommentsInline ? handleClickCommentText : undefined}
           >
             <Typo type="label-large" color="BLACK" underline>
               {comment_count || 0} {t('comments')}

--- a/src/components/_common/post-footer/PostFooterLikeOnly.tsx
+++ b/src/components/_common/post-footer/PostFooterLikeOnly.tsx
@@ -57,6 +57,7 @@ function PostFooterLikeOnly({
 
   const sampleUsers = like_user_sample ?? [];
   const showLikeMeta = typeof like_count === 'number' ? like_count > 0 : (like_count ?? 0) > 0;
+  const canOpenCommentsInline = displayType !== 'DETAIL';
 
   return (
     <Layout.FlexCol
@@ -122,7 +123,7 @@ function PostFooterLikeOnly({
         </Layout.FlexRow>
 
         <Layout.FlexRow gap={8} alignItems="center">
-          {displayType === 'LIST' && (
+          {canOpenCommentsInline && (
             <Layout.FlexRow w={48} h={48} alignItems="center" justifyContent="center">
               <Icon name="add_comment" size={23} onClick={handleClickCommentIcon} />
             </Layout.FlexRow>
@@ -130,7 +131,7 @@ function PostFooterLikeOnly({
           {!!comment_count && (
             <button
               type="button"
-              onClick={displayType === 'LIST' ? handleClickCommentText : undefined}
+              onClick={canOpenCommentsInline ? handleClickCommentText : undefined}
             >
               <Typo type="label-large" color="BLACK" underline>
                 {comment_count ?? 0} {t('comments')}

--- a/src/components/friends/swipeable-post-carousel/SwipeablePostCarousel.styled.ts
+++ b/src/components/friends/swipeable-post-carousel/SwipeablePostCarousel.styled.ts
@@ -20,6 +20,8 @@ export const CarouselSlide = styled.div`
   flex: 0 0 100%;
   width: 100%;
   min-width: 0;
+  border-radius: 12px;
+  background-color: ${({ theme }) => theme.WHITE};
 `;
 
 export const DotContainer = styled.div`

--- a/src/routes/friends/FriendsList.tsx
+++ b/src/routes/friends/FriendsList.tsx
@@ -149,11 +149,7 @@ function FriendsList() {
       unread_chat_count: 0,
       check_in_id: checkIn?.id ?? null,
       track_id: checkIn?.track_id,
-      mood: checkIn?.mood
-        ? Array.isArray(checkIn.mood)
-          ? checkIn.mood.join(',')
-          : checkIn.mood
-        : undefined,
+      mood: checkIn?.mood,
       social_battery: checkIn?.social_battery,
       description: checkIn?.thought ?? '',
       thought: checkIn?.thought ?? '',


### PR DESCRIPTION
## Summary
- Show comment controls for feed-style post footers outside detail pages
- Keep People tab recent post carousel slides white inside the profile card
- Pass my check-in mood as an array so mood chips render correctly

## Test
- npm run build