### PR TITLE
Remove leading 🤪 from filled Be Random pills

### DIFF
--- a/src/components/check-in/CheckIn.tsx
+++ b/src/components/check-in/CheckIn.tsx
@@ -171,9 +171,6 @@ function CheckIn({ user }: CheckInProps) {
                   style={{ minWidth: 0, maxWidth: '100%', cursor: 'pointer' }}
                   onClick={() => handleClickCheckInComponent('thought')}
                 >
-                  <span style={{ fontSize: 14, lineHeight: 1 }} aria-hidden>
-                    🤪
-                  </span>
                   <Typo type="label-large" numberOfLines={2}>
                     {thought}
                   </Typo>

--- a/src/components/check-in/my-check-in-card/MyCheckInCard.tsx
+++ b/src/components/check-in/my-check-in-card/MyCheckInCard.tsx
@@ -144,7 +144,6 @@ function MyCheckInCard() {
         </Layout.FlexRow>
       )}
 
-      {/* Thought pill — leading 🤪 emoji reads as a "be random" prompt. */}
       {thought ? (
         <Layout.FlexRow
           bgColor="WHITE"
@@ -157,9 +156,6 @@ function MyCheckInCard() {
           style={{ flexShrink: 0, cursor: 'pointer', alignSelf: 'flex-start' }}
           onClick={goToCheckIn}
         >
-          <span style={{ fontSize: 14, lineHeight: 1 }} aria-hidden>
-            🤪
-          </span>
           <Typo type="label-large" numberOfLines={1}>
             {thought}
           </Typo>

--- a/src/components/friends/check-in-update-card/CheckInUpdateCard.tsx
+++ b/src/components/friends/check-in-update-card/CheckInUpdateCard.tsx
@@ -118,9 +118,6 @@ function CheckInUpdateCard({
               rounded={8}
               style={{ alignSelf: 'flex-start' }}
             >
-              <span style={{ fontSize: 14, lineHeight: 1 }} aria-hidden>
-                🤪
-              </span>
               <Typo type="label-large" numberOfLines={2}>
                 {content}
               </Typo>

--- a/src/components/friends/friend-item-with-updates/FriendItemWithUpdates.tsx
+++ b/src/components/friends/friend-item-with-updates/FriendItemWithUpdates.tsx
@@ -340,7 +340,7 @@ function FriendItemWithUpdates({
             </Layout.FlexRow>
           )}
 
-          {/* Thought pill — leading 🤪 emoji; empty only shows poke in check-in tab (hidden in unified). */}
+          {/* Thought pill — empty only shows poke in check-in tab (hidden in unified). */}
           {hasThought ? (
             <Layout.FlexRow
               bgColor="WHITE"
@@ -353,9 +353,6 @@ function FriendItemWithUpdates({
               style={{ flexShrink: 0, cursor: 'pointer', alignSelf: 'flex-start' }}
               onClick={() => openCheckInDetail('thought')}
             >
-              <span style={{ fontSize: 14, lineHeight: 1 }} aria-hidden>
-                🤪
-              </span>
               <Typo type="label-large" numberOfLines={1}>
                 {thought}
               </Typo>

--- a/src/components/friends/friend-profile-accordion-item/FriendProfileAccordionItem.tsx
+++ b/src/components/friends/friend-profile-accordion-item/FriendProfileAccordionItem.tsx
@@ -304,9 +304,6 @@ function FriendProfileAccordionItem({
                   style={{ flexShrink: 0, cursor: 'pointer' }}
                   onClick={() => openCheckInDetail('thought')}
                 >
-                  <span style={{ fontSize: 14, lineHeight: 1 }} aria-hidden>
-                    🤪
-                  </span>
                   <Typo type="label-large" numberOfLines={1}>
                     {thought}
                   </Typo>


### PR DESCRIPTION
## Summary
- 채워진 Be Random(thought) pill 앞에 하드코딩된 `🤪` prepend 를 5곳에서 제거. 사용자가 thought 텍스트 시작 부분에 이모지가 같이 묶여있는 것처럼 보여 혼란을 일으킴 (특히 한글 자모만으로 된 thought 텍스트는 작은 박스처럼 보여 빈 네모로 오해됨).
- Empty 상태 CTA 인 `Ping to be random 🤪` (PokeButton) 은 유지 — placeholder 성격이라 그대로 둠.

## Sites updated
- `CheckIn.tsx` — 체크인 그리드 thought 칸
- `MyCheckInCard.tsx` — Friends 탭 본인 카드 thought pill
- `FriendProfileAccordionItem.tsx` — 친구 아코디언 thought pill
- `CheckInUpdateCard.tsx` — Update 카드 thought pill
- `FriendItemWithUpdates.tsx` — 친구 카드 thought pill

## Test plan
- [x] `npx craco build` clean
- [ ] 친구 카드 / 본인 카드 thought pill: text 만 노출 (🤪 없음)
- [ ] `Ping to be random 🤪` 빈 상태 버튼 — 🤪 그대로
- [ ] 320px / 393px 뷰포트 레이아웃 회귀 없음