### PR TITLE
Fix unchanged username profile saves

### DIFF
--- a/src/routes/settings/EditProfile.tsx
+++ b/src/routes/settings/EditProfile.tsx
@@ -423,11 +423,13 @@ function EditProfile() {
       }
     }
 
+    const usernameChanged = draft.username !== myProfile.username;
+
     const profileData = {
       bio: draft.bio,
-      username: draft.username,
       name: draft.name,
       pronouns: draft.pronouns,
+      ...(usernameChanged ? { username: draft.username } : {}),
       ...(!featureFlags?.postsVerQ && {
         name_visibility: draft.name_visibility,
         pronouns_visibility: draft.pronouns_visibility,


### PR DESCRIPTION
## Summary
- Do not include username in the Edit Profile PATCH payload when it has not changed.
- Prevents unchanged current usernames from being revalidated as unavailable.

## Verification
- ./node_modules/.bin/eslint src/routes/settings/EditProfile.tsx

## Notes
- Full tsc is currently blocked by @spotify/web-api-ts-sdk declarations requiring newer TypeScript syntax.