### PR TITLE
feat(friends): persist expanded friend accordion across navigation

### DIFF
--- a/src/hooks/usePersistedExpandedFriendId.ts
+++ b/src/hooks/usePersistedExpandedFriendId.ts
@@ -1,0 +1,21 @@
+import { Dispatch, SetStateAction, useEffect, useState } from 'react';
+import { getItemFromSessionStorage, setItemToSessionStorage } from '@utils/sessionStorage';
+
+const SESSION_STORAGE_KEY = 'WHOAMI_TODAY_FRIENDS_EXPANDED_ID';
+
+type ExpandedId = number | null;
+
+const readInitial = (): ExpandedId => {
+  const stored = getItemFromSessionStorage<ExpandedId>(SESSION_STORAGE_KEY, null);
+  return typeof stored === 'number' || stored === null ? stored : null;
+};
+
+export function usePersistedExpandedFriendId(): [ExpandedId, Dispatch<SetStateAction<ExpandedId>>] {
+  const [expandedFriendId, setExpandedFriendId] = useState<ExpandedId>(readInitial);
+
+  useEffect(() => {
+    setItemToSessionStorage<ExpandedId>(SESSION_STORAGE_KEY, expandedFriendId);
+  }, [expandedFriendId]);
+
+  return [expandedFriendId, setExpandedFriendId];
+}

--- a/src/routes/friends/FriendsList.tsx
+++ b/src/routes/friends/FriendsList.tsx
@@ -9,6 +9,7 @@ import FriendsTimelineFeed from '@components/friends/friends-timeline-feed/Frien
 import NoCloseFriends from '@components/friends/no-close-friends/NoCloseFriends';
 import { FLOATING_BUTTON_SIZE } from '@components/header/floating-button/FloatingButton.styled';
 import { Colors, Layout, SvgIcon, Typo } from '@design-system';
+import { usePersistedExpandedFriendId } from '@hooks/usePersistedExpandedFriendId';
 import { useRestoreScrollPosition } from '@hooks/useRestoreScrollPosition';
 import { useTrackEvent } from '@hooks/useTrackEvent';
 import { Connection, FriendType, UpdatedProfile } from '@models/api/friends';
@@ -29,7 +30,7 @@ function FriendsList() {
   const [searchParams, setSearchParams] = useSearchParams();
   const initialTab: TabType = searchParams.get('tab') === 'feed' ? 'feed' : 'people';
   const [selectedTab, setSelectedTab] = useState<TabType>(initialTab);
-  const [expandedFriendId, setExpandedFriendId] = useState<number | null>(null);
+  const [expandedFriendId, setExpandedFriendId] = usePersistedExpandedFriendId();
 
   // Browse mode can prefill the close-friends-only filter when "Just my people" is active.
   const browseModeForcesCloseFriends = useBoundStore(
@@ -134,6 +135,14 @@ function FriendsList() {
       .filter((user) => !user.is_hidden);
   }, [allFriends]);
 
+  // Collapse a persisted expansion if the friend is no longer in the list
+  // (e.g., filter toggled, friend hidden) — avoids a phantom expansion when they reappear.
+  useEffect(() => {
+    if (expandedFriendId === null || expandedFriendId === -1) return;
+    const stillVisible = filteredFriends.some((f) => f.id === expandedFriendId);
+    if (!stillVisible) setExpandedFriendId(null);
+  }, [filteredFriends, expandedFriendId, setExpandedFriendId]);
+
   const isEmpty = filteredFriends.length === 0 && !isAllFriendsLoading;
 
   // Build "my" data as an UpdatedProfile-like object for the accordion item
@@ -203,12 +212,12 @@ function FriendsList() {
         return friendId;
       });
     },
-    [filteredFriends, markFriendAsRead, trackEvent],
+    [filteredFriends, markFriendAsRead, trackEvent, setExpandedFriendId],
   );
 
   const handleToggleMyExpand = useCallback(() => {
     setExpandedFriendId((prev) => (prev === -1 ? null : -1));
-  }, []);
+  }, [setExpandedFriendId]);
 
   const handleConnectionChanged = useCallback(
     (userId: number, connection: Connection) => {


### PR DESCRIPTION
## Summary

- 친구 리스트 아코디언의 펼침 상태가 페이지 이동 후 돌아오면 사라지던 문제 수정
- 새 훅 `usePersistedExpandedFriendId`로 sessionStorage에 영속화 — `useRestoreScrollPosition`과 동일 패턴
- 펼친 친구가 필터에서 사라지면 자동으로 정리해 유령 펼침 방지

## 동작

- 친구 펼침 → 다른 화면 이동 → 복귀 시 **그대로 펼쳐짐**
- 새로고침에도 유지됨 (sessionStorage)
- 탭 종료 시 자동 초기화
- 명시적 접기는 영속화되어 다음 진입 시 닫힘 상태
- 복원 시 `markFriendAsRead` / `friends_profile_expanded` 분석 이벤트는 재발화하지 않음 (사용자 클릭 경로에만 위치)
- 펼친 친구가 close-friends 필터로 빠지거나 숨겨지면 자동 정리

## Test plan

- [ ] `/friends`에서 친구 A 펼치기 → 프로필 사진 클릭 → 뒤로 가기 → A 그대로 펼쳐짐
- [ ] Share 탭으로 이동 후 Friends 탭 복귀 → 그대로 펼쳐짐
- [ ] 내 카드 펼친 후 다른 탭 갔다 와도 그대로 펼쳐짐
- [ ] 명시적 접기 후 이동/복귀 → 닫힘 상태
- [ ] `Cmd-R` 새로고침 후 그대로 펼쳐짐
- [ ] 탭 닫고 새 탭에서 `/friends` → 닫힘 상태
- [ ] 일반 친구 D 펼침 → "Close friends only" 토글 ON/OFF → D 닫힘 상태로 재등장
- [ ] 안 읽은 체크인 있는 친구 펼침 → 이동/복귀 시 `readFriendCheckIn` 한 번만 호출 (네트워크 탭 확인)
- [ ] `friends_profile_expanded` 분석 이벤트 펼침 시 1회만 기록 (복원 시 재발화 없음)
- [ ] 320px / 393px 모바일 뷰포트에서 시각 확인