### PR TITLE
feat(browse-mode): sync route on mode change + restore last tab on cold start

### DIFF
--- a/src/components/tab/Tab.tsx
+++ b/src/components/tab/Tab.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useMatch } from 'react-router-dom';
@@ -7,6 +8,7 @@ import { resetScrollPosition } from '@hooks/useRestoreScrollPosition';
 import { BrowseModeTabKey } from '@models/browseMode';
 import { useBoundStore } from '@stores/useBoundStore';
 import { UserSelector } from '@stores/user';
+import { getVisibleTabs } from '@utils/browseModeTabs';
 import {
   NavTabItem,
   StyledMessageCount,
@@ -111,15 +113,13 @@ export default function Tab() {
   const activeBrowseMode = useBoundStore((state) => state.activeBrowseMode);
   const isChatPage = !!useMatch('/users/:username/chat');
 
-  // When a browse mode is active, only render tabs whose key is in the mode's allowlist.
-  // `my` and `questions` are intentionally exempt — profile lives in the hamburger menu
-  // and questions is feature-flag-gated, so users always want them when those flags allow.
-  const allowedTabs = activeBrowseMode?.config.tabs;
-  const ALWAYS_SHOWN: BrowseModeTabKey[] = ['my', 'questions'];
-  const isTabAllowed = (key: BrowseModeTabKey) => {
-    if (ALWAYS_SHOWN.includes(key)) return true;
-    return !allowedTabs || allowedTabs.includes(key);
-  };
+  // Single source of truth for tab visibility — shared with route-sync hook
+  // and cold-start restore. See `getVisibleTabs` for the rules.
+  const visibleKeys = useMemo(
+    () => new Set(getVisibleTabs(featureFlags, activeBrowseMode).map((t) => t.key)),
+    [featureFlags, activeBrowseMode],
+  );
+  const isTabAllowed = (key: BrowseModeTabKey) => visibleKeys.has(key);
 
   if (featureFlags?.checkInPosts) {
     return (

--- a/src/hooks/useBrowseModeRouteSync.ts
+++ b/src/hooks/useBrowseModeRouteSync.ts
@@ -1,0 +1,41 @@
+import { useEffect, useRef } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useBoundStore } from '@stores/useBoundStore';
+import { getTabKeyForPath, getVisibleTabs } from '@utils/browseModeTabs';
+
+/**
+ * When `activeBrowseMode` changes (user picks a new mode, custom mode is
+ * cleared, tab durations auto-tighten the allowlist), redirect off any tab
+ * the new mode no longer surfaces. Detail routes (profile, chat room, etc.)
+ * are left alone — only tab-level routes get bounced.
+ *
+ * First mount is intentionally skipped so the cold-start route restored by
+ * Intro.tsx isn't immediately overwritten.
+ */
+export function useBrowseModeRouteSync() {
+  const activeBrowseMode = useBoundStore((state) => state.activeBrowseMode);
+  const featureFlags = useBoundStore((state) => state.featureFlags);
+  const location = useLocation();
+  const navigate = useNavigate();
+  const hasMountedRef = useRef(false);
+
+  useEffect(() => {
+    if (!hasMountedRef.current) {
+      hasMountedRef.current = true;
+      return;
+    }
+
+    const currentKey = getTabKeyForPath(location.pathname);
+    if (currentKey === null) return;
+
+    const visible = getVisibleTabs(featureFlags, activeBrowseMode);
+    if (visible.some((tab) => tab.key === currentKey)) return;
+
+    const first = visible[0];
+    if (first) navigate(first.path, { replace: true });
+    // Intentionally exclude location.pathname / featureFlags from deps:
+    // we only want to react to mode changes, not to the user navigating
+    // around within an existing mode.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeBrowseMode]);
+}

--- a/src/hooks/useLastVisitedTabPersistence.ts
+++ b/src/hooks/useLastVisitedTabPersistence.ts
@@ -1,0 +1,22 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+import { useBoundStore } from '@stores/useBoundStore';
+import { getTabKeyForPath } from '@utils/browseModeTabs';
+import { writeLastVisitedTab } from '@utils/lastVisitedTab';
+
+/**
+ * Mirrors the user's current tab to localStorage so cold-start (Intro
+ * redirect) can restore it next session. Detail routes are skipped — the
+ * stored value should always be a tab the user can return to directly.
+ */
+export function useLastVisitedTabPersistence() {
+  const userId = useBoundStore((state) => state.myProfile?.id);
+  const location = useLocation();
+
+  useEffect(() => {
+    if (!userId) return;
+    const key = getTabKeyForPath(location.pathname);
+    if (!key) return;
+    writeLastVisitedTab(userId, key);
+  }, [userId, location.pathname]);
+}

--- a/src/routes/Intro.tsx
+++ b/src/routes/Intro.tsx
@@ -4,19 +4,28 @@ import MainContainer from '@components/_common/main-container/MainContainer';
 import { Button, Layout } from '@design-system';
 import { MyProfile, VersionType } from '@models/api/user';
 import { useBoundStore } from '@stores/useBoundStore';
+import { getVisibleTabs } from '@utils/browseModeTabs';
+import { readLastVisitedTab } from '@utils/lastVisitedTab';
 
 function Intro() {
   const [t] = useTranslation('translation', { keyPrefix: 'intro' });
   const data = useLoaderData() as MyProfile | null;
 
-  const { myProfile } = useBoundStore((state) => ({
+  const { myProfile, featureFlags, activeBrowseMode } = useBoundStore((state) => ({
     myProfile: state.myProfile,
+    featureFlags: state.featureFlags,
+    activeBrowseMode: state.activeBrowseMode,
   }));
 
   if (data) {
-    // Use current_ver from data or myProfile to determine redirect path
-    const currentVer = data.current_ver || myProfile?.current_ver;
-    const targetPath = currentVer === VersionType.VER_Q ? '/feed' : '/friends';
+    const profile = data;
+    const currentVer = profile.current_ver || myProfile?.current_ver;
+    const versionDefault = currentVer === VersionType.VER_Q ? '/feed' : '/friends';
+
+    const visible = getVisibleTabs(featureFlags, activeBrowseMode);
+    const lastKey = readLastVisitedTab(profile.id);
+    const lastTab = lastKey ? visible.find((tab) => tab.key === lastKey) : null;
+    const targetPath = lastTab?.path ?? visible[0]?.path ?? versionDefault;
     return <Navigate to={targetPath} replace />;
   }
   return (

--- a/src/routes/Root.tsx
+++ b/src/routes/Root.tsx
@@ -22,10 +22,12 @@ import { Layout } from '@design-system';
 import { useGetAppMessage, usePostAppMessage } from '@hooks/useAppMessage';
 import useAsyncEffect from '@hooks/useAsyncEffect';
 import { useBrowseModeActivePersistence } from '@hooks/useBrowseModeActivePersistence';
+import { useBrowseModeRouteSync } from '@hooks/useBrowseModeRouteSync';
 import { useBrowseModeSessionPrompt } from '@hooks/useBrowseModeSessionPrompt';
 import { useBrowseModeTabDurations } from '@hooks/useBrowseModeTabDurations';
 import { useCheckInFreshnessPrompt } from '@hooks/useCheckInFreshnessPrompt';
 import useFcm from '@hooks/useFcm';
+import { useLastVisitedTabPersistence } from '@hooks/useLastVisitedTabPersistence';
 import { SetAppStateData } from '@models/app';
 import { useBoundStore } from '@stores/useBoundStore';
 import { MainWrapper, RootContainer } from '@styles/wrappers';
@@ -70,6 +72,10 @@ function Root() {
   // user's pick within the same tab. Cleared on tab close (next visit
   // starts fresh and the auto-prompt logic decides whether to ask again).
   useBrowseModeActivePersistence();
+  // Bounce off tabs the active browse mode no longer surfaces.
+  useBrowseModeRouteSync();
+  // Mirror the user's current tab to localStorage for cold-start restore.
+  useLastVisitedTabPersistence();
   const isBrowseModePickerOpen = useBoundStore((state) => state.isBrowseModePickerOpen);
   const closeBrowseModePicker = useBoundStore((state) => state.closeBrowseModePicker);
   const location = useLocation();

--- a/src/utils/browseModeTabs.ts
+++ b/src/utils/browseModeTabs.ts
@@ -1,0 +1,74 @@
+import { FeatureFlagMap } from '@constants/featureFlag';
+import { ActiveBrowseMode, BrowseModeTabKey } from '@models/browseMode';
+
+export type VisibleTab = { key: BrowseModeTabKey; path: string };
+
+const ALWAYS_SHOWN: BrowseModeTabKey[] = ['my', 'questions'];
+
+function isInActiveMode(key: BrowseModeTabKey, activeBrowseMode: ActiveBrowseMode | null): boolean {
+  if (ALWAYS_SHOWN.includes(key)) return true;
+  const allowed = activeBrowseMode?.config.tabs;
+  if (!allowed) return true;
+  return allowed.includes(key);
+}
+
+/**
+ * Compute the bottom-tab list the user actually sees, in render order.
+ * Mirrors `Tab.tsx` 1:1 — must stay in sync if either is edited.
+ */
+export function getVisibleTabs(
+  featureFlags: FeatureFlagMap | undefined,
+  activeBrowseMode: ActiveBrowseMode | null,
+): VisibleTab[] {
+  const tabs: VisibleTab[] = [];
+  const allow = (key: BrowseModeTabKey) => isInActiveMode(key, activeBrowseMode);
+
+  if (featureFlags?.checkInPosts) {
+    if (allow('friends')) tabs.push({ key: 'friends', path: '/feed' });
+    if (allow('discover')) tabs.push({ key: 'discover', path: '/discover' });
+    if (allow('share')) tabs.push({ key: 'share', path: '/share' });
+    if (allow('chats')) tabs.push({ key: 'chats', path: '/chats' });
+    if (allow('my')) tabs.push({ key: 'my', path: '/my' });
+    return tabs;
+  }
+
+  if (featureFlags?.friendList) {
+    if (allow('friends')) tabs.push({ key: 'friends', path: '/friends' });
+    if (allow('discover')) tabs.push({ key: 'discover', path: '/discover' });
+    if (allow('update')) tabs.push({ key: 'update', path: '/update' });
+    if (allow('share')) tabs.push({ key: 'share', path: '/share' });
+  } else if (featureFlags?.friendFeed) {
+    if (allow('friends')) tabs.push({ key: 'friends', path: '/feed' });
+  }
+
+  if (featureFlags?.questionsTab && allow('questions')) {
+    tabs.push({ key: 'questions', path: '/questions' });
+  }
+  if (featureFlags?.chatTab && allow('chats')) {
+    tabs.push({ key: 'chats', path: '/chats' });
+  }
+
+  return tabs;
+}
+
+const ALL_TAB_PATHS: { path: string; key: BrowseModeTabKey }[] = [
+  { path: '/friends', key: 'friends' },
+  { path: '/feed', key: 'friends' },
+  { path: '/discover', key: 'discover' },
+  { path: '/update', key: 'update' },
+  { path: '/share', key: 'share' },
+  { path: '/chats', key: 'chats' },
+  { path: '/my', key: 'my' },
+  { path: '/questions', key: 'questions' },
+];
+
+/**
+ * Map a route pathname to the tab key it represents, or null if the user is
+ * on a non-tab detail route (e.g. `/users/:id/profile`, `/notes/new`,
+ * `/chats/group/:roomId`). Matches only the exact tab paths so deep routes
+ * stay un-mapped.
+ */
+export function getTabKeyForPath(pathname: string): BrowseModeTabKey | null {
+  const match = ALL_TAB_PATHS.find((entry) => entry.path === pathname);
+  return match?.key ?? null;
+}

--- a/src/utils/lastVisitedTab.ts
+++ b/src/utils/lastVisitedTab.ts
@@ -1,0 +1,31 @@
+import { BrowseModeTabKey } from '@models/browseMode';
+
+const PREFIX = 'last_visited_tab_';
+
+const VALID_KEYS: BrowseModeTabKey[] = [
+  'friends',
+  'update',
+  'share',
+  'discover',
+  'chats',
+  'my',
+  'questions',
+];
+
+function storageKey(userId: number): string {
+  return `${PREFIX}${userId}`;
+}
+
+export function readLastVisitedTab(userId: number): BrowseModeTabKey | null {
+  const raw = localStorage.getItem(storageKey(userId));
+  if (!raw) return null;
+  return (VALID_KEYS as string[]).includes(raw) ? (raw as BrowseModeTabKey) : null;
+}
+
+export function writeLastVisitedTab(userId: number, key: BrowseModeTabKey): void {
+  try {
+    localStorage.setItem(storageKey(userId), key);
+  } catch {
+    /* private mode / quota — best-effort */
+  }
+}


### PR DESCRIPTION
## Summary

- 브라우징 모드를 바꿨을 때 현재 탭이 새 모드의 표시 목록(`config.tabs`)에 없으면 **첫 번째 표시 탭으로 자동 이동**. 비-탭 상세 라우트(`/users/:id`, 채팅방, `/notes/new` 등)는 그대로 유지하여 작성 중인 메시지/노트 유실 방지.
- 콜드스타트 시 직전 세션의 **마지막 방문 탭을 user-scoped localStorage에서 복원**. 활성 모드와 호환되지 않으면 첫 번째 표시 탭, 그것도 없으면 기존 `current_ver` 디폴트로 폴백.
- 탭 가시성 결정 로직을 `getVisibleTabs` 헬퍼로 추출. `Tab.tsx`, `useBrowseModeRouteSync`, `Intro.tsx` 모두 동일한 단일 진실 출처를 공유.

## 핵심 정책

- 자동 이동은 **탭 라우트일 때만** 발동 — 깊은 라우트는 그대로 유지.
- 마지막 방문 탭 저장도 **탭 라우트일 때만** — 깊은 라우트는 무시하고 직전 탭 정보 유지.
- `useBrowseModeTabDurations`가 시간 경과로 모드의 탭을 줄일 때도 동일한 effect 발동 (디지털 디톡스 모드의 의도된 fade-out 동작).

## Test plan

- [ ] `/chats` 진입 → SideMenu → Browsing Mode → `quiet`(`tabs: ['share']`) 활성 → `/share`로 자동 이동
- [ ] `/share` 진입 → `very_social`(모든 탭) 활성 → `/share` 그대로 유지
- [ ] `/users/<friend>/profile`에서 모드 변경 → 라우트 유지 (비-탭 라우트 보호)
- [ ] PreviewBar의 X로 모드 클리어 → 모든 탭 표시되므로 이동 안 함
- [ ] `/chats` 방문 → 앱 강제 종료 → 재진입 → `/chats` 복원 (모드 = `very_social` 또는 null일 때)
- [ ] `/chats` 방문 → `quiet` 활성화(자동 `/share` 이동) → 종료 → 재진입 → `/share` 폴백 확인
- [ ] 다른 사용자로 로그아웃/로그인 → 이전 사용자 lastVisitedTab 영향 없음 (user별 키 분리)
- [ ] 320px / 393px 뷰포트에서 Tab.tsx 렌더 회귀 없음 (헬퍼 추출은 로직 동일)