### PR TITLE
Add hamburger menu to chatroom headers

### DIFF
--- a/src/routes/chat/Chat.tsx
+++ b/src/routes/chat/Chat.tsx
@@ -3,11 +3,13 @@ import { isSameDay } from 'date-fns';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import Icon from '@components/_common/icon/Icon';
 import { Loader } from '@components/_common/loader/Loader.styled';
 import { SwipeToReply } from '@components/_common/swipe-to-reply/SwipeToReply';
 import ChatMessageInput from '@components/chat/chat-message-input/ChatMessageInput';
 import ChatMessageItem from '@components/chat/chat-message-item/ChatMessageItem';
 import ChatRequestBar from '@components/chat/chat-request-bar/ChatRequestBar';
+import SideMenu from '@components/header/side-menu/SideMenu';
 import SubHeader from '@components/sub-header/SubHeader';
 import { CHAT_MESSAGE_INPUT_HEIGHT } from '@constants/layout';
 import { Layout } from '@design-system';
@@ -69,6 +71,7 @@ function Chat() {
   const [nextUrl, setNextUrl] = useState<string | null>(null);
   const [firstLoad, setFirstLoad] = useState(true);
   const [replyTarget, setReplyTarget] = useState<ChatMessage | null>(null);
+  const [showSideMenu, setShowSideMenu] = useState(false);
 
   const [areFriends, setAreFriends] = useState<boolean | null>(null);
   const [sentChatRequest, setSentChatRequest] = useState(false);
@@ -408,7 +411,12 @@ function Chat() {
     <MainScrollContainer scrollRef={scrollRef}>
       {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
       <div onClick={markRead} style={{ width: '100%' }}>
-        <SubHeader title={username} onClickTitle={() => navigate(`/users/${username}`)} />
+        <SubHeader
+          title={username}
+          onClickTitle={() => navigate(`/users/${username}`)}
+          RightComponent={<Icon name="hamburger" size={44} onClick={() => setShowSideMenu(true)} />}
+        />
+        {showSideMenu && <SideMenu closeSideMenu={() => setShowSideMenu(false)} />}
         {firstLoad && (
           <Layout.FlexCol w="100%" alignItems="center" mt={30}>
             <Loader />

--- a/src/routes/chat/GroupChat.tsx
+++ b/src/routes/chat/GroupChat.tsx
@@ -8,6 +8,7 @@ import ProfileImage from '@components/_common/profile-image/ProfileImage';
 import { SwipeToReply } from '@components/_common/swipe-to-reply/SwipeToReply';
 import ChatMessageInput from '@components/chat/chat-message-input/ChatMessageInput';
 import ChatMessageItem from '@components/chat/chat-message-item/ChatMessageItem';
+import SideMenu from '@components/header/side-menu/SideMenu';
 import { CHAT_MESSAGE_INPUT_HEIGHT, TOP_NAVIGATION_HEIGHT } from '@constants/layout';
 import { Layout, Typo } from '@design-system';
 import useInfiniteScroll from '@hooks/useInfiniteScroll';
@@ -54,6 +55,7 @@ function GroupChat() {
   const [firstLoad, setFirstLoad] = useState(true);
   const [replyTarget, setReplyTarget] = useState<ChatMessage | null>(null);
   const [showMemberDrawer, setShowMemberDrawer] = useState(false);
+  const [showSideMenu, setShowSideMenu] = useState(false);
   const socketRef = useRef<WebSocket>();
 
   const [typingUsers, setTypingUsers] = useState<Record<number, string>>({});
@@ -416,8 +418,8 @@ function GroupChat() {
           )}
         </Layout.FlexRow>
 
-        {/* Right: members icon — vertically centered */}
-        <Layout.FlexRow w={36} h={36} alignItems="center" justifyContent="center">
+        {/* Right: members + hamburger */}
+        <Layout.FlexRow alignItems="center" justifyContent="flex-end" gap={4}>
           <button
             type="button"
             onClick={() => setShowMemberDrawer(true)}
@@ -434,8 +436,10 @@ function GroupChat() {
             <EmojiItem emojiString="👤" size={16} bgColor="TRANSPARENT" outline="TRANSPARENT" />
             <span style={{ fontSize: 12, color: '#666', lineHeight: 1 }}>{members.length}</span>
           </button>
+          <Icon name="hamburger" size={44} onClick={() => setShowSideMenu(true)} />
         </Layout.FlexRow>
       </Layout.FlexRow>
+      {showSideMenu && <SideMenu closeSideMenu={() => setShowSideMenu(false)} />}
 
       {/* Right-side member drawer */}
       {showMemberDrawer && (


### PR DESCRIPTION
## Summary
- Add a persistent hamburger menu button to DM chatroom headers
- Add the same side menu access to group chatroom headers next to the member button

## Test
- yarn build