### PR TITLE
Hide empty mood pill on my check-in card

### DIFF
--- a/src/components/check-in/my-check-in-card/MyCheckInCard.tsx
+++ b/src/components/check-in/my-check-in-card/MyCheckInCard.tsx
@@ -27,7 +27,7 @@ function MyCheckInCard() {
   }, []);
 
   const { social_battery, track_id, mood, thought } = checkIn || {};
-  const moodArray: string[] = Array.isArray(mood) ? mood : mood ? [mood] : [];
+  const moodArray: string[] = (Array.isArray(mood) ? mood : mood ? [mood] : []).filter(Boolean);
   const hasMood = moodArray.length > 0;
   const hasBattery = !!social_battery && Object.values(SocialBattery).includes(social_battery);
   const bothBatteryAndMoodFilled = hasBattery && hasMood;


### PR DESCRIPTION
## Summary
- `58bea37d` ("Hide empty mood check-in pills") added `.filter(Boolean)` on the mood array in `FriendItemWithUpdates.tsx` and `FriendProfileAccordionItem.tsx`, but missed `MyCheckInCard.tsx`. As a result the user's own card on the Friends tab top still rendered empty-string mood entries as empty squares.
- Mirrors the sibling fix one-for-one — single-line change.

## Test plan
- [x] `npx craco build` clean
- [ ] Friends tab top — own card renders no empty squares when mood array contains stale empty strings
- [ ] mood empty → `MoodPlaceholder` falls back as before
- [ ] mood filled (1–5 emojis) → renders unchanged
- [ ] Be Random / 🤪 thought pill unchanged (regression check)